### PR TITLE
Sync: v0.3.3 hotfix — .mcpb に scripts/ 同梱 (PDF 処理復旧)

### DIFF
--- a/mcp/manifest.json
+++ b/mcp/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "kioku-wiki",
   "display_name": "KIOKU Wiki",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Read, search, and write your KIOKU Obsidian Wiki from Claude Desktop or Claude Code.",
   "long_description": "KIOKU is a personal knowledge base ('second brain') built on top of an Obsidian Vault. This MCP server exposes eight tools (kioku_search, kioku_read, kioku_list, kioku_write_note, kioku_write_wiki, kioku_delete, kioku_ingest_pdf, kioku_ingest_url) so that Claude Desktop and Claude Code can browse and update the Wiki without leaving the chat. All operations are local stdio — nothing leaves your machine. See https://github.com/megaphone-tokyo/kioku for the full project.",
   "author": {

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kioku-mcp",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kioku-mcp",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "dependencies": {
         "@modelcontextprotocol/sdk": "~1.29.0",
         "@mozilla/readability": "^0.5.0",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kioku-mcp",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "private": true,
   "type": "module",
   "description": "KIOKU local MCP server (Wiki read/list/search/write_note/write_wiki/delete) for Claude Desktop and Claude Code.",

--- a/scripts/build-mcpb.sh
+++ b/scripts/build-mcpb.sh
@@ -138,6 +138,32 @@ cp -R "${MCP_DIR}/tools" "${STAGING_DIR}/server/tools"
 # .mjs ファイル以外を staging から落とす。
 find "${STAGING_DIR}/server/tools" -mindepth 1 -type d -empty -delete 2>/dev/null || true
 
+# 2026-04-20 v0.3.3 fix (機能 2.1 以降の長期バグ): MCP tool `kioku_ingest_pdf` は
+# `scripts/extract-pdf.sh` を spawn するが (ingest-pdf.mjs 内で
+# `join(__dirname, '..', '..', 'scripts', 'extract-pdf.sh')` に resolve)、
+# v0.2.0/v0.3.0/v0.3.1/v0.3.2 の .mcpb bundle にこの shell script が含まれて
+# いなかったため、Claude Desktop 経由で kioku_ingest_pdf を叩くと rc=127 で
+# 失敗していた (dev 時は parent repo 直パスで解決するので dogfooding でも
+# 検出できなかった)。staging のルートに scripts/ を配置することで
+# server/tools/ingest-pdf.mjs から `../../scripts/extract-pdf.sh` が正しく解決する。
+#
+# 同梱対象:
+#   - extract-pdf.sh        : kioku_ingest_pdf が spawn (必須)
+#   - mask-text.mjs         : extract-pdf.sh が Node CLI として呼ぶ (必須)
+#   - lib/masking.mjs       : mask-text.mjs が import (必須)
+#   - extract-url.sh        : 将来 MCP-side から spawn する可能性あり (現状 cron 専用だが念のため)
+#   - auto-ingest.sh / auto-lint.sh / setup-*.sh / install-*.sh 等の cron/setup 系:
+#     MCP から spawn されない → 除外する (余計な配布物を減らす)
+echo "build-mcpb: [stage] copying MCP-invoked scripts (extract-pdf.sh + deps)"
+mkdir -p "${STAGING_DIR}/scripts"
+cp "${SCRIPT_DIR}/extract-pdf.sh" "${STAGING_DIR}/scripts/extract-pdf.sh"
+cp "${SCRIPT_DIR}/mask-text.mjs" "${STAGING_DIR}/scripts/mask-text.mjs"
+cp "${SCRIPT_DIR}/extract-url.sh" "${STAGING_DIR}/scripts/extract-url.sh"
+cp -R "${SCRIPT_DIR}/lib" "${STAGING_DIR}/scripts/lib"
+# 実行権限を明示 (cp -p だとテスト環境の uid 違いで失敗しうるので chmod で確定)
+chmod 0755 "${STAGING_DIR}/scripts/extract-pdf.sh"
+chmod 0755 "${STAGING_DIR}/scripts/extract-url.sh"
+
 # -----------------------------------------------------------------------------
 # staging で本番依存を install (lock ファイルが揃っていれば npm ci、無ければ npm install)
 # -----------------------------------------------------------------------------

--- a/tests/build-mcpb.test.sh
+++ b/tests/build-mcpb.test.sh
@@ -119,6 +119,43 @@ STAGING="${REPO_ROOT}/tools/claude-brain/mcp/build/staging"
   || fail "MCPB4 staging missing @modelcontextprotocol/sdk"
 
 # -----------------------------------------------------------------------------
+# MCPB4b (v0.3.3 regression test): staging に MCP-invoked shell scripts が含まれる
+#
+# v0.2.0-v0.3.2 の .mcpb bundle は scripts/ を staging に入れていなかったため、
+# Claude Desktop 経由で kioku_ingest_pdf を叩くと `extract-pdf.sh: No such file or
+# directory` (rc=127) で失敗していた。v0.3.3 で scripts/ staging コピーを追加。
+# 本テストは regression 防止 (手元 build でなく .mcpb 経由で tool が動く前提を固定)。
+# -----------------------------------------------------------------------------
+[[ -f "${STAGING}/scripts/extract-pdf.sh" ]] \
+  && pass "MCPB4b staging includes scripts/extract-pdf.sh (kioku_ingest_pdf 依存)" \
+  || fail "MCPB4b staging missing scripts/extract-pdf.sh — kioku_ingest_pdf will fail at runtime"
+[[ -x "${STAGING}/scripts/extract-pdf.sh" ]] \
+  && pass "MCPB4b extract-pdf.sh is executable (0o755)" \
+  || fail "MCPB4b extract-pdf.sh lacks execute permission"
+[[ -f "${STAGING}/scripts/mask-text.mjs" ]] \
+  && pass "MCPB4b staging includes scripts/mask-text.mjs (extract-pdf.sh 依存)" \
+  || fail "MCPB4b staging missing scripts/mask-text.mjs"
+[[ -f "${STAGING}/scripts/lib/masking.mjs" ]] \
+  && pass "MCPB4b staging includes scripts/lib/masking.mjs (mask-text.mjs 依存)" \
+  || fail "MCPB4b staging missing scripts/lib/masking.mjs"
+[[ -f "${STAGING}/scripts/extract-url.sh" ]] \
+  && pass "MCPB4b staging includes scripts/extract-url.sh (将来の MCP spawn 用)" \
+  || fail "MCPB4b staging missing scripts/extract-url.sh"
+# auto-ingest.sh / install-*.sh / setup-*.sh は MCP から spawn されないため staging に入らない
+[[ ! -f "${STAGING}/scripts/auto-ingest.sh" ]] \
+  && pass "MCPB4b staging excludes cron-only scripts/auto-ingest.sh (最小配布)" \
+  || fail "MCPB4b staging includes scripts/auto-ingest.sh (不要に同梱されている)"
+
+# ingest-pdf.mjs の path 解決整合確認:
+# `join(__dirname, '..', '..', 'scripts', 'extract-pdf.sh')` は
+# staging では `server/tools/../../scripts/extract-pdf.sh` = staging ルート直下 scripts/
+# parent repo でも `mcp/tools/../../scripts/extract-pdf.sh` = tools/claude-brain/scripts/
+# この契約が壊れていないことを確認 (ingest-pdf.mjs にパス文字列が残っている)
+grep -q "'..', '..', 'scripts', 'extract-pdf.sh'" "${REPO_ROOT}/tools/claude-brain/mcp/tools/ingest-pdf.mjs" \
+  && pass "MCPB4b ingest-pdf.mjs の path resolve が scripts/ staging 配置と整合" \
+  || fail "MCPB4b ingest-pdf.mjs の path 文字列が変更された — build-mcpb.sh の staging 位置と再整合すること"
+
+# -----------------------------------------------------------------------------
 # MCPB5: --clean removes build/ and dist/
 # -----------------------------------------------------------------------------
 echo "== MCPB5: --clean =="


### PR DESCRIPTION
親リポ PR #9 の sync。v0.2.0 以降 4 リリース分の .mcpb で `kioku_ingest_pdf` が動作しなかった致命バグの修正。詳細: [親リポ PR #9](https://github.com/megaphone-kurata/claude-tools/pull/9)