### PR TITLE
Sync: v0.3.2 kioku_delete scanReferences size cap

### DIFF
--- a/mcp/manifest.json
+++ b/mcp/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "kioku-wiki",
   "display_name": "KIOKU Wiki",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Read, search, and write your KIOKU Obsidian Wiki from Claude Desktop or Claude Code.",
   "long_description": "KIOKU is a personal knowledge base ('second brain') built on top of an Obsidian Vault. This MCP server exposes eight tools (kioku_search, kioku_read, kioku_list, kioku_write_note, kioku_write_wiki, kioku_delete, kioku_ingest_pdf, kioku_ingest_url) so that Claude Desktop and Claude Code can browse and update the Wiki without leaving the chat. All operations are local stdio — nothing leaves your machine. See https://github.com/megaphone-tokyo/kioku for the full project.",
   "author": {

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kioku-mcp",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kioku-mcp",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "dependencies": {
         "@modelcontextprotocol/sdk": "~1.29.0",
         "@mozilla/readability": "^0.5.0",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kioku-mcp",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": true,
   "type": "module",
   "description": "KIOKU local MCP server (Wiki read/list/search/write_note/write_wiki/delete) for Claude Desktop and Claude Code.",

--- a/mcp/tools/delete.mjs
+++ b/mcp/tools/delete.mjs
@@ -85,12 +85,12 @@ export async function handleDelete(vault, args) {
     // 残った状態で wiki ページを archive すると broken_links_detected が発火せず
     // silent orphan 化していた。
     const vaultAbs = await realpath(vault);
-    const brokenLinks = await scanReferences(vaultAbs, wikiAbs, abs, targets);
+    const { brokenLinks, skippedLargeFiles } = await scanReferences(vaultAbs, wikiAbs, abs, targets);
 
     if (brokenLinks.length > 0 && !force) {
       const e = new Error('broken links detected (use force=true to override)');
       e.code = 'broken_links_detected';
-      e.data = { brokenLinks };
+      e.data = { brokenLinks, skippedLargeFiles };
       throw e;
     }
 
@@ -113,6 +113,7 @@ export async function handleDelete(vault, args) {
     return {
       archivedPath: 'wiki/' + relative(wikiAbs, archiveAbs).split(sep).join('/'),
       brokenLinks,
+      skippedLargeFiles,
     };
   });
 }
@@ -130,10 +131,20 @@ function validate(args) {
   }
 }
 
+// 2026-04-20 NEW-M1 fix: scanReferences walker は wiki/ に加え raw-sources/ も
+// 舐めるようになった (HIGH-a1 fix) が、`raw-sources/<subdir>/fetched/*.md` は
+// attacker-controlled な HTML → Markdown 化 出力を含みうる。size cap なしで
+// readFile(..., 'utf8') を回すと、500 本の大きな fetched MD が仕込まれた場合に
+// kioku_delete が withLock を長時間掴んで他 MCP 操作をブロックする (DoS 表面拡大)。
+// 2MB 超のファイルは scan 対象から外す: wiki/ の通常運用では個別ページがこの
+// サイズを超えることはほぼなく、attacker-controlled な巨大 MD だけが弾かれる。
+const SCAN_MAX_BYTES = 2_000_000;
+
 async function scanReferences(vaultAbs, wikiAbs, targetAbs, targetSet) {
   // 2026-04-20 HIGH-a1 fix: vault ルートから走査して wiki/ + raw-sources/ の両方を
   // 対象に入れる。session-logs / .cache / .obsidian / node_modules 等は除外。
   const out = [];
+  const skipped = [];
   // ディレクトリ名除外 (トップレベルおよび任意階層)
   const excludeDirs = new Set([
     '.obsidian', '.archive', '.trash', 'templates',
@@ -154,6 +165,14 @@ async function scanReferences(vaultAbs, wikiAbs, targetAbs, targetSet) {
         await walk(childAbs);
       } else if (dirent.isFile() && dirent.name.endsWith('.md') && childAbs !== targetAbs) {
         try {
+          // NEW-M1 fix: size cap を先にチェックする。st.isFile() は readdir 側で
+          // 確認済。2MB 超は readFile せず skipped[] に記録して operator 視認性を残す。
+          const st = await stat(childAbs);
+          if (st.size > SCAN_MAX_BYTES) {
+            const relFromVault = relative(vaultAbs, childAbs).split(sep).join('/');
+            skipped.push({ sourcePath: relFromVault, size: st.size });
+            continue;
+          }
           const c = await readFile(childAbs, 'utf8');
           // 生 [[<target>]] の出現回数を数える (findWikilinks は dedupe するので別カウント)
           let occ = 0;
@@ -179,5 +198,5 @@ async function scanReferences(vaultAbs, wikiAbs, targetAbs, targetSet) {
     }
   }
   await walk(vaultAbs);
-  return out;
+  return { brokenLinks: out, skippedLargeFiles: skipped };
 }

--- a/tests/mcp/tools-delete.test.mjs
+++ b/tests/mcp/tools-delete.test.mjs
@@ -123,6 +123,52 @@ describe('kioku_delete', () => {
     } finally { await cleanup(); }
   });
 
+  test('MCP26d scanReferences skips files > 2MB and records them (NEW-M1)', async () => {
+    // 2026-04-20 NEW-M1 regression test: HIGH-a1 fix で vault 全体 walk に
+    // 拡張した scanReferences が attacker-controlled な巨大 fetched MD を
+    // size cap なしで readFile すると DoS になる経路を塞ぐ。
+    // 2MB 超のファイルは skip して skippedLargeFiles[] に記録される。
+    try {
+      await writeFile(join(vault, 'wiki', 'foo.md'),
+        '---\ntitle: Foo\n---\n\n# Foo\n');
+      const fetchedDir = join(vault, 'raw-sources', 'articles', 'fetched');
+      await mkdir(fetchedDir, { recursive: true });
+      // 2.5MB の MD を作成 (中には [[Foo]] を含むが size cap で検知されない)
+      const bigPath = join(fetchedDir, 'evil.com-huge.md');
+      const marker = '\n\nsee [[Foo]]\n';
+      // 2.5MB の padding + wikilink marker
+      await writeFile(bigPath, 'x'.repeat(2_500_000) + marker);
+      // 通常 size の MD にも wikilink を持たせて, こちらは検知される
+      await writeFile(join(fetchedDir, 'normal.com-small.md'),
+        '---\nsource_url: "https://normal.com/"\n---\n\nsee [[Foo]]\n');
+      await assert.rejects(
+        handleDelete(vault, { path: 'foo.md' }),
+        (err) => {
+          if (err.code !== 'broken_links_detected') return false;
+          const links = err.data?.brokenLinks ?? [];
+          const skipped = err.data?.skippedLargeFiles ?? [];
+          // 2.5MB の MD は brokenLinks に載らない
+          const bigInLinks = links.find((x) =>
+            x.sourcePath === 'raw-sources/articles/fetched/evil.com-huge.md'
+          );
+          if (bigInLinks) return false;
+          // 代わりに skippedLargeFiles に記録される
+          const bigInSkipped = skipped.find((x) =>
+            x.sourcePath === 'raw-sources/articles/fetched/evil.com-huge.md'
+          );
+          if (!bigInSkipped) return false;
+          assert.ok(bigInSkipped.size > 2_000_000,
+            'skippedLargeFiles[].size must reflect actual file size');
+          // 通常 size の MD は引き続き検知される
+          const smallInLinks = links.find((x) =>
+            x.sourcePath === 'raw-sources/articles/fetched/normal.com-small.md'
+          );
+          return smallInLinks !== undefined;
+        },
+      );
+    } finally { await cleanup(); }
+  });
+
   test('MCP26c excludes .cache / session-logs / .git from scanReferences', async () => {
     // 2026-04-20: HIGH-a1 fix で scanReferences を vault ルートに広げたので、
     // 除外ディレクトリ (.cache / session-logs / .git / node_modules) が誤って


### PR DESCRIPTION
親リポ PR #8 の merge 同期。v0.3.1 post-release review で検出した NEW-M1 (kioku_delete の DoS 表面) を修正。詳細: [親リポ PR #8](https://github.com/megaphone-kurata/claude-tools/pull/8)