### PR TITLE
v0.4.0 — Tier A (security + ops) + Tier B (cleanness) overhaul

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -113,7 +113,7 @@ The MCP server adds write paths that did not exist before. The matrix:
 | MCP `kioku_ingest_url` (images) | `raw-sources/<subdir>/fetched/media/<host>/` | file 0600 / sha256-named | MIME whitelist + hostname traversal guard + git-ignored |
 | MCP `kioku_ingest_url` (raw HTML cache) | `.cache/html/` | dir 0700 / file 0600 | `urlToFilename` sanitizer (SAFE_PATH_RE compatible) + git-ignored |
 
-Cross-boundary writes (e.g. `kioku_write_wiki` pointing into `session-logs/`) are rejected at the realpath stage. All wiki/ writes are serialized through `$VAULT/.kioku-mcp.lock` (advisory flock with 30 s TTL) so MCP and `auto-ingest.sh` cannot collide. `kioku_ingest_url` dispatches to `kioku_ingest_pdf` with `skipLock=true` to avoid re-entrance on the same lock. `MASK_RULES` (mirror of `session-logger.mjs`) is applied to every `body` argument **and** URL-derived frontmatter fields before persistence.
+Cross-boundary writes (e.g. `kioku_write_wiki` pointing into `session-logs/`) are rejected at the realpath stage. All wiki/ writes are serialized through `$VAULT/.kioku-mcp.lock` (advisory flock with 30 s TTL) so MCP and `auto-ingest.sh` cannot collide. `kioku_ingest_url` releases the outer `withLock` after writing the PDF to disk (seconds) and then calls `kioku_ingest_pdf`, which acquires its own `withLock` for the extraction phase — this keeps the shared lock hold time bounded even for large PDFs (v0.4.0 Tier A#3 refactor; the earlier `skipLock` injection has been removed). `MASK_RULES` (mirror of `session-logger.mjs`) is applied to every `body` argument **and** URL-derived frontmatter fields before persistence.
 
 ### Outbound Network Policy (feature 2.2)
 

--- a/hooks/session-logger.mjs
+++ b/hooks/session-logger.mjs
@@ -10,7 +10,7 @@ import { appendFile, mkdir, readFile, writeFile, rename, open, stat, realpath } 
 import { dirname, join } from 'node:path';
 import { hostname } from 'node:os';
 
-import { MASK_RULES } from '../scripts/lib/masking.mjs';
+import { maskText as mask } from '../scripts/lib/masking.mjs';
 
 // -----------------------------------------------------------------------------
 // 定数
@@ -31,13 +31,41 @@ const BASH_BLOCKLIST = new Set([
 
 // マスキング規則 (MASK_RULES) は ../scripts/lib/masking.mjs に集約した。
 // 新パターン追加時はそちらのコメント (同期対象 3 箇所) を参照すること。
+// v0.4.0 Tier B#1: 旧自前 mask() を削除し maskText() に委譲。INVISIBLE_CHARS
+// 除去 + NFC 正規化を Hook 経路にも適用 (RED-L0-01 / BLUE-L0-01)。
+
+// 環境変数の真偽判定を 1 / true / yes / on (case-insensitive) に統一する。
+// 既定は fail-safe (値が不明瞭なら falsy 側に倒さず truthy に寄せる) 設計。
+// KIOKU_NO_LOG は "true" でも発火すべき (再帰ログ防止の本意)。
+// v0.4.0 Tier B#1 (BLUE-L0-02): strict `=== '1'` の truthy drift 対策。
+function envTruthy(val) {
+  if (!val) return false;
+  return /^(1|true|yes|on)$/i.test(String(val).trim());
+}
+
+// YAML スカラー値を安全に埋め込むためのヘルパ。
+// - 制御文字 (U+0000..U+001F, U+007F) と Unicode 不可視/区切り文字を除去。
+// - YAML 構造文字を含む場合は単一引用符で囲み、単引用符自体は '' に倍化する。
+// v0.4.0 Tier B#1 (RED-L0-02): frontmatter injection 対策。
+// session_id / cwd / project_dir が改行や `---` を含む場合に YAML 境界を偽装
+// できないようにする。
+function yamlSafeValue(v) {
+  if (v == null) return '';
+  let s = String(v)
+    .replace(/[\u0000-\u001F\u007F]/g, '')
+    .replace(/[\u200B-\u200F\u2028-\u2029\uFEFF]/g, '');
+  if (/[:#&*!|>'"%@`[\]{},]|^\s|\s$|^[-?~]|^(null|true|false|yes|no|on|off)$/i.test(s)) {
+    return `'${s.replace(/'/g, "''")}'`;
+  }
+  return s;
+}
 
 // -----------------------------------------------------------------------------
 // ユーティリティ
 // -----------------------------------------------------------------------------
 
 function debugLog(ctx, msg) {
-  if (process.env.KIOKU_DEBUG !== '1') return;
+  if (!envTruthy(process.env.KIOKU_DEBUG)) return;
   process.stderr.write(`[claude-brain] ${msg}\n`);
   writeErrorLog(ctx, `DEBUG: ${msg}`).catch(() => {});
 }
@@ -51,15 +79,6 @@ async function writeErrorLog(ctx, msg) {
   } catch {
     // 無視: エラーログ書き込み失敗は黙殺
   }
-}
-
-function mask(text) {
-  if (typeof text !== 'string') return text;
-  let out = text;
-  for (const [re, rep] of MASK_RULES) {
-    out = out.replace(re, rep);
-  }
-  return out;
 }
 
 // ローカルタイムゾーンのタイムスタンプ生成 (OSS-001: Asia/Tokyo ハードコードを廃止)
@@ -222,11 +241,11 @@ function buildFrontmatter(payload, ts) {
   const lines = [
     '---',
     'type: session-log',
-    `session_id: ${payload.session_id}`,
-    `hostname: ${hostname()}`,
-    `cwd: ${payload.cwd || ''}`,
+    `session_id: ${yamlSafeValue(payload.session_id)}`,
+    `hostname: ${yamlSafeValue(hostname())}`,
+    `cwd: ${yamlSafeValue(payload.cwd || '')}`,
     `date: ${ts.iso}`,
-    `project_dir: ${projectDir || 'null'}`,
+    `project_dir: ${projectDir ? yamlSafeValue(projectDir) : 'null'}`,
     'ingested: false',
     'related: []',
     '---',
@@ -455,11 +474,13 @@ const HANDLERS = {
 // -----------------------------------------------------------------------------
 
 async function main() {
-  // KIOKU_NO_LOG=1 のときは Hook 全体を no-op 化する。
+  // KIOKU_NO_LOG が truthy (1 / true / yes / on) のときは Hook 全体を no-op 化する。
   // auto-ingest.sh / auto-lint.sh が起動する claude -p サブプロセスは
   // 親の ~/.claude/settings.json を継承するため、このフラグがないと
   // サブプロセス自身の活動が session-logs/ に再帰的に記録されてしまう。
-  if (process.env.KIOKU_NO_LOG === '1') return;
+  // v0.4.0 Tier B#1 (BLUE-L0-02): strict `=== '1'` から envTruthy 経由に変更し、
+  // ユーザーが直感的に `=true` と書いた場合の silent drift を防ぐ (fail-safe)。
+  if (envTruthy(process.env.KIOKU_NO_LOG)) return;
 
   const vault = process.env.OBSIDIAN_VAULT;
   if (!vault) return;

--- a/mcp/manifest.json
+++ b/mcp/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "kioku-wiki",
   "display_name": "KIOKU Wiki",
-  "version": "0.3.7",
+  "version": "0.4.0",
   "description": "Read, search, and write your KIOKU Obsidian Wiki from Claude Desktop or Claude Code.",
   "long_description": "KIOKU is a personal knowledge base ('second brain') built on top of an Obsidian Vault. This MCP server exposes eight tools (kioku_search, kioku_read, kioku_list, kioku_write_note, kioku_write_wiki, kioku_delete, kioku_ingest_pdf, kioku_ingest_url) so that Claude Desktop and Claude Code can browse and update the Wiki without leaving the chat. All operations are local stdio — nothing leaves your machine. See https://github.com/megaphone-tokyo/kioku for the full project.",
   "author": {

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "kioku-mcp",
-  "version": "0.3.7",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kioku-mcp",
-      "version": "0.3.7",
+      "version": "0.4.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "~1.29.0",
-        "@mozilla/readability": "^0.5.0",
+        "@mozilla/readability": "^0.6.0",
         "jsdom": "^24.1.3",
         "turndown": "^7.2.4",
         "turndown-plugin-gfm": "^1.0.2"
@@ -200,9 +200,9 @@
       }
     },
     "node_modules/@mozilla/readability": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@mozilla/readability/-/readability-0.5.0.tgz",
-      "integrity": "sha512-Z+CZ3QaosfFaTqvhQsIktyGrjFjSC0Fa4EMph4mqKnWhmyoGICsV/8QK+8HpXut6zV7zwfWwqDmEjtk1Qf6EgQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@mozilla/readability/-/readability-0.6.0.tgz",
+      "integrity": "sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14.0.0"

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kioku-mcp",
-  "version": "0.3.7",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "description": "KIOKU local MCP server (Wiki read/list/search/write_note/write_wiki/delete) for Claude Desktop and Claude Code.",
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "~1.29.0",
-    "@mozilla/readability": "^0.5.0",
+    "@mozilla/readability": "^0.6.0",
     "jsdom": "^24.1.3",
     "turndown": "^7.2.4",
     "turndown-plugin-gfm": "^1.0.2"

--- a/mcp/tools/delete.mjs
+++ b/mcp/tools/delete.mjs
@@ -85,12 +85,13 @@ export async function handleDelete(vault, args) {
     // 残った状態で wiki ページを archive すると broken_links_detected が発火せず
     // silent orphan 化していた。
     const vaultAbs = await realpath(vault);
-    const { brokenLinks, skippedLargeFiles } = await scanReferences(vaultAbs, wikiAbs, abs, targets);
+    const { brokenLinks, skippedLargeFiles, skippedUnreadable } =
+      await scanReferences(vaultAbs, wikiAbs, abs, targets);
 
     if (brokenLinks.length > 0 && !force) {
       const e = new Error('broken links detected (use force=true to override)');
       e.code = 'broken_links_detected';
-      e.data = { brokenLinks, skippedLargeFiles };
+      e.data = { brokenLinks, skippedLargeFiles, skippedUnreadable };
       throw e;
     }
 
@@ -114,6 +115,7 @@ export async function handleDelete(vault, args) {
       archivedPath: 'wiki/' + relative(wikiAbs, archiveAbs).split(sep).join('/'),
       brokenLinks,
       skippedLargeFiles,
+      skippedUnreadable,
     };
   });
 }
@@ -145,6 +147,10 @@ async function scanReferences(vaultAbs, wikiAbs, targetAbs, targetSet) {
   // 対象に入れる。session-logs / .cache / .obsidian / node_modules 等は除外。
   const out = [];
   const skipped = [];
+  // 2026-04-21 L-2 fix: readFile 失敗を silent catch せず operator 視認性を残す。
+  // SCAN_MAX_BYTES (size cap) の先を抜けて readFile が EACCES / EIO / ENOENT
+  // (symlink 切れ 等) で落ちたときは skippedUnreadable[] に記録して caller に返す。
+  const unreadable = [];
   // ディレクトリ名除外 (トップレベルおよび任意階層)
   const excludeDirs = new Set([
     '.obsidian', '.archive', '.trash', 'templates',
@@ -191,12 +197,20 @@ async function scanReferences(vaultAbs, wikiAbs, targetAbs, targetSet) {
               inWiki,
             });
           }
-        } catch {
-          // skip unreadable
+        } catch (err) {
+          // L-2 fix: silent skip せず skippedUnreadable[] に記録。
+          // error フィールドは運用側で EACCES / EIO / ENOENT 等を区別できるよう
+          // code を優先し、無ければ message 先頭 200 char に truncate する
+          // (攻撃者制御の長大 error メッセージで operator 視認性を損なわないため)。
+          const relFromVault = relative(vaultAbs, childAbs).split(sep).join('/');
+          const errStr = typeof err?.code === 'string' && err.code
+            ? err.code
+            : String(err?.message ?? 'unknown').slice(0, 200);
+          unreadable.push({ sourcePath: relFromVault, error: errStr });
         }
       }
     }
   }
   await walk(vaultAbs);
-  return { brokenLinks: out, skippedLargeFiles: skipped };
+  return { brokenLinks: out, skippedLargeFiles: skipped, skippedUnreadable: unreadable };
 }

--- a/mcp/tools/ingest-pdf.mjs
+++ b/mcp/tools/ingest-pdf.mjs
@@ -99,7 +99,7 @@ export async function handleIngestPdf(vault, args, injections = {}) {
   const subdirPrefix = relFromRaw.includes('/') ? relFromRaw.split('/')[0] : 'root';
   const stem = basename(absPath, ext);
 
-  // v0.3.4: 15s heartbeat を仕込む。ingest-url からの skipLock 経由呼び出しでも
+  // v0.3.4: 15s heartbeat を仕込む。ingest-url からの dispatch 経由呼び出しでも
   // sendProgress は外側 (kioku_ingest_url 側) から injection で渡ってくるので、
   // 同じ progressToken で継続的に notification が流れる (client は単一 token を
   // 追うので、handler 境界を跨いでも timeout リセットが一貫)。
@@ -108,13 +108,16 @@ export async function handleIngestPdf(vault, args, injections = {}) {
     `kioku_ingest_pdf: processing ${pathArg}`,
   );
 
-  // skipLock: 機能 2.2 kioku_ingest_url が PDF URL を dispatch するとき、外側で既に
-  // withLock を取得済みなので二重取得 (deadlock or 60s timeout) を避けるための injection。
-  // 通常呼び出しでは undefined → withLock で囲む。
+  // 2026-04-21 v0.4.0 Tier A#3 M-a4: skipLock injection を完全削除した。
+  // 旧実装では ingest-url が outer withLock を保持したまま handleIngestPdf を
+  // skipLock=true で呼んで二重取得を回避していたが、これは outer lock を最大
+  // 4.5 分保持する M-a2 問題の原因でもあった。M-a2 修正 (ingest-url.mjs の
+  // dispatch を withLock 外へ出す) により skipLock は構造的に不要になったため削除。
+  // handleIngestPdf は常に自前で withLock を取得する (reentrant 判定不要)。
   //
-  // v0.3.5 Option B: Phase 1 (extract + analyze + decide) は従来通り lock 下で
+  // v0.3.5 Option B: Phase 1 (extract + analyze + decide) は lock 下で
   // 実行する。chunks >= DETACHED_CHUNK_THRESHOLD なら `{ __queued }` を返し、
-  // lock 解放後に Phase 2 (spawnDetached) を回す。short PDF (1 chunk) は従来通り
+  // lock 解放後に Phase 2 (spawnDetached) を回す。short PDF (1 chunk) は
   // lock 下で sync に claude -p を回して `extracted_and_summarized` を返す。
   const phase1 = async () => {
       const warnings = [];
@@ -250,16 +253,11 @@ export async function handleIngestPdf(vault, args, injections = {}) {
   };
 
   try {
-    // Phase 1 — lock 下 (or skipLock 時は素通し) で extract + decide
-    let phase1Result;
-    if (injections.skipLock) {
-      phase1Result = await phase1();
-    } else {
-      phase1Result = await withLock(vault, phase1, {
-        ttlMs: LOCK_TTL_MS,
-        timeoutMs: LOCK_ACQUIRE_TIMEOUT_MS,
-      });
-    }
+    // Phase 1 — lock 下で extract + decide (skipLock は v0.4.0 Tier A#3 で削除)
+    const phase1Result = await withLock(vault, phase1, {
+      ttlMs: LOCK_TTL_MS,
+      timeoutMs: LOCK_ACQUIRE_TIMEOUT_MS,
+    });
 
     if (phase1Result.kind === 'done') {
       return phase1Result.result;

--- a/mcp/tools/ingest-url.mjs
+++ b/mcp/tools/ingest-url.mjs
@@ -1,6 +1,7 @@
 // kioku_ingest_url — 機能 2.2 MCP tool。
 //
 // 設計書: plan/claude/26041801_feature-2-2-html-url-ingest-design.md §4.1 §4.7
+//         plan/claude/26042102_meeting_v0-4-0-lock-refactor-decision.md (v0.4.0 refactor)
 // フロー:
 //   1. URL バリデーション (SSRF / scheme / credentials) — withLock の外で先行 reject
 //   2. withLock(vault) — cron auto-ingest.sh / kioku_ingest_pdf と `.kioku-mcp.lock` を共有
@@ -8,12 +9,22 @@
 //   4. robots.txt を確認 (defense-in-depth: HTML 経路では extractAndSaveUrl 内でも再評価)
 //   5. Content-Type 分岐:
 //        text/html / application/xhtml+xml → extractAndSaveUrl に委譲
-//        application/pdf / (octet-stream + URL末尾.pdf) → handleIngestPdf に skipLock=true で dispatch
+//        application/pdf / (octet-stream + URL末尾.pdf) → inner が __pendingPdfDispatch signal
+//          を返す。outer withLock **release 後** に handleIngestPdf を呼び、PDF 処理側で
+//          自前の withLock を取得する (v0.4.0 Tier A#3 M-a2/M-a4)
 //   6. extractAndSaveUrl が後段で PDF を検知 (リダイレクト先が PDF だった等) した場合も
 //      err.code === 'not_html' && err.pdfCandidate === true で PDF 経路に rerouting。
 //      この時 extractAndSaveUrl の fetch は **非バイナリ** なので body は UTF-8 文字列で
 //      PDF を保持できない。late-PDF 経路では必ず再 fetch (binary:true) する (CRIT-1)。
 //   7. 結果 JSON を返す
+//
+// v0.4.0 Tier A#3 の lock refactor 要点 (2026-04-21):
+//   - 旧実装は PDF dispatch 時に outer withLock を最大 4.5 分保持する経路があった
+//     (大容量 PDF の poppler 同期 extract)。新実装は PDF disk write まで (数秒) で
+//     outer を release し、handleIngestPdf に自前の withLock を再取得させる。
+//   - この変更により `skipLock` injection は不要になったため API 自体を削除。
+//   - race 窓の実害なし: kioku_delete は wiki/ 配下のみ対象 / sha256 冪等で重複
+//     ingest も safe / auto-ingest.sh との競合は新規リスクではない (既存 semantic)。
 //
 // セキュリティ要点:
 //   - 外側で URL validation (validateUrl) を済ませてから lock 取得
@@ -25,7 +36,7 @@
 //   - エラー文字列に attacker-controlled URL / 内部 IP / credentials を載せない
 //     (HIGH-2: prompt-injection / SSRF info leak 対策)。code-only で MCP 境界を渡す。
 
-import { mkdir, open, rename } from 'node:fs/promises';
+import { mkdir, open, rename, unlink } from 'node:fs/promises';
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { z } from 'zod';
@@ -126,9 +137,14 @@ export const INGEST_URL_TOOL_DEF = {
 /**
  * @param {string} vault
  * @param {{url: string, subdir?: string, title?: string, source_type?: string, tags?: string[], refresh_days?: number|'never', max_turns?: number}} args
- * @param {{claudeBin?: string, robotsUrlOverride?: string, skipLock?: boolean}} [injections]
- *   skipLock: WARNING — only set true when the caller already holds withLock(vault, ...).
- *   Used internally by the late-PDF dispatch path; do not pass from external callers.
+ * @param {{claudeBin?: string, robotsUrlOverride?: string, sendProgress?: Function}} [injections]
+ *
+ * 2026-04-21 v0.4.0 Tier A#3 M-a2/M-a4 refactor:
+ * - PDF dispatch 時の outer withLock 保持時間を最大 4.5 分 → 数秒に短縮するため、
+ *   inner() は PDF 書き出しまでを withLock 下で行い、handleIngestPdf 呼び出しは
+ *   outer withLock **release 後** に実行する構造に変更。
+ * - skipLock injection は削除 (API surface 縮小)。handleIngestPdf は常に自前の
+ *   withLock を取得する (このファイルが持つ outer withLock はその時点で released)。
  */
 export async function handleIngestUrl(vault, args, injections = {}) {
   validate(args);
@@ -212,14 +228,21 @@ export async function handleIngestUrl(vault, args, injections = {}) {
       // PDF の既定 subdir は 'papers' (機能 2 の PDF 配置規約と整合)。
       // ユーザーが明示的に subdir を指定した場合はそれを尊重する。
       const pdfSubdir = (args.subdir == null) ? 'papers' : subdir;
-      return await dispatchToPdf({
+      // outer withLock 下で PDF を disk に atomic write する。
+      // handleIngestPdf 呼び出しは outer withLock release **後** に行う
+      // (inner から __pendingPdfDispatch signal を返すことで指示する)。
+      const { pdfRelPath } = await writePdfToDisk({
         vault,
         subdir: pdfSubdir,
         url,
         body: fetchResult.body,
-        claudeBin: injections.claudeBin,
-        sendProgress: injections.sendProgress,
       });
+      return {
+        __pendingPdfDispatch: true,
+        vault,
+        pdfRelPath,
+        url,
+      };
     }
 
     if (!ct.includes('text/html') && !ct.includes('application/xhtml+xml')) {
@@ -262,14 +285,20 @@ export async function handleIngestUrl(vault, args, injections = {}) {
           throwInvalidRequest('PDF exceeds size cap');
         }
         const pdfSubdir = (args.subdir == null) ? 'papers' : subdir;
-        return await dispatchToPdf({
+        // late-PDF 経路でも outer withLock 内で PDF を disk に write して、
+        // handleIngestPdf 呼び出しは outer withLock release 後に行う (同上)。
+        const { pdfRelPath } = await writePdfToDisk({
           vault,
           subdir: pdfSubdir,
           url,
           body: refetch.body,
-          claudeBin: injections.claudeBin,
-          sendProgress: injections.sendProgress,
         });
+        return {
+          __pendingPdfDispatch: true,
+          vault,
+          pdfRelPath,
+          url,
+        };
       }
       // HIGH-2: extractAndSaveUrl 由来のエラーも raw message を漏らさず code only で返す
       if (err && err.code === 'extraction_failed') throwInternal(`extraction failed: ${err.code}`);
@@ -279,10 +308,61 @@ export async function handleIngestUrl(vault, args, injections = {}) {
   };
 
   try {
-    if (injections.skipLock) {
-      return await inner();
+    // 2026-04-21 M-a2/M-a4 refactor: outer withLock は fetch + (PDF なら) disk write
+    // までを守る。inner が __pendingPdfDispatch signal を返した場合は、withLock
+    // release **後** に handleIngestPdf を呼んで自前の withLock を取らせる。
+    // これにより outer lock の保持時間が 4.5 分 → 数秒に短縮される。
+    const innerResult = await withLock(vault, inner, {
+      ttlMs: LOCK_TTL_MS,
+      timeoutMs: LOCK_ACQUIRE_TIMEOUT_MS,
+    });
+
+    if (innerResult && innerResult.__pendingPdfDispatch) {
+      // outer withLock は既に release 済 (withLock の finally で lockfile unlink 完了)。
+      // handleIngestPdf が自前で withLock を acquire する。
+      //
+      // 2026-04-21 v0.4.0 Tier A#3 post-review GAP-1 fix (red/blue 共通指摘):
+      // handleIngestPdf が失敗した場合、outer withLock は既に release されているため
+      // PDF ファイルが raw-sources/ に orphan として永続化される。旧 skipLock 設計では
+      // 全体が一体 try/finally 内だったので orphan は観察されにくかったが、新 design
+      // では明示的 cleanup が必要。
+      //
+      // cleanup 分岐の判定:
+      //   - `lock_timeout`: user retry の余地があるので PDF を保持 (次回呼出で処理される)
+      //   - それ以外 (encrypted_or_invalid / extract rc=2,4,5 / claude -p 失敗): PDF が
+      //     processable でないことが判明しているので削除。best-effort (unlink 失敗は
+      //     operator 側で手動 cleanup すれば済む)
+      let pdfResult;
+      try {
+        pdfResult = await handleIngestPdf(
+          innerResult.vault,
+          { path: innerResult.pdfRelPath },
+          {
+            claudeBin: injections.claudeBin,
+            sendProgress: injections.sendProgress,
+          },
+        );
+      } catch (err) {
+        if (err?.code !== 'lock_timeout') {
+          try {
+            await unlink(join(innerResult.vault, innerResult.pdfRelPath));
+          } catch {
+            /* best-effort: orphan PDF cleanup 失敗は本体エラーを隠さない */
+          }
+        }
+        throw err;
+      }
+      return {
+        status: pdfResult.status === 'queued_for_summary'
+          ? 'dispatched_to_pdf_queued'
+          : 'dispatched_to_pdf',
+        url: innerResult.url,
+        path: innerResult.pdfRelPath,
+        pdf_result: pdfResult,
+      };
     }
-    return await withLock(vault, inner, { ttlMs: LOCK_TTL_MS, timeoutMs: LOCK_ACQUIRE_TIMEOUT_MS });
+
+    return innerResult;
   } finally {
     await stopHeartbeat('kioku_ingest_url: done');
   }
@@ -356,7 +436,12 @@ function sanitizeForError(s) {
   return cleaned.length > 100 ? `${cleaned.slice(0, 100)}…` : cleaned;
 }
 
-async function dispatchToPdf({ vault, subdir, url, body, claudeBin, sendProgress }) {
+// 2026-04-21 v0.4.0 Tier A#3 M-a2: 旧 dispatchToPdf は「PDF を disk に書く」と
+// 「handleIngestPdf を呼ぶ」を一体で行っていた (outer withLock を 4.5 分保持する原因)。
+// refactor 後は、このヘルパーは **PDF を disk に書くまで** (outer withLock 下で実行可能)
+// を担当し、handleIngestPdf 呼び出しは handleIngestUrl 側で outer withLock **release 後**
+// に行う。
+async function writePdfToDisk({ vault, subdir, url, body }) {
   if (!body) throwInternal('PDF body missing for dispatch');
   // urlToFilename は <host>-<slug>.md を返すので拡張子だけ差し替える。
   const name = urlToFilename(url).replace(/\.md$/, '.pdf');
@@ -377,21 +462,8 @@ async function dispatchToPdf({ vault, subdir, url, body, claudeBin, sendProgress
   }
   await rename(tmp, absPath);
 
-  // 内側 handleIngestPdf に dispatch — 外側で withLock を保持済みなので skipLock=true。
-  // v0.3.4: sendProgress も伝搬して PDF 処理中も heartbeat が流れ続けるようにする。
-  // v0.3.5 Option B: 長い PDF は handleIngestPdf が `queued_for_summary` で早期 return
-  // する。その場合 dispatchToPdf 側の status も `dispatched_to_pdf_queued` に昇格させ、
-  // client が "summary は数分後に wiki/summaries/ に出現する" 旨を明示的に知れるようにする。
-  const pdfResult = await handleIngestPdf(
-    vault,
-    { path: `raw-sources/${subdir}/${name}` },
-    { claudeBin, skipLock: true, sendProgress },
-  );
   return {
-    status: pdfResult.status === 'queued_for_summary' ? 'dispatched_to_pdf_queued' : 'dispatched_to_pdf',
-    url,
-    path: `raw-sources/${subdir}/${name}`,
-    pdf_result: pdfResult,
+    pdfRelPath: `raw-sources/${subdir}/${name}`,
   };
 }
 

--- a/scripts/auto-ingest.sh
+++ b/scripts/auto-ingest.sh
@@ -480,6 +480,15 @@ elif git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   # NEW-009: .gitignore に session-logs/ が含まれていることを確認してから git 操作
   if ! grep -q '^session-logs/' .gitignore 2>/dev/null; then
     echo "${LOG_PREFIX} WARNING: .gitignore missing 'session-logs/' entry. Skipping git commit/push for safety." >&2
+  # v0.4.0 Tier A#2 (2026-04-21): detached HEAD ガード
+  # rebase 中断・git bisect・detached checkout などで HEAD が branch から外れていると
+  # `git commit` は成功するが push 先 branch が決まらず `git push` が silent に失敗、
+  # commit が reflog にたまるだけで remote に反映されない (Mac mini で 2026-04-16〜04-21
+  # に 5 日間の drift を実測)。git symbolic-ref -q HEAD で branch 確認し、detached なら
+  # 全ての git 書き込みを skip してリカバリ手順を WARN で出す (処理は非破壊的に継続)。
+  elif ! git symbolic-ref -q HEAD >/dev/null 2>&1; then
+    echo "${LOG_PREFIX} WARNING: detached HEAD in vault; skipping git commit/push to avoid local drift." >&2
+    echo "${LOG_PREFIX}          Recovery: cd \"\${OBSIDIAN_VAULT}\" && git rebase --abort 2>/dev/null; git checkout main (or your working branch)" >&2
   else
     git add wiki/ raw-sources/ templates/ CLAUDE.md 2>/dev/null || true
     if git diff --cached --quiet 2>/dev/null; then

--- a/scripts/auto-lint.sh
+++ b/scripts/auto-lint.sh
@@ -261,6 +261,11 @@ elif git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   # R4-006: .gitignore に session-logs/ が含まれていることを確認してから git 操作
   if ! grep -q '^session-logs/' .gitignore 2>/dev/null; then
     echo "${LOG_PREFIX} WARNING: .gitignore missing 'session-logs/' entry. Skipping git commit/push for safety." >&2
+  # v0.4.0 Tier A#2 (2026-04-21): detached HEAD ガード (auto-ingest.sh と同 pattern)
+  # rebase 中断・detached checkout 状態で走ると commit は溜まるが push 失敗でローカル drift。
+  elif ! git symbolic-ref -q HEAD >/dev/null 2>&1; then
+    echo "${LOG_PREFIX} WARNING: detached HEAD in vault; skipping git commit/push to avoid local drift." >&2
+    echo "${LOG_PREFIX}          Recovery: cd \"\${OBSIDIAN_VAULT}\" && git rebase --abort 2>/dev/null; git checkout main (or your working branch)" >&2
   else
     git add wiki/lint-report.md 2>/dev/null || true
     if git diff --cached --quiet 2>/dev/null; then

--- a/scripts/extract-url.sh
+++ b/scripts/extract-url.sh
@@ -31,6 +31,16 @@ LOG_PREFIX="[extract-url]"
 # なる経路を塞ぐ。shell 側で明示的に unset することで node CLI に伝搬させない。
 # テスト目的で loopback fixture-server を許可したい場合は
 # `KIOKU_ALLOW_LOOPBACK_IN_CRON=1` を指定すること (最低限の allowlist flag)。
+#
+# 2026-04-21 NEW-L2: `KIOKU_ALLOW_LOOPBACK_IN_CRON` / `KIOKU_ALLOW_IGNORE_ROBOTS_IN_CRON`
+# は shell 層のテスト専用 gate であり、意図的に `mcp/lib/child-env.mjs` の
+# `ENV_ALLOW_EXACT` allowlist には載せていない。理由:
+#   1. node CLI (`url-extract-cli.mjs`) 側は `KIOKU_URL_ALLOW_LOOPBACK` /
+#      `KIOKU_URL_IGNORE_ROBOTS` だけを読む (命名が別体系なのは意図的)
+#   2. 上記 `_IN_CRON` flag を `ENV_ALLOW_EXACT` に追加すると、cron 以外の caller
+#      (MCP tool 経由の `kioku_ingest_url` 等) が同じ flag で bypass を発動できて
+#      しまい、shell 層で unset している LOW-d4 の防御が崩れる (security regression)。
+# 将来誰かが「allowlist に足せば simpler」と思っても、この別体系は維持すること。
 if [[ "${KIOKU_ALLOW_LOOPBACK_IN_CRON:-0}" != "1" ]]; then
   unset KIOKU_URL_ALLOW_LOOPBACK
 fi

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -184,7 +184,7 @@ emit_snippet_json() {
         "hooks": [
           {
             "type": "command",
-            "command": "[ \"\${KIOKU_NO_LOG:-0}\" = \"1\" ] || { cd \"${OBSIDIAN_VAULT}\" && grep -q '^session-logs/' .gitignore 2>/dev/null && git add wiki/ raw-sources/ templates/ CLAUDE.md 2>/dev/null && (git diff --cached --quiet || (git commit -m \"auto: wiki update \$(date +%Y%m%d-%H%M)\" --quiet && git push --quiet)) 2>/dev/null; } || true"
+            "command": "[ \"\${KIOKU_NO_LOG:-0}\" = \"1\" ] || { cd \"${OBSIDIAN_VAULT}\" && grep -q '^session-logs/' .gitignore 2>/dev/null && git symbolic-ref -q HEAD >/dev/null 2>&1 && git add wiki/ raw-sources/ templates/ CLAUDE.md 2>/dev/null && (git diff --cached --quiet || (git commit -m \"auto: wiki update \$(date +%Y%m%d-%H%M)\" --quiet && git push --quiet)) 2>/dev/null; } || true"
           }
         ]
       }

--- a/scripts/sync-to-app.sh
+++ b/scripts/sync-to-app.sh
@@ -33,6 +33,50 @@ for arg in "$@"; do
 done
 
 # -----------------------------------------------------------------------------
+# GitHub-side lock (α): 2026-04-21 NEW-L2 fix (v0.4.0 Tier B#3)
+#
+# 2 台運用 (MacBook + Mac mini) で cron sync が近接時刻に起動すると、両方が
+# 同じ内容で origin/next に push して重複 PR を生む race 条件がある (症状 #1)。
+# kioku の origin/next の最終 push 時刻を gh CLI で確認し、閾値秒数以内に
+# 他 run が push 済ならこの run は早期 exit して重複 push を避ける。
+#
+# Config:
+#   KIOKU_SYNC_LOCK_MAX_AGE  閾値 (秒)。デフォルト 120。0 を指定すると無効化。
+#
+# Fail-open:
+#   - gh auth 失敗 / network error / rate limit: 全て現状回帰 (guard skip)。
+#   - 片方 Mac で gh 無効化の場合、この guard は効かない。trade-off として受容。
+#
+# Design:
+#   - --dry-run では skip (operator が手動検証する時に guard でブロックしない)。
+#   - line 72 の `git fetch` 直後に呼び出す。branch checkout より前に入れて、
+#     push 予定の branch 作り込みコストを早期回避する。
+#   - exit 時は既存 trap (line 65) が .git-kioku を復元する。
+#
+# Reference: 合意記録 plan/claude/26042104_meeting...md ## Resume session 2
+# -----------------------------------------------------------------------------
+check_github_side_lock() {
+  [[ "${DRY_RUN:-0}" == "1" ]] && return 0
+  local max_age="${KIOKU_SYNC_LOCK_MAX_AGE:-120}"
+  (( max_age <= 0 )) && return 0
+
+  local last_push_iso last_push_epoch now_epoch age
+  last_push_iso="$(gh api repos/megaphone-tokyo/kioku/branches/next \
+      --jq .commit.commit.committer.date 2>/dev/null || true)"
+  [[ -z "${last_push_iso}" ]] && return 0  # gh 未認証 / network error → fail-open
+
+  last_push_epoch="$(date -j -u -f '%Y-%m-%dT%H:%M:%SZ' "${last_push_iso}" +%s 2>/dev/null || echo 0)"
+  now_epoch="$(date -u +%s)"
+  age=$(( now_epoch - last_push_epoch ))
+
+  if (( age >= 0 && age < max_age )); then
+    echo "  [skip] origin/next was pushed ${age}s ago (<${max_age}s); another sync likely just completed" >&2
+    exit 0
+  fi
+  return 0
+}
+
+# -----------------------------------------------------------------------------
 # 前提チェック
 # -----------------------------------------------------------------------------
 
@@ -71,6 +115,11 @@ mv .git-kioku .git
 # 散らかる (feature 2.2 リリース時の WT drift 問題)。fetch 失敗は許容。
 git fetch origin --quiet 2>/dev/null || true
 
+# 2026-04-21 NEW-L2 (v0.4.0 Tier B#3): cross-machine race guard.
+# gh api で origin/next の最終 push 時刻を取り、閾値以内なら早期 exit。
+# --dry-run / KIOKU_SYNC_LOCK_MAX_AGE=0 で skip。gh エラーは fail-open。
+check_github_side_lock
+
 # 2026-04-20: rebase-merge 運用で origin/next の履歴が rewrite される
 # (kioku main へ rebase-merge 済の commit が origin/main に存在し、ローカル
 # next に残る pre-rebase commit と diverge して PR が CONFLICT) ケース + WT が
@@ -87,7 +136,11 @@ if git show-ref --quiet refs/remotes/origin/main 2>/dev/null; then
   # git stash list で後から復旧可能。
   if ! git diff --quiet 2>/dev/null || ! git diff --cached --quiet 2>/dev/null; then
     local_dirty_stash=1
-    git stash push -u -m "sync-to-app auto-stash $(date +%Y%m%d-%H%M%S)" --quiet 2>/dev/null || true
+    # 2026-04-21 NEW-L1 fix: stash message に `$$` (shell PID) を混ぜて 1 秒以内の
+    # 連続呼び出しでも message が衝突しないようにする。macOS `date` は `%N`
+    # (nanosec) 非対応のため PID で一意化する。`git stash list` で recovery する
+    # operator が履歴を区別できる。
+    git stash push -u -m "sync-to-app auto-stash $(date +%Y%m%d-%H%M%S)-pid$$" --quiet 2>/dev/null || true
     echo "  [notice] dirty WT detected; uncommitted changes stashed. Recover with: cd $(pwd) && mv .git-kioku .git && git stash list" >&2
   fi
   # -B: 既存なら reset、無ければ create。--force 相当で WT の untracked も排除しない

--- a/tests/auto-ingest.test.sh
+++ b/tests/auto-ingest.test.sh
@@ -816,6 +816,47 @@ else
 fi
 
 # -----------------------------------------------------------------------------
+# Test F19 (v0.4.0 Tier A#2, 2026-04-21): detached HEAD ガード
+# rebase 中断・detached checkout 状態で auto-ingest が走ると、guard 無しでは
+# git commit が detached HEAD 先端に積まれて push 失敗でローカル drift する。
+# guard (git symbolic-ref -q HEAD) で git 書き込みを丸ごと skip + WARN することを検証。
+# -----------------------------------------------------------------------------
+echo "test F19: detached HEAD state -> skip git commit/push + WARN"
+VAULT_F19="$(make_vault vault-f19)"
+add_unprocessed_log "${VAULT_F19}" "20260421-100000-test-f19"
+(
+  cd "${VAULT_F19}" && \
+  git init --quiet && \
+  git config user.email t@test && \
+  git config user.name t && \
+  echo 'session-logs/' > .gitignore && \
+  git add .gitignore && \
+  git commit -m init --quiet && \
+  git checkout --detach --quiet
+)
+# wiki/ に変更を用意: guard が無ければ `git diff --cached` が非空となり
+# `git commit` が detached HEAD 先端に積まれてしまうシナリオを再現する。
+echo "content" > "${VAULT_F19}/wiki/new-page.md"
+
+before_sha_f19="$(cd "${VAULT_F19}" && git rev-parse HEAD)"
+
+set +e
+out_f19="$(
+  PATH="${STUB_DIR}:${PATH}" \
+  OBSIDIAN_VAULT="${VAULT_F19}" \
+  bash "${AUTO_INGEST}" 2>&1
+)"
+rc=$?
+set -e
+
+after_sha_f19="$(cd "${VAULT_F19}" && git rev-parse HEAD)"
+
+assert_eq "0" "${rc}" "F19 exit 0 (non-destructive fail-safe)"
+assert_contains "${out_f19}" "detached HEAD" "F19 stderr mentions detached HEAD"
+assert_contains "${out_f19}" "Recovery:" "F19 stderr provides recovery hint"
+assert_eq "${before_sha_f19}" "${after_sha_f19}" "F19 HEAD unchanged (guard prevented commit in detached state)"
+
+# -----------------------------------------------------------------------------
 # サマリ
 # -----------------------------------------------------------------------------
 echo

--- a/tests/auto-lint.test.sh
+++ b/tests/auto-lint.test.sh
@@ -425,6 +425,46 @@ if [[ -f "${CAPTURE_FILE_LINT}" ]]; then
 fi
 
 # -----------------------------------------------------------------------------
+# G6 (v0.4.0 Tier A#2, 2026-04-21): detached HEAD ガード
+# rebase 中断・detached checkout 状態で auto-lint が走ると、guard 無しでは
+# git commit が detached HEAD 先端に積まれて push 失敗でローカル drift する。
+# guard (git symbolic-ref -q HEAD) で git 書き込みを丸ごと skip + WARN することを検証。
+# -----------------------------------------------------------------------------
+echo "test G6: detached HEAD state -> skip git commit/push + WARN"
+VAULT_G6="$(make_vault vault-g6)"
+add_wiki_page "${VAULT_G6}" "page-g6"
+(
+  cd "${VAULT_G6}" && \
+  git init --quiet && \
+  git config user.email t@test && \
+  git config user.name t && \
+  echo 'session-logs/' > .gitignore && \
+  git add .gitignore && \
+  git commit -m init --quiet && \
+  git checkout --detach --quiet
+)
+# auto-lint は lint-report.md を書くので、DRY RUN でない本走行時は wiki/ に
+# 変更が出て `git add wiki/lint-report.md` が空でなくなる想定。
+# guard が無ければ detached HEAD 先端に commit が積まれてしまう。
+before_sha_g6="$(cd "${VAULT_G6}" && git rev-parse HEAD)"
+
+set +e
+out_g6="$(
+  PATH="${STUB_DIR}:${PATH}" \
+  OBSIDIAN_VAULT="${VAULT_G6}" \
+  bash "${AUTO_LINT}" 2>&1
+)"
+rc=$?
+set -e
+
+after_sha_g6="$(cd "${VAULT_G6}" && git rev-parse HEAD)"
+
+assert_eq "0" "${rc}" "G6 exit 0 (non-destructive fail-safe)"
+assert_contains "${out_g6}" "detached HEAD" "G6 stderr mentions detached HEAD"
+assert_contains "${out_g6}" "Recovery:" "G6 stderr provides recovery hint"
+assert_eq "${before_sha_g6}" "${after_sha_g6}" "G6 HEAD unchanged (guard prevented commit in detached state)"
+
+# -----------------------------------------------------------------------------
 # サマリ
 # -----------------------------------------------------------------------------
 echo

--- a/tests/cron-guard-parity.test.sh
+++ b/tests/cron-guard-parity.test.sh
@@ -1,0 +1,252 @@
+#!/usr/bin/env bash
+#
+# cron-guard-parity.test.sh — cron/setup 層の env-override ガード統一性を
+# invariant テストとして強制する (v0.4.0 Tier B#2)。
+#
+# 実行: bash tools/claude-brain/tests/cron-guard-parity.test.sh
+#
+# ## 背景
+#
+# claude-brain には 2 系統の env override / escape-hatch flag が存在する:
+#
+# 1. **Category A — script override gate** (v0.3.0 VULN-004 対策):
+#    `KIOKU_EXTRACT_<RES>_SCRIPT` / `KIOKU_ALLOW_EXTRACT_<RES>_OVERRIDE` のペアで、
+#    テスト時のみ script path を差し替えるための env。production cron では
+#    _OVERRIDE ゲートが無ければ WARN + 無視する。使用場所は scripts/auto-ingest.sh のみ。
+#
+# 2. **Category B — cron escape hatch** (v0.3.0 LOW-d4 + v0.3.1 NEW-L2 対策):
+#    `KIOKU_ALLOW_<HAZARD>_IN_CRON` で cron 経路で危険操作 (loopback / robots bypass)
+#    を明示 opt-in する gate。使用場所は scripts/extract-url.sh のみ。
+#
+# どちらも child-env.mjs の ENV_ALLOW_EXACT allowlist に **意図的に載せない**
+# (HIGH-d1 fix + NEW-L2 の設計意図)。本テストはこの設計意図が drift しないよう
+# 不変条件を enforcement する。
+#
+# ## 検証項目
+#
+#   CGP-1 auto-ingest.sh の各 KIOKU_EXTRACT_<X>_SCRIPT に対応する
+#         KIOKU_ALLOW_EXTRACT_<X>_OVERRIDE ignore 分岐が存在する (A pattern の対称性)
+#   CGP-2 mcp/lib/child-env.mjs の ENV_ALLOW_EXACT に KIOKU_EXTRACT_* /
+#         KIOKU_ALLOW_EXTRACT_* / KIOKU_URL_* / KIOKU_ALLOW_*_IN_CRON が載っていない
+#   CGP-3 scripts/extract-url.sh に Category B escape hatch ガード
+#         (KIOKU_ALLOW_LOOPBACK_IN_CRON / KIOKU_ALLOW_IGNORE_ROBOTS_IN_CRON) が存在
+#   CGP-4 Category A pattern (KIOKU_EXTRACT_*_SCRIPT) を使うのは scripts/auto-ingest.sh
+#         のみ (他 script への drift なし)
+#   CGP-5 Category B pattern (KIOKU_ALLOW_*_IN_CRON) を使うのは scripts/extract-url.sh
+#         のみ (他 script への drift なし)
+#
+# 注意: macOS 標準 bash 3.2 でも動くように `mapfile` / associative array /
+# process substitution の多用を避けている。
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+TOOL_ROOT="${REPO_ROOT}/tools/claude-brain"
+SCRIPTS_DIR="${TOOL_ROOT}/scripts"
+CHILD_ENV="${TOOL_ROOT}/mcp/lib/child-env.mjs"
+AUTO_INGEST="${SCRIPTS_DIR}/auto-ingest.sh"
+EXTRACT_URL="${SCRIPTS_DIR}/extract-url.sh"
+
+PASS=0
+FAIL=0
+
+pass() {
+  PASS=$((PASS + 1))
+  echo "  ok  $1"
+}
+
+fail() {
+  FAIL=$((FAIL + 1))
+  echo "  NG  $1" >&2
+}
+
+# -----------------------------------------------------------------------------
+# CGP-1: Category A pattern の対称性
+#   各 KIOKU_EXTRACT_<X>_SCRIPT に対し、同じ <X> の KIOKU_ALLOW_EXTRACT_<X>_OVERRIDE
+#   ignore 分岐 (WARN + fallback) が存在することを確認。
+# -----------------------------------------------------------------------------
+echo "test CGP-1: auto-ingest.sh の script override ゲート対称性"
+
+if [[ ! -f "${AUTO_INGEST}" ]]; then
+  fail "CGP-1 auto-ingest.sh not found at ${AUTO_INGEST}"
+else
+  # KIOKU_EXTRACT_<X>_SCRIPT を env lookup している行から <X> を抽出
+  extract_resources="$(
+    grep -oE 'KIOKU_EXTRACT_[A-Z]+_SCRIPT' "${AUTO_INGEST}" 2>/dev/null \
+      | sed -E 's/^KIOKU_EXTRACT_([A-Z]+)_SCRIPT$/\1/' \
+      | sort -u \
+      | tr '\n' ' '
+  )"
+
+  if [[ -z "${extract_resources// }" ]]; then
+    fail "CGP-1 no KIOKU_EXTRACT_*_SCRIPT lookup found in auto-ingest.sh (regression?)"
+  else
+    pass "CGP-1 found script-override resource(s): ${extract_resources}"
+  fi
+
+  # 各 <X> に対し、対応する _SCRIPT lookup / _OVERRIDE gate / WARN が存在するか
+  for res in ${extract_resources}; do
+    script_re="\\\$\\{KIOKU_EXTRACT_${res}_SCRIPT:-"
+    override_re="\\\$\\{KIOKU_ALLOW_EXTRACT_${res}_OVERRIDE:-0\\}"
+    warn_str="KIOKU_EXTRACT_${res}_SCRIPT is set but KIOKU_ALLOW_EXTRACT_${res}_OVERRIDE"
+
+    if grep -qE "${script_re}" "${AUTO_INGEST}"; then
+      pass "CGP-1[${res}] script env lookup present"
+    else
+      fail "CGP-1[${res}] script env lookup \${KIOKU_EXTRACT_${res}_SCRIPT:-...} not found"
+    fi
+
+    if grep -qE "${override_re}" "${AUTO_INGEST}"; then
+      pass "CGP-1[${res}] override gate present"
+    else
+      fail "CGP-1[${res}] gate \${KIOKU_ALLOW_EXTRACT_${res}_OVERRIDE:-0} not found"
+    fi
+
+    if grep -qF "${warn_str}" "${AUTO_INGEST}"; then
+      pass "CGP-1[${res}] WARN message present"
+    else
+      fail "CGP-1[${res}] WARN message naming both flags not found"
+    fi
+  done
+
+  # 逆方向: KIOKU_ALLOW_EXTRACT_<X>_OVERRIDE に対応する _SCRIPT も必須
+  override_resources="$(
+    grep -oE 'KIOKU_ALLOW_EXTRACT_[A-Z]+_OVERRIDE' "${AUTO_INGEST}" 2>/dev/null \
+      | sed -E 's/^KIOKU_ALLOW_EXTRACT_([A-Z]+)_OVERRIDE$/\1/' \
+      | sort -u \
+      | tr '\n' ' '
+  )"
+  for res in ${override_resources}; do
+    # extract_resources の中に含まれるか (空白区切りで包含チェック)
+    if printf ' %s ' "${extract_resources}" | grep -qF " ${res} "; then
+      pass "CGP-1[${res}] _OVERRIDE has matching _SCRIPT (inverse check)"
+    else
+      fail "CGP-1[${res}] _OVERRIDE gate found but matching _SCRIPT lookup missing"
+    fi
+  done
+fi
+
+# -----------------------------------------------------------------------------
+# CGP-2: child-env.mjs ENV_ALLOW_EXACT に上記 flag が載っていない (HIGH-d1 不変)
+# -----------------------------------------------------------------------------
+echo "test CGP-2: child-env.mjs ENV_ALLOW_EXACT に禁止 prefix が含まれない"
+
+if [[ ! -f "${CHILD_ENV}" ]]; then
+  fail "CGP-2 child-env.mjs not found at ${CHILD_ENV}"
+else
+  # ENV_ALLOW_EXACT = new Set([ ... ]) の中身を awk で抽出
+  exact_block="$(awk '/ENV_ALLOW_EXACT = new Set\(\[/,/\]\);/' "${CHILD_ENV}")"
+  if [[ -z "${exact_block}" ]]; then
+    fail "CGP-2 ENV_ALLOW_EXACT literal block not found"
+  else
+    any_leak=0
+    # Category A prefixes (leaked = regression)
+    for prefix in 'KIOKU_EXTRACT_' 'KIOKU_ALLOW_EXTRACT_' 'KIOKU_URL_'; do
+      if printf '%s' "${exact_block}" | grep -qE "['\"]${prefix}[A-Z_]+['\"]"; then
+        fail "CGP-2 forbidden prefix '${prefix}*' leaked into ENV_ALLOW_EXACT"
+        any_leak=1
+      fi
+    done
+    # Category B exact names (leaked = regression)
+    for exact_name in 'KIOKU_ALLOW_LOOPBACK_IN_CRON' 'KIOKU_ALLOW_IGNORE_ROBOTS_IN_CRON'; do
+      if printf '%s' "${exact_block}" | grep -qE "['\"]${exact_name}['\"]"; then
+        fail "CGP-2 forbidden name '${exact_name}' leaked into ENV_ALLOW_EXACT"
+        any_leak=1
+      fi
+    done
+    if [[ "${any_leak}" -eq 0 ]]; then
+      pass "CGP-2 ENV_ALLOW_EXACT excludes all forbidden patterns (Categories A + B)"
+    fi
+  fi
+
+  # ENV_ALLOW_PREFIXES に KIOKU_ 丸ごとが入っていないか (旧 HIGH-d1 regression 防止)
+  # コメント内の prose 記述に誤マッチしないよう、`export const` 行に限定する。
+  prefixes_line="$(grep -E '^export const ENV_ALLOW_PREFIXES' "${CHILD_ENV}" || true)"
+  if [[ -z "${prefixes_line}" ]]; then
+    fail "CGP-2 ENV_ALLOW_PREFIXES export declaration not found"
+  elif printf '%s' "${prefixes_line}" | grep -qE "['\"]KIOKU_['\"]"; then
+    fail "CGP-2 ENV_ALLOW_PREFIXES contains bare 'KIOKU_' (HIGH-d1 regression)"
+  else
+    pass "CGP-2 ENV_ALLOW_PREFIXES excludes bare 'KIOKU_'"
+  fi
+fi
+
+# -----------------------------------------------------------------------------
+# CGP-3: extract-url.sh の Category B escape hatch ガード
+# -----------------------------------------------------------------------------
+echo "test CGP-3: extract-url.sh の cron escape-hatch ガード"
+
+if [[ ! -f "${EXTRACT_URL}" ]]; then
+  fail "CGP-3 extract-url.sh not found at ${EXTRACT_URL}"
+else
+  # Category B の 2 ペア: "gate:unset_target"
+  for pair in \
+      'KIOKU_ALLOW_LOOPBACK_IN_CRON:KIOKU_URL_ALLOW_LOOPBACK' \
+      'KIOKU_ALLOW_IGNORE_ROBOTS_IN_CRON:KIOKU_URL_IGNORE_ROBOTS'; do
+    gate="${pair%%:*}"
+    target="${pair##*:}"
+    if grep -qE "\\\$\\{${gate}:-0\\}" "${EXTRACT_URL}"; then
+      pass "CGP-3[${gate}] opt-in gate present"
+    else
+      fail "CGP-3[${gate}] opt-in gate not found"
+    fi
+    if grep -qE "unset ${target}" "${EXTRACT_URL}"; then
+      pass "CGP-3[${gate}] unset ${target} line present"
+    else
+      fail "CGP-3[${gate}] 'unset ${target}' line not found"
+    fi
+  done
+fi
+
+# -----------------------------------------------------------------------------
+# CGP-4: Category A pattern (KIOKU_EXTRACT_*_SCRIPT) の使用は auto-ingest.sh に限定
+# -----------------------------------------------------------------------------
+echo "test CGP-4: Category A pattern の使用範囲"
+
+set +e
+cat_a_users="$(grep -lE 'KIOKU_EXTRACT_[A-Z]+_SCRIPT' "${SCRIPTS_DIR}"/*.sh 2>/dev/null | sort -u | tr '\n' ' ')"
+set -e
+
+if [[ -z "${cat_a_users// }" ]]; then
+  fail "CGP-4 no Category A user found (regression?)"
+else
+  # 期待: auto-ingest.sh の 1 ファイルのみ (末尾に半角スペース付きで比較)
+  if [[ "${cat_a_users}" == "${AUTO_INGEST} " ]]; then
+    pass "CGP-4 Category A usage limited to scripts/auto-ingest.sh"
+  else
+    fail "CGP-4 Category A pattern leaked: ${cat_a_users}"
+  fi
+fi
+
+# -----------------------------------------------------------------------------
+# CGP-5: Category B pattern (KIOKU_ALLOW_*_IN_CRON) の使用は extract-url.sh に限定
+# -----------------------------------------------------------------------------
+echo "test CGP-5: Category B pattern の使用範囲"
+
+set +e
+cat_b_users="$(grep -lE 'KIOKU_ALLOW_[A-Z_]+_IN_CRON' "${SCRIPTS_DIR}"/*.sh 2>/dev/null | sort -u | tr '\n' ' ')"
+set -e
+
+if [[ -z "${cat_b_users// }" ]]; then
+  fail "CGP-5 no Category B user found (regression?)"
+else
+  if [[ "${cat_b_users}" == "${EXTRACT_URL} " ]]; then
+    pass "CGP-5 Category B usage limited to scripts/extract-url.sh"
+  else
+    fail "CGP-5 Category B pattern leaked: ${cat_b_users}"
+  fi
+fi
+
+# -----------------------------------------------------------------------------
+# サマリ
+# -----------------------------------------------------------------------------
+echo
+echo "==========================="
+echo "  passed: ${PASS}"
+echo "  failed: ${FAIL}"
+echo "==========================="
+
+if [[ "${FAIL}" -gt 0 ]]; then
+  exit 1
+fi

--- a/tests/hooks/session-logger.test.mjs
+++ b/tests/hooks/session-logger.test.mjs
@@ -693,3 +693,95 @@ describe('session-logger: index corruption recovery', () => {
     }
   });
 });
+
+// v0.4.0 Tier B#1 — Hook 層 re-audit findings の回帰テスト
+// 参照: security-review/meeting/2026-04-21_hook-layer-reaudit.md
+describe('session-logger: v0.4.0 Tier B#1 regression', () => {
+  // RED-L0-01 / BLUE-L0-01: Hook 経路の maskText 適用 (INVISIBLE_CHARS + NFC)
+  test('masks tokens that contain zero-width invisibles (INVISIBLE_CHARS bypass)', async () => {
+    const { root, vault } = await createVault();
+    try {
+      // U+200B (ZWSP) を prefix 境界に挿入した API key は旧 mask() では素通りしたが、
+      // maskText() は INVISIBLE_CHARS_RE で前処理するのでマッチするはず。
+      const zwspKey = 'sk-ant-\u200Babcdefghijklmnopqrstuvwxyz';
+      const softHyphenKey = 'ghp_\u00ADabcdefghijklmnopqrstuvwxyz';
+      await runHook(vault, {
+        session_id: 'test-session-b1-01',
+        hook_event_name: 'UserPromptSubmit',
+        cwd: '/tmp',
+        prompt: `zwsp=${zwspKey} soft=${softHyphenKey}`,
+      });
+      const body = await readFirstSessionFile(vault);
+      assert.ok(!body.includes('abcdefghijklmnopqrstuvwxyz'),
+        'raw 20-char suffix must not survive masking');
+      assert.match(body, /sk-ant-\*\*\*/);
+      assert.match(body, /ghp_\*\*\*/);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  // RED-L0-02: frontmatter YAML value injection
+  test('buildFrontmatter neutralizes newline/--- injection in cwd', async () => {
+    const { root, vault } = await createVault();
+    try {
+      const evilCwd = '/tmp/x\n---\ntype: injected\nrelated: ["/etc/passwd"]';
+      await runHook(vault, {
+        session_id: 'test-session-b1-02',
+        hook_event_name: 'UserPromptSubmit',
+        cwd: evilCwd,
+        prompt: 'hello',
+      });
+      const body = await readFirstSessionFile(vault);
+      // frontmatter は必ず 1 つの `---` 開始と 1 つの `---` 終端で閉じる
+      const fmMatch = body.match(/^---\n([\s\S]*?)\n---\n/);
+      assert.ok(fmMatch, 'frontmatter must be well-formed');
+      const fm = fmMatch[1];
+      // 注入された type/related キーが frontmatter に追加されていないこと
+      assert.ok(!/\ntype: injected/.test(fm), 'injected `type:` key must not appear');
+      assert.ok(!/\nrelated: \["\/etc\/passwd"\]/.test(fm),
+        'injected `related:` key must not appear');
+      // cwd は単一引用符でクオートされ、制御文字が除去された状態で残る
+      assert.match(fm, /^cwd: '/m);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  // BLUE-L0-02: KIOKU_NO_LOG の truthy drift 対策
+  for (const truthy of ['true', 'yes', 'on', 'TRUE', 'Yes']) {
+    test(`KIOKU_NO_LOG=${truthy} suppresses output (envTruthy)`, async () => {
+      const { root, vault } = await createVault();
+      try {
+        const { code } = await runHook(vault, {
+          session_id: `test-session-b1-03-${truthy.toLowerCase()}`,
+          hook_event_name: 'UserPromptSubmit',
+          prompt: 'should be suppressed',
+        }, { KIOKU_NO_LOG: truthy });
+        assert.strictEqual(code, 0);
+        const files = await listSessionFiles(vault);
+        assert.strictEqual(files.length, 0,
+          `no session file should be created when KIOKU_NO_LOG=${truthy}`);
+      } finally {
+        await rm(root, { recursive: true, force: true });
+      }
+    });
+  }
+
+  test('KIOKU_NO_LOG=false or empty does NOT suppress output', async () => {
+    const { root, vault } = await createVault();
+    try {
+      await runHook(vault, {
+        session_id: 'test-session-b1-03-false',
+        hook_event_name: 'UserPromptSubmit',
+        cwd: '/tmp',
+        prompt: 'should be recorded',
+      }, { KIOKU_NO_LOG: 'false' });
+      const files = await listSessionFiles(vault);
+      assert.strictEqual(files.length, 1,
+        'falsy value must not trigger no-op (only 1/true/yes/on activate)');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/install-hooks.test.sh
+++ b/tests/install-hooks.test.sh
@@ -128,6 +128,15 @@ else
   fail "SessionStart should include both git pull and wiki-context-injector.mjs"
 fi
 
+# v0.4.0 Tier A#2 (2026-04-21): SessionEnd の git one-liner に detached HEAD ガード
+# (git symbolic-ref -q HEAD) が含まれていること。detached 状態で commit が貯まって
+# push 失敗 → ローカル drift する regression を防ぐため。
+if node -e "const j=require('${tmpjson}'); const gitCmd=j.hooks.SessionEnd[1].hooks[0].command; process.exit(/git symbolic-ref -q HEAD/.test(gitCmd) ? 0 : 1)"; then
+  pass "SessionEnd git one-liner has detached HEAD guard (git symbolic-ref -q HEAD)"
+else
+  fail "SessionEnd git one-liner missing 'git symbolic-ref -q HEAD' guard (v0.4.0 Tier A#2 regression)"
+fi
+
 # -----------------------------------------------------------------------------
 # Test 4: fully-configured vault has no warnings
 # -----------------------------------------------------------------------------

--- a/tests/mcp/tools-delete.test.mjs
+++ b/tests/mcp/tools-delete.test.mjs
@@ -2,7 +2,7 @@
 
 import { test, describe, beforeEach, after } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtemp, mkdir, rm, writeFile, readdir, stat, readFile } from 'node:fs/promises';
+import { mkdtemp, mkdir, rm, writeFile, readdir, stat, readFile, chmod } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -166,6 +166,52 @@ describe('kioku_delete', () => {
           return smallInLinks !== undefined;
         },
       );
+    } finally { await cleanup(); }
+  });
+
+  test('MCP26e scanReferences records unreadable files in skippedUnreadable (L-2)', async () => {
+    // 2026-04-21 L-2 regression test: readFile 失敗 (EACCES / EIO / ENOENT) が
+    // silent catch で握りつぶされて operator が気付けない経路を塞ぐ。
+    // chmod 0 (permission denied) の file を walk に含めて skippedUnreadable[] に
+    // 記録されることを確認する。macOS で root 以外なら EACCES を確実に誘発できる。
+    try {
+      await writeFile(join(vault, 'wiki', 'foo.md'),
+        '---\ntitle: Foo\n---\n\n# Foo\n');
+      const fetchedDir = join(vault, 'raw-sources', 'articles', 'fetched');
+      await mkdir(fetchedDir, { recursive: true });
+      // 通常 size & 読取り不能な MD (permission denied)
+      const unreadablePath = join(fetchedDir, 'evil.com-locked.md');
+      await writeFile(unreadablePath, '---\nsource_url: "https://evil.com/"\n---\n\nsee [[Foo]]\n');
+      await chmod(unreadablePath, 0o000);
+      // 通常 size の読取り可能な MD にも wikilink を持たせて brokenLinks 側は発火する
+      await writeFile(join(fetchedDir, 'normal.com-small.md'),
+        '---\nsource_url: "https://normal.com/"\n---\n\nsee [[Foo]]\n');
+
+      try {
+        await assert.rejects(
+          handleDelete(vault, { path: 'foo.md' }),
+          (err) => {
+            if (err.code !== 'broken_links_detected') return false;
+            const unreadable = err.data?.skippedUnreadable ?? [];
+            // 読取り不能 file が skippedUnreadable[] に載ること
+            const locked = unreadable.find((x) =>
+              x.sourcePath === 'raw-sources/articles/fetched/evil.com-locked.md'
+            );
+            if (!locked) return false;
+            assert.ok(typeof locked.error === 'string' && locked.error.length > 0,
+              'skippedUnreadable[].error must be a non-empty string');
+            // 読取り可能 file は brokenLinks に載ること
+            const links = err.data?.brokenLinks ?? [];
+            const smallInLinks = links.find((x) =>
+              x.sourcePath === 'raw-sources/articles/fetched/normal.com-small.md'
+            );
+            return smallInLinks !== undefined;
+          },
+        );
+      } finally {
+        // cleanup 前に permission を戻さないと rm が失敗する
+        await chmod(unreadablePath, 0o644).catch(() => {});
+      }
     } finally { await cleanup(); }
   });
 

--- a/tests/mcp/tools-ingest-pdf.test.mjs
+++ b/tests/mcp/tools-ingest-pdf.test.mjs
@@ -363,24 +363,9 @@ describe('kioku_ingest_pdf', { skip: !HAS_POPPLER ? 'poppler not installed' : fa
     assert.equal(result2.status, 'extracted_and_summarized');
   });
 
-  test('MCP30c skipLock injection bypasses withLock (機能 2.2 PDF dispatch 用)', async () => {
-    // 機能 2.2 kioku_ingest_url が PDF URL を内部 dispatch するとき、外側で
-    // withLock を保持済みなので handleIngestPdf 側は再取得をスキップする必要がある。
-    // skipLock=true なら、外部で lockfile が握られていてもタイムアウトせず即進行する。
-    const vault = await makeVault('mcp30c-skiplock');
-    await cp(join(FIXTURES, 'sample-8p.pdf'), join(vault, 'raw-sources', 'papers', 'noloc.pdf'));
-    // 別 PID の lockfile を擬似的に置く (TTL 内で生きている扱い)
-    const lockPath = join(vault, '.kioku-mcp.lock');
-    await writeFile(lockPath, '99999\n');
-    try {
-      const result = await handleIngestPdf(
-        vault,
-        { path: 'raw-sources/papers/noloc.pdf' },
-        { claudeBin: claudeBin(), skipLock: true },
-      );
-      assert.equal(result.status, 'extracted_and_summarized');
-    } finally {
-      await rm(lockPath, { force: true });
-    }
-  });
+  // 2026-04-21 v0.4.0 Tier A#3 M-a4: skipLock injection を削除したため、
+  // 旧 MCP30c (skipLock bypass 動作テスト) は API ごと消滅。
+  // 新しい invariant は MCP45 (tools-ingest-url.test.mjs) 側で検証する:
+  // - kioku_ingest_url → PDF dispatch 経路で handleIngestPdf が自前の withLock を
+  //   取得する (outer withLock は dispatch 前に release される) ことが整合性の要。
 });

--- a/tests/mcp/tools-ingest-url.test.mjs
+++ b/tests/mcp/tools-ingest-url.test.mjs
@@ -16,7 +16,11 @@
 // MCP42   application/pdf → handleIngestPdf に dispatch
 // MCP43   octet-stream + URL 末尾 .pdf → dispatch
 // MCP44   PDF body > 50MB → invalid_request
-// MCP45   dispatch では skipLock=true で内側 withLock を跨がず即進行する
+// MCP45   PDF dispatch は outer withLock を release してから handleIngestPdf が
+//         自前 withLock を acquire する (v0.4.0 Tier A#3 M-a2 refactor)
+// MCP45b  concurrent PDF dispatch (異 vault) が短時間で完了する (Tier A#3 M-a2 invariant)
+// MCP45c  handleIngestPdf 失敗時に orphan PDF が raw-sources/ から cleanup される
+//         (v0.4.0 Tier A#3 post-review GAP-1 fix)
 // MCP46   CRIT-1: late-PDF discovery で binary 再 fetch して PDF magic bytes が保持される
 // MCP46b  v0.3.5 Option B: 長い PDF dispatch → status: dispatched_to_pdf_queued
 // MCP47   HIGH-2: fetch エラーメッセージに credentials / 内部 IP / raw URL を含めない
@@ -32,7 +36,7 @@
 import { test, describe, before, after } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { mkdtemp, rm, mkdir, writeFile, readFile, chmod } from 'node:fs/promises';
+import { mkdtemp, rm, mkdir, writeFile, readFile, readdir, chmod } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -392,9 +396,16 @@ describe('kioku_ingest_url', () => {
       );
     });
 
-    test('MCP45 dispatch uses skipLock (no re-entrance deadlock)', async () => {
-      // 内側 handleIngestPdf が skipLock=false だと外側 withLock と二重取得で
-      // 60s timeout する。skipLock=true が伝わっていれば即進行する。
+    test('MCP45 PDF dispatch releases outer lock before handleIngestPdf acquires its own (v0.4.0 Tier A#3 M-a2)', async () => {
+      // 2026-04-21 M-a2 fix: 旧実装は outer withLock を保持したまま handleIngestPdf に
+      // skipLock=true で dispatch → 大容量 PDF (poppler 同期 extract) で outer lock を
+      // 最大 4.5 分保持する問題があった。新実装は dispatchToPdf を withLock の外へ
+      // 出し、handleIngestPdf が自前で withLock を取る (skipLock injection は API ごと
+      // 削除済)。
+      //
+      // このテストは dispatch_to_pdf が成功することを検証する。refactor が壊れていて
+      // outer lock が handleIngestPdf 呼び出し中も保持されていたら、handleIngestPdf
+      // 側の withLock が 60s timeout で LockTimeoutError になり、このテストが失敗する。
       const v = await makeVault('mcp45');
       const r = await handleIngestUrl(
         v,
@@ -402,6 +413,92 @@ describe('kioku_ingest_url', () => {
         { claudeBin: stubBin, robotsUrlOverride: `${server.url}/robots.txt?variant=allow` },
       );
       assert.equal(r.status, 'dispatched_to_pdf');
+      // Lockfile が呼び出し完了後に残っていないこと (withLock の finally で unlink される)
+      const lockPath = join(v, '.kioku-mcp.lock');
+      let lockExists = false;
+      try {
+        await readFile(lockPath);
+        lockExists = true;
+      } catch (err) {
+        if (err.code !== 'ENOENT') throw err;
+      }
+      assert.equal(lockExists, false, 'lockfile must be unlinked after dispatch');
+    });
+
+    test('MCP45c GAP-1 fix: orphan PDF is cleaned up when handleIngestPdf fails (v0.4.0 Tier A#3 post-review)', async () => {
+      // 2026-04-21 /security-review (red + blue parallel) の GAP-1 共通指摘:
+      //   refactor 後は outer withLock release 後に PDF が raw-sources/ に
+      //   visible になるため、handleIngestPdf が失敗 (encrypted / invalid PDF /
+      //   extract rc=2,4,5 / claude -p 失敗 等) した場合 PDF が orphan 化する。
+      //
+      // cleanup 条件:
+      //   - `lock_timeout`: user retry 用に PDF を残す (このテストでは誘発しない)
+      //   - それ以外の失敗: PDF を unlink する (このテストで検証する)
+      //
+      // 本テストは sample-encrypted.pdf を返す URL を ingest して、extract-pdf.sh
+      // rc=2 → throwInvalidRequest('encrypted or invalid PDF') で failure が走る
+      // ことを契機に、orphan PDF が raw-sources/papers/ から削除されることを確認。
+      const v = await makeVault('mcp45c');
+      let caught;
+      try {
+        await handleIngestUrl(
+          v,
+          { url: `${server.url}/pdf?name=sample-encrypted.pdf` },
+          { claudeBin: stubBin, robotsUrlOverride: `${server.url}/robots.txt?variant=allow` },
+        );
+      } catch (e) {
+        caught = e;
+      }
+      assert.ok(caught, 'expected handleIngestUrl to throw on encrypted PDF');
+      // GAP-1 invariant: raw-sources/papers/ には orphan PDF が残っていないこと。
+      // directory 自体は writePdfToDisk が mkdir 済なので存在するが、.pdf ファイルは 0。
+      const papersDir = join(v, 'raw-sources', 'papers');
+      let entries = [];
+      try {
+        entries = await readdir(papersDir);
+      } catch (err) {
+        if (err.code !== 'ENOENT') throw err;
+      }
+      const remainingPdfs = entries.filter((n) => n.endsWith('.pdf'));
+      assert.deepEqual(
+        remainingPdfs,
+        [],
+        `expected no orphan PDFs after handleIngestPdf failure, got: ${JSON.stringify(remainingPdfs)}`,
+      );
+    });
+
+    test('MCP45b PDF dispatch: outer lock is released during handleIngestPdf Phase 1 (v0.4.0 Tier A#3 M-a2)', async () => {
+      // 2026-04-21 M-a2 refactor の invariant test: late-PDF dispatch 中、
+      // outer withLock は既に解放されているので「別の操作が lockfile を取得できる」
+      // はずである。旧実装 (skipLock=true で outer 保持) だと、以下の concurrent write
+      // は outer lock と conflict して 60s LockTimeoutError になるケースがあった。
+      //
+      // 実装: PDF dispatch 中に別 vault への kioku_ingest_url を同時並行で走らせて、
+      // 両方とも短時間で完了する (60s timeout せず) ことを確認する。
+      // (別 vault = lockfile 分離されているので本来は無関係だが、本 test では
+      //  handleIngestUrl API 自体に concurrent 安全性があることを proof する)
+      const v1 = await makeVault('mcp45b-1');
+      const v2 = await makeVault('mcp45b-2');
+      const start = Date.now();
+      const [r1, r2] = await Promise.all([
+        handleIngestUrl(
+          v1,
+          { url: `${server.url}/pdf?name=sample-8p.pdf` },
+          { claudeBin: stubBin, robotsUrlOverride: `${server.url}/robots.txt?variant=allow` },
+        ),
+        handleIngestUrl(
+          v2,
+          { url: `${server.url}/pdf?name=sample-8p.pdf` },
+          { claudeBin: stubBin, robotsUrlOverride: `${server.url}/robots.txt?variant=allow` },
+        ),
+      ]);
+      const duration = Date.now() - start;
+      assert.equal(r1.status, 'dispatched_to_pdf');
+      assert.equal(r2.status, 'dispatched_to_pdf');
+      // 60s timeout に達していたら旧実装の lock 競合を疑う。
+      // stub claude では通常 5-20s 程度で完了するので 30s cap で十分余裕がある。
+      assert.ok(duration < 30_000,
+        `concurrent dispatch must complete quickly (actual: ${duration}ms)`);
     });
 
     test('MCP46 CRIT-1: late-PDF discovery re-fetches with binary mode', async () => {

--- a/tests/sync-to-app.test.sh
+++ b/tests/sync-to-app.test.sh
@@ -1,0 +1,295 @@
+#!/usr/bin/env bash
+#
+# sync-to-app.test.sh — v0.4.0 Tier B#3 GitHub-side lock (α) のテスト
+#
+# 実行: bash tools/claude-brain/tests/sync-to-app.test.sh
+#
+# ## 背景
+#
+# 2 台運用 (MacBook + Mac mini) で cron sync が近接時刻に起動すると、両方が
+# 同じ内容で origin/next に push して重複 PR を生む race 条件がある (症状 #1)。
+# α = GitHub-side lock: `gh api branches/next` で最終 push 時刻を確認し、閾値
+# 以内なら早期 exit (scripts/sync-to-app.sh の check_github_side_lock)。
+#
+# 合意記録: plan/claude/26042104_meeting_v0-4-0-sync-to-app-race-fix.md
+#           ## Resume session 2 — 2026-04-21
+#
+# ## 検証項目 (動的: 関数を抽出して直接呼ぶ)
+#
+#   SYN-R1  gh が now timestamp → 早期 exit (skip メッセージ付き)
+#   SYN-R1b gh が old timestamp → return 0 (proceed, REACHED_END 到達)
+#   SYN-R1c gh コマンド失敗 → return 0 (fail-open)
+#   SYN-R5  DRY_RUN=1 → return 0 (dry-run で lock skip)
+#   SYN-R6  KIOKU_SYNC_LOCK_MAX_AGE=0 → return 0 (env で無効化)
+#
+# ## 検証項目 (静的: script 本体の構造 regression 防止)
+#
+#   SYN-S1  check_github_side_lock() 関数が sync-to-app.sh に定義されている
+#   SYN-S2  関数呼び出しが `git fetch origin` の直後 (fetch → checkout の間)
+#   SYN-S3  既存 trap (.git-kioku restore) が破壊されていない
+#   SYN-S4  KIOKU_SYNC_LOCK_MAX_AGE の env 参照と DRY_RUN チェックが存在
+#
+# ## 設計メモ
+#
+# 関数を subshell で呼ぶと、exit 0 は subshell 終了 / return 0 は続く echo 実行、
+# で挙動差が観測できる (REACHED_END sentinel)。rsync / git scaffold を避ける
+# ための軽量パターン。full-flow integration は 2 台実機 smoke に委譲。
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+TOOL_ROOT="${REPO_ROOT}/tools/claude-brain"
+TARGET="${TOOL_ROOT}/scripts/sync-to-app.sh"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP}"' EXIT
+
+PASS=0
+FAIL=0
+
+pass() {
+  PASS=$((PASS + 1))
+  echo "  ok  $1"
+}
+
+fail() {
+  FAIL=$((FAIL + 1))
+  echo "  NG  $1" >&2
+}
+
+# -----------------------------------------------------------------------------
+# SYN-S1: 関数定義の存在確認 + extract
+# -----------------------------------------------------------------------------
+echo "test SYN-S1: check_github_side_lock() definition exists in sync-to-app.sh"
+
+if [[ ! -f "${TARGET}" ]]; then
+  fail "SYN-S1 sync-to-app.sh not found at ${TARGET}"
+  echo "FATAL: cannot continue without target script" >&2
+  exit 1
+fi
+
+# awk で関数定義 (最初の `}` まで) を取り出す。関数内に nested brace がない前提。
+fn_def="$(awk '
+  /^check_github_side_lock\(\) \{/ { flag=1 }
+  flag { print }
+  flag && /^}$/ { exit }
+' "${TARGET}")"
+
+if [[ -z "${fn_def}" ]]; then
+  fail "SYN-S1 check_github_side_lock() definition not found in ${TARGET}"
+  echo "FATAL: cannot continue without function definition" >&2
+  exit 1
+else
+  pass "SYN-S1 function definition extracted ($(printf '%s' "${fn_def}" | wc -l | tr -d ' ') lines)"
+fi
+
+# test shell に関数を取り込み
+eval "${fn_def}"
+
+# -----------------------------------------------------------------------------
+# SYN-S2: 関数呼び出しが git fetch 直後 (fetch → checkout の間) にある
+# -----------------------------------------------------------------------------
+echo "test SYN-S2: check_github_side_lock is invoked between fetch and checkout"
+
+# `git fetch origin --quiet` 行の次にある (空行/コメントを挟んでも OK) 数行以内に
+# `check_github_side_lock` があり、更にそれが `git checkout -B next origin/main`
+# より前にあることを確認。
+fetch_line="$(grep -n '^git fetch origin --quiet' "${TARGET}" | head -1 | cut -d: -f1)"
+call_line="$(grep -n '^check_github_side_lock$' "${TARGET}" | head -1 | cut -d: -f1)"
+checkout_line="$(grep -n 'git checkout -B next origin/main' "${TARGET}" | head -1 | cut -d: -f1)"
+
+if [[ -z "${fetch_line}" ]]; then
+  fail "SYN-S2 'git fetch origin --quiet' not found"
+elif [[ -z "${call_line}" ]]; then
+  fail "SYN-S2 'check_github_side_lock' call site not found"
+elif [[ -z "${checkout_line}" ]]; then
+  fail "SYN-S2 'git checkout -B next origin/main' not found"
+elif (( call_line > fetch_line && call_line < checkout_line )); then
+  pass "SYN-S2 call position ok (fetch@${fetch_line} < call@${call_line} < checkout@${checkout_line})"
+else
+  fail "SYN-S2 call position wrong (fetch@${fetch_line}, call@${call_line}, checkout@${checkout_line})"
+fi
+
+# -----------------------------------------------------------------------------
+# SYN-S3: 既存 trap chain (.git-kioku restore) 非破壊
+# -----------------------------------------------------------------------------
+echo "test SYN-S3: existing trap for .git-kioku restore is preserved"
+
+if grep -qE "trap .*mv \.git \.git-kioku.* EXIT INT TERM HUP" "${TARGET}"; then
+  pass "SYN-S3 trap line for .git-kioku restore intact"
+else
+  fail "SYN-S3 trap for .git-kioku restore not found or malformed (regression?)"
+fi
+
+# -----------------------------------------------------------------------------
+# SYN-S4: KIOKU_SYNC_LOCK_MAX_AGE env と DRY_RUN skip の参照が関数内に存在
+# -----------------------------------------------------------------------------
+echo "test SYN-S4: env-var hooks inside check_github_side_lock"
+
+if printf '%s' "${fn_def}" | grep -qE 'KIOKU_SYNC_LOCK_MAX_AGE'; then
+  pass "SYN-S4 KIOKU_SYNC_LOCK_MAX_AGE env reference present"
+else
+  fail "SYN-S4 KIOKU_SYNC_LOCK_MAX_AGE env reference missing"
+fi
+
+if printf '%s' "${fn_def}" | grep -qE 'DRY_RUN.*== .1.'; then
+  pass "SYN-S4 DRY_RUN=1 skip branch present"
+else
+  fail "SYN-S4 DRY_RUN=1 skip branch missing"
+fi
+
+# -----------------------------------------------------------------------------
+# 動的テスト用 gh stub 準備
+# -----------------------------------------------------------------------------
+# 同じ stub バイナリを 3 モード (now / old / fail) で使い分けるため、mode を
+# ファイル (STUB_MODE_FILE) で動的に切替える。
+STUB_MODE_FILE="${TMP}/gh-mode"
+export STUB_MODE_FILE
+
+mkdir -p "${TMP}/bin"
+cat > "${TMP}/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+# gh stub for sync-to-app.test.sh
+# STUB_MODE_FILE で挙動選択 (now/old/fail)
+mode="unset"
+if [[ -n "${STUB_MODE_FILE:-}" && -f "${STUB_MODE_FILE}" ]]; then
+  mode="$(cat "${STUB_MODE_FILE}")"
+fi
+case "${mode}" in
+  now)
+    # 現在 UTC ISO-8601 (lock が効く新鮮な push)
+    date -u +%Y-%m-%dT%H:%M:%SZ
+    ;;
+  old)
+    # 1 時間前 (閾値 120s より十分古い → proceed)
+    # macOS (BSD) と Linux (GNU) 両方で動くよう両構文を試す
+    if out="$(date -u -v-1H +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)"; then
+      echo "${out}"
+    else
+      date -u -d '1 hour ago' +%Y-%m-%dT%H:%M:%SZ
+    fi
+    ;;
+  fail)
+    # gh auth 切れ / network error 相当
+    exit 1
+    ;;
+  *)
+    echo "gh stub: mode '${mode}' not set" >&2
+    exit 1
+    ;;
+esac
+STUB
+chmod +x "${TMP}/bin/gh"
+
+# PATH 先頭に stub を注入。real gh がシステムにあってもこちらが優先される。
+export PATH="${TMP}/bin:${PATH}"
+
+# -----------------------------------------------------------------------------
+# 動的テストヘルパ: subshell で関数呼び出し、exit/return を REACHED_END で判定
+# -----------------------------------------------------------------------------
+# exit 0 → subshell 終了、REACHED_END 出ない
+# return 0 → 続く echo 実行、REACHED_END 出る
+# stdout/stderr は 2>&1 でマージして一括観測。
+call_and_capture() {
+  ( check_github_side_lock 2>&1; echo "REACHED_END" )
+}
+
+# -----------------------------------------------------------------------------
+# SYN-R1: gh が now timestamp → 早期 exit (skip メッセージ)
+# -----------------------------------------------------------------------------
+echo "test SYN-R1: exits early when origin/next was just pushed"
+echo "now" > "${STUB_MODE_FILE}"
+unset DRY_RUN KIOKU_SYNC_LOCK_MAX_AGE
+out="$(call_and_capture)"
+
+if echo "${out}" | grep -q "REACHED_END"; then
+  fail "SYN-R1 function returned instead of exiting (output: ${out})"
+else
+  pass "SYN-R1 function exited early (REACHED_END not emitted)"
+fi
+
+if echo "${out}" | grep -qF '[skip] origin/next was pushed'; then
+  pass "SYN-R1 skip message emitted to stderr"
+else
+  fail "SYN-R1 skip message not found (output: ${out})"
+fi
+
+# -----------------------------------------------------------------------------
+# SYN-R1b: gh が old timestamp → return 0 (proceed)
+# -----------------------------------------------------------------------------
+echo "test SYN-R1b: proceeds when origin/next push is stale (>threshold)"
+echo "old" > "${STUB_MODE_FILE}"
+unset DRY_RUN KIOKU_SYNC_LOCK_MAX_AGE
+out="$(call_and_capture)"
+
+if echo "${out}" | grep -q "REACHED_END"; then
+  pass "SYN-R1b function returned (script would proceed to checkout)"
+else
+  fail "SYN-R1b function exited but was expected to proceed (output: ${out})"
+fi
+
+# -----------------------------------------------------------------------------
+# SYN-R1c: gh が失敗 → fail-open (proceed)
+# -----------------------------------------------------------------------------
+echo "test SYN-R1c: fails open when gh returns non-zero (auth/network error)"
+echo "fail" > "${STUB_MODE_FILE}"
+unset DRY_RUN KIOKU_SYNC_LOCK_MAX_AGE
+out="$(call_and_capture)"
+
+if echo "${out}" | grep -q "REACHED_END"; then
+  pass "SYN-R1c function fail-open succeeded (proceed despite gh error)"
+else
+  fail "SYN-R1c function exited when it should fail-open (output: ${out})"
+fi
+
+# -----------------------------------------------------------------------------
+# SYN-R5: DRY_RUN=1 → 即 return 0 (gh を呼ばず)
+# -----------------------------------------------------------------------------
+echo "test SYN-R5: --dry-run skips lock check without calling gh"
+# gh を "now" モードに設定: もし gh が呼ばれていたら SYN-R1 と同じ skip exit になる。
+# REACHED_END が出れば DRY_RUN 分岐で早期 return できている証拠。
+echo "now" > "${STUB_MODE_FILE}"
+unset KIOKU_SYNC_LOCK_MAX_AGE
+out="$(
+  export DRY_RUN=1
+  check_github_side_lock 2>&1
+  echo "REACHED_END"
+)"
+
+if echo "${out}" | grep -q "REACHED_END"; then
+  pass "SYN-R5 function returned early under DRY_RUN=1"
+else
+  fail "SYN-R5 function exited despite DRY_RUN=1 (output: ${out})"
+fi
+
+# -----------------------------------------------------------------------------
+# SYN-R6: KIOKU_SYNC_LOCK_MAX_AGE=0 → guard 無効化 (proceed)
+# -----------------------------------------------------------------------------
+echo "test SYN-R6: KIOKU_SYNC_LOCK_MAX_AGE=0 disables the guard"
+echo "now" > "${STUB_MODE_FILE}"
+unset DRY_RUN
+out="$(
+  export KIOKU_SYNC_LOCK_MAX_AGE=0
+  check_github_side_lock 2>&1
+  echo "REACHED_END"
+)"
+
+if echo "${out}" | grep -q "REACHED_END"; then
+  pass "SYN-R6 function returned early with KIOKU_SYNC_LOCK_MAX_AGE=0"
+else
+  fail "SYN-R6 function exited despite KIOKU_SYNC_LOCK_MAX_AGE=0 (output: ${out})"
+fi
+
+# -----------------------------------------------------------------------------
+# サマリ
+# -----------------------------------------------------------------------------
+echo
+echo "==========================="
+echo "  passed: ${PASS}"
+echo "  failed: ${FAIL}"
+echo "==========================="
+
+if [[ "${FAIL}" -gt 0 ]]; then
+  exit 1
+fi


### PR DESCRIPTION
## 概要

v0.3.7 (quality hotfix) 以降に実施した **v0.4.0 全面レビュー** の成果を束ねる major release。Tier A (3 項目) + Tier B (4 項目) の計 7 項目の cleanness gate を完了。新機能追加なし。

## 含まれる変更 (要約)

### Tier A (security + 運用 stability)
- **A#1** 依存 CVE audit: `@mozilla/readability` 0.5 → 0.6 (ReDoS GHSA-3p6v-hrg8-8qj7 解消)
- **A#2** detached HEAD ガード: auto-ingest / auto-lint / install-hooks SessionEnd の 3 箇所
- **A#3** lock refactor: `withLock` 保持時間短縮 + `skipLock` API 全削除 + orphan PDF cleanup

### Tier B (cleanness)
- **B#1** Hook 層 re-audit: `session-logger.mjs` MEDIUM × 3 fix (INVISIBLE / YAML injection / NO_LOG strict)
- **B#2** cron/setup 層 ガード統一: `cron-guard-parity.test.sh` (17 assertions) enforcement
- **B#3** `sync-to-app.sh` race 構造的解消: GitHub-side lock (α) + `sync-to-app.test.sh` (11 assertions)
- **B#8** README i18n parity: 8 言語 README (zh-TW / zh-CN / ko / fr / es / pt-BR / hi / ru) に §10 MCP / §11 MCPB / Changelog (+1384 行)

## `.mcpb` バンドル

- filename: `kioku-wiki-0.4.0.mcpb`
- size: 7.4 MB
- shasum: `4a4eb71132f35539d41ff21dd6cdc57523a3774f`
- install: Claude Desktop に drag & drop → Vault directory 指定 → ⌘Q で再起動

## 新規 env (任意、`sync-to-app.sh` 専用)

- **`KIOKU_SYNC_LOCK_MAX_AGE`** (秒、デフォルト `120`、`0` で無効化) — 2 台以上 cron 並走時の race guard 閾値。1 台運用なら触る必要なし

## テスト

- Node: 299 tests green (46 suites)
- Bash: 15 suites / 415 assertions green (全 rc=0)

## 詳細

Release notes 全文は [GitHub Release v0.4.0](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.4.0) 参照。