### PR TITLE
v0.5.0 release prep — version bump 0.4.0 → 0.5.0

### DIFF
--- a/mcp/manifest.json
+++ b/mcp/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "kioku-wiki",
   "display_name": "KIOKU Wiki",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Read, search, and write your KIOKU Obsidian Wiki from Claude Desktop or Claude Code.",
   "long_description": "KIOKU is a personal knowledge base ('second brain') built on top of an Obsidian Vault. This MCP server exposes eight tools (kioku_search, kioku_read, kioku_list, kioku_write_note, kioku_write_wiki, kioku_delete, kioku_ingest_pdf, kioku_ingest_url) so that Claude Desktop and Claude Code can browse and update the Wiki without leaving the chat. All operations are local stdio — nothing leaves your machine. See https://github.com/megaphone-tokyo/kioku for the full project.",
   "author": {

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kioku-mcp",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kioku-mcp",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "~1.29.0",
         "@mozilla/readability": "^0.6.0",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kioku-mcp",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "description": "KIOKU local MCP server (Wiki read/list/search/write_note/write_wiki/delete) for Claude Desktop and Claude Code.",


### PR DESCRIPTION
## Summary

Parent repo の version bump (manifest.json + package.json + package-lock.json) を kioku main に propagate。直後に v0.5.0 tag を打つ準備。

## Changes

- \`mcp/manifest.json\`: 0.4.0 → 0.5.0
- \`mcp/package.json\`: 0.4.0 → 0.5.0
- \`mcp/package-lock.json\`: 0.4.0 → 0.5.0 (name + root package の 2 箇所)

3 files / +4 / -4

## 関連

- parent #26 (version bump PR、main merge 済)
- kioku #16 (v0.5.0 本体 content、main merge 済)

## 次 action (本 PR merge 後)

1. v0.5.0 tag on kioku main
2. \`.mcpb\` build (kioku-wiki-0.5.0.mcpb)
3. GitHub Release v0.5.0 公開 (.mcpb asset 添付、release notes に fast-xml-parser CVE-2026-41650 の非適用宣言 + v0.5.1 mitigation plan を記載)