### PR TITLE
v0.6 prep: Phase C-1 (multi-agent) + C-2 (plugin marketplace) + defuddle skip

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,30 @@
+{
+  "name": "kioku-marketplace",
+  "owner": {
+    "name": "megaphone-tokyo",
+    "url": "https://github.com/megaphone-tokyo"
+  },
+  "metadata": {
+    "description": "KIOKU: Hardened LLM Wiki for Claude Code / Claude Desktop by megaphone-tokyo",
+    "version": "0.5.1"
+  },
+  "plugins": [
+    {
+      "name": "kioku",
+      "source": {
+        "source": "github",
+        "repo": "megaphone-tokyo/kioku",
+        "ref": "main"
+      },
+      "description": "Hardened LLM Wiki for Claude Code + Claude Desktop. Automatic conversation → Obsidian Vault knowledge base. Hot cache + PostCompact hook + secret masking + Git sync.",
+      "version": "0.5.1",
+      "author": {
+        "name": "megaphone-tokyo",
+        "url": "https://github.com/megaphone-tokyo"
+      },
+      "homepage": "https://github.com/megaphone-tokyo/kioku",
+      "repository": "https://github.com/megaphone-tokyo/kioku",
+      "license": "MIT"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,34 @@
+{
+  "name": "kioku",
+  "version": "0.5.1",
+  "description": "KIOKU — Hardened LLM Wiki for Claude Code + Claude Desktop. Automatic conversation capture to Obsidian Vault, Karpathy LLM Wiki pattern, hot cache + PostCompact hook, secret masking, cross-machine Git sync. Research/legal/enterprise-grade memory for Claude.",
+  "author": {
+    "name": "megaphone-tokyo",
+    "url": "https://github.com/megaphone-tokyo"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/megaphone-tokyo/kioku",
+  "repository": "https://github.com/megaphone-tokyo/kioku",
+  "keywords": [
+    "obsidian",
+    "knowledge-base",
+    "wiki",
+    "memory",
+    "second-brain",
+    "vault",
+    "markdown",
+    "llm-wiki",
+    "karpathy",
+    "pkm",
+    "hot-cache",
+    "post-compact",
+    "session-logger",
+    "ingest",
+    "pdf",
+    "epub",
+    "docx",
+    "url-extraction",
+    "hardened",
+    "security-first"
+  ]
+}

--- a/docs/install-guide-plugin.md
+++ b/docs/install-guide-plugin.md
@@ -1,0 +1,161 @@
+---
+title: Install KIOKU as a Claude Code Plugin
+updated: 2026-04-23
+---
+
+# KIOKU as a Claude Code Plugin
+
+KIOKU は 3 つのインストール方法があります:
+
+| 方法 | 用途 | 対象 |
+|---|---|---|
+| **1. `.mcpb` bundle** | Claude Desktop / Claude Code (GUI) への drag & drop | エンドユーザー、最速 |
+| **2. Claude Code plugin (本書)** | `claude plugin install` コマンドで install / update | 開発者、version 管理重視 |
+| **3. Manual setup** | parent repo を clone + `install-hooks.sh` | contributor、カスタマイズ運用 |
+
+本書は **方法 2 (plugin install)** をガイドします。方法 1 は [README](../README.md) を、方法 3 は [app/README.md](../app/README.md) #Quick-Start を参照。
+
+## 前提
+
+- Claude Code (Max plan) インストール済
+- `claude` CLI が PATH に通っている (`claude --version` で確認)
+- Obsidian Vault を 1 つ用意 (どのフォルダでもよい、iCloud Drive は不要)
+
+## 方法 A: marketplace 経由でインストール
+
+```bash
+# 1. marketplace を登録 (初回のみ)
+claude marketplace add megaphone-tokyo/kioku
+
+# 2. plugin install
+claude plugin install kioku@megaphone-tokyo
+
+# 3. 動作確認
+claude plugin list | grep kioku
+# => kioku  0.5.1  (installed)
+```
+
+## 方法 B: 直接 repo を指定してインストール
+
+```bash
+claude plugin install github:megaphone-tokyo/kioku
+```
+
+## Post-install 手順
+
+plugin install は **skills / hooks / scripts を Claude Code の discover path に配置** するだけで、Vault 初期化までは自動化されません。以下を追加実行してください:
+
+### 1. 環境変数を設定
+
+```bash
+# ~/.zshrc (macOS zsh) or ~/.bashrc (Linux bash) に追加
+export OBSIDIAN_VAULT="$HOME/claude-brain/main-claude-brain"
+```
+
+### 2. Vault の初期化
+
+```bash
+# 新規 Vault の場合のみ
+mkdir -p "$OBSIDIAN_VAULT"
+cd "$OBSIDIAN_VAULT" && git init
+gh repo create --private --source=. --push  # GitHub Private repo を作成
+
+# KIOKU の Vault 構造を展開 (冪等、既存ファイルは上書きしない)
+bash ~/.claude/plugins/kioku/scripts/setup-vault.sh
+```
+
+### 3. Hook を `~/.claude/settings.json` にマージ
+
+```bash
+bash ~/.claude/plugins/kioku/scripts/install-hooks.sh --apply
+# バックアップ作成 → diff 表示 → 確認プロンプト → 既存設定を保持して Hook 追加
+```
+
+### 4. LaunchAgent / cron で定期 Ingest (任意)
+
+```bash
+# OS 自動判別 (macOS → LaunchAgent / Linux → cron)
+bash ~/.claude/plugins/kioku/scripts/install-schedule.sh
+```
+
+### 5. MCP server を Claude Desktop に登録 (任意、全 Claude Code skills + Desktop 両方で使う場合)
+
+```bash
+# 依存セットアップ
+bash ~/.claude/plugins/kioku/scripts/setup-mcp.sh
+
+# Claude Desktop に登録
+bash ~/.claude/plugins/kioku/scripts/install-mcp-client.sh --apply
+```
+
+## 動作確認
+
+Claude Code を再起動してから、会話を 1 つ発生させる:
+
+```bash
+# KIOKU 管理下の Vault に session log が出るはず
+ls "$OBSIDIAN_VAULT/session-logs/" | tail -1
+# => 20260423-170000-xxxx-<最初のプロンプト>.md が最新
+```
+
+Hot cache 機能の確認 (v0.5.1 以降):
+
+```bash
+# 新規セッションで、hot.md を自動注入されていることを verify
+cat "$OBSIDIAN_VAULT/wiki/hot.md"
+# => frontmatter + "## Recent Context" が入っている
+
+# context compaction (`/compact` で手動発火) 後、再注入されるか
+# KIOKU_DEBUG=1 で stderr にサイズ log が出る
+export KIOKU_DEBUG=1
+```
+
+## Upgrade
+
+```bash
+claude plugin upgrade kioku
+```
+
+KIOKU は SemVer を守ります。major bump (0.x → 1.0) で breaking change が起きる場合は Release note に `BREAKING:` を明記します。
+
+## Uninstall
+
+```bash
+# 1. plugin を削除
+claude plugin uninstall kioku
+
+# 2. Hook 設定を手動で削除
+# ~/.claude/settings.json から KIOKU 関連の hook entry を削除
+# (install-hooks.sh の backup が ~/.claude/settings.json.backup.<timestamp> にあるので復元可能)
+
+# 3. LaunchAgent (macOS の場合)
+launchctl unload ~/Library/LaunchAgents/com.kioku.ingest.plist
+launchctl unload ~/Library/LaunchAgents/com.kioku.lint.plist
+rm ~/Library/LaunchAgents/com.kioku.*.plist
+
+# 4. (任意) Vault を削除
+# rm -rf "$OBSIDIAN_VAULT"  # 注意: knowledge base も消える
+```
+
+## トラブルシューティング
+
+| 症状 | 原因 | 解決 |
+|---|---|---|
+| `claude plugin install` で not found | marketplace 未登録 | `claude marketplace add megaphone-tokyo/kioku` を先に実行 |
+| session log が生成されない | Hook が `~/.claude/settings.json` に入っていない | `install-hooks.sh --apply` を再実行 |
+| hot.md が LLM に届かない | `$OBSIDIAN_VAULT` env 未設定 / Vault 外シムリンク escape | `echo $OBSIDIAN_VAULT` で確認、`realpath` で link 先確認 |
+| auto-ingest が動かない | LaunchAgent / cron 未インストール | `install-schedule.sh` を実行 / `launchctl list | grep kioku` で確認 |
+| `.mcpb` 側と plugin 側の衝突 | 両方 install | 1 方法のみに絞る (本書の方法 2 推奨なら `.mcpb` を Claude Desktop から uninstall) |
+
+## 関連
+
+- [README](../README.md) — プロダクト概要
+- [SECURITY.md](../SECURITY.md) — セキュリティポリシー (CVE / Safe Harbor / Disclosure Timeline)
+- [context/context.md](../context/context.md) — 実装の INDEX
+- [app/README.md](../app/README.md) — 方法 3 manual setup 詳細
+
+## リンク
+
+- Repository: https://github.com/megaphone-tokyo/kioku
+- Releases: https://github.com/megaphone-tokyo/kioku/releases
+- Issues: https://github.com/megaphone-tokyo/kioku/issues

--- a/mcp/manifest.json
+++ b/mcp/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "kioku-wiki",
   "display_name": "KIOKU Wiki",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Read, search, and write your KIOKU Obsidian Wiki from Claude Desktop or Claude Code.",
   "long_description": "KIOKU is a personal knowledge base ('second brain') built on top of an Obsidian Vault. This MCP server exposes eight tools (kioku_search, kioku_read, kioku_list, kioku_write_note, kioku_write_wiki, kioku_delete, kioku_ingest_pdf, kioku_ingest_url) so that Claude Desktop and Claude Code can browse and update the Wiki without leaving the chat. All operations are local stdio — nothing leaves your machine. See https://github.com/megaphone-tokyo/kioku for the full project.",
   "author": {

--- a/scripts/setup-multi-agent.sh
+++ b/scripts/setup-multi-agent.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+#
+# setup-multi-agent.sh — claude-brain の skills/ を Claude Code 以外の AI agent にも symlink で配置
+#
+# Claude Code 用は `install-skills.sh` ($HOME/.claude/skills/ 以下に per-skill symlink) を使う。
+# 本 script は **それ以外の agent** (Codex CLI / OpenCode / Gemini CLI) 向けに、
+# `skills/` ディレクトリ全体を `<agent-root>/skills/kioku/` として symlink する。
+#
+# Agent の slash command / skill 認識経路:
+#   Codex CLI        : ~/.codex/skills/kioku       (per https://github.com/openai/codex)
+#   OpenCode         : ~/.opencode/skills/kioku    (per opencode.ai)
+#   Gemini CLI       : ~/.gemini/skills/kioku      (per https://github.com/google-gemini/gemini-cli)
+#
+# Usage:
+#   bash setup-multi-agent.sh                    # 冪等に全 agent に symlink
+#   bash setup-multi-agent.sh --agent codex      # 特定 agent のみ
+#   bash setup-multi-agent.sh --dry-run          # 実行予定のみ表示、書き込みなし
+#   bash setup-multi-agent.sh --uninstall        # 全 agent の symlink を削除
+#
+# Exit codes:
+#   0  正常終了 (全 agent 処理完了、warned を含む)
+#   1  fatal error (skills/ 不在、unknown argument, etc.)
+#
+# 環境変数 (テスト用 override):
+#   KIOKU_CODEX_SKILLS_DIR    — default: $HOME/.codex/skills
+#   KIOKU_OPENCODE_SKILLS_DIR — default: $HOME/.opencode/skills
+#   KIOKU_GEMINI_SKILLS_DIR   — default: $HOME/.gemini/skills
+#
+# 参考:
+#   - plan/claude/26042303 §Phase C Task C-1
+#   - competitors/claude-obsidian/bin/setup-multi-agent.sh (実装パターン元ネタ)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILLS_SRC_DIR="$(cd "${SCRIPT_DIR}/../skills" && pwd)"
+
+# 対象 agent 定義 (name|default_dir の配列)
+# 新 agent 追加時はここを増やす
+AGENTS=(
+  "codex|${KIOKU_CODEX_SKILLS_DIR:-${HOME}/.codex/skills}"
+  "opencode|${KIOKU_OPENCODE_SKILLS_DIR:-${HOME}/.opencode/skills}"
+  "gemini|${KIOKU_GEMINI_SKILLS_DIR:-${HOME}/.gemini/skills}"
+)
+
+DRY_RUN=0
+UNINSTALL=0
+TARGET_AGENT=""
+
+for arg in "$@"; do
+  case "${arg}" in
+    --dry-run) DRY_RUN=1 ;;
+    --uninstall) UNINSTALL=1 ;;
+    --agent=*) TARGET_AGENT="${arg#--agent=}" ;;
+    --agent)
+      echo "ERROR: --agent requires a value (e.g. --agent=codex)" >&2
+      exit 1
+      ;;
+    -h|--help)
+      sed -n '2,28p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: ${arg}" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ ! -d "${SKILLS_SRC_DIR}" ]]; then
+  echo "ERROR: skills source directory not found: ${SKILLS_SRC_DIR}" >&2
+  exit 1
+fi
+
+# symlink 名 = kioku (固定)
+LINK_NAME="kioku"
+
+echo "setup-multi-agent: source = ${SKILLS_SRC_DIR}"
+echo "setup-multi-agent: link name = ${LINK_NAME}"
+if [[ -n "${TARGET_AGENT}" ]]; then
+  echo "setup-multi-agent: target agent = ${TARGET_AGENT}"
+fi
+if [[ ${UNINSTALL} -eq 1 ]]; then
+  echo "setup-multi-agent: mode = UNINSTALL"
+elif [[ ${DRY_RUN} -eq 1 ]]; then
+  echo "setup-multi-agent: mode = DRY RUN"
+fi
+echo
+
+CREATED=0
+SKIPPED=0
+REPLACED=0
+REMOVED=0
+WARNED=0
+
+for entry in "${AGENTS[@]}"; do
+  agent_name="${entry%%|*}"
+  dest_dir="${entry#*|}"
+  dest_link="${dest_dir}/${LINK_NAME}"
+
+  # --agent フィルタ
+  if [[ -n "${TARGET_AGENT}" && "${TARGET_AGENT}" != "${agent_name}" ]]; then
+    continue
+  fi
+
+  # UNINSTALL モード
+  if [[ ${UNINSTALL} -eq 1 ]]; then
+    if [[ -L "${dest_link}" ]]; then
+      current_target="$(readlink "${dest_link}")"
+      if [[ "${current_target}" == "${SKILLS_SRC_DIR}" ]]; then
+        echo "  [remove]  ${agent_name}: ${dest_link}"
+        if [[ ${DRY_RUN} -eq 0 ]]; then
+          rm "${dest_link}"
+        fi
+        REMOVED=$((REMOVED + 1))
+      else
+        echo "  [skip]    ${agent_name}: symlink points elsewhere (${current_target}), not touching" >&2
+        WARNED=$((WARNED + 1))
+      fi
+    else
+      echo "  [skip]    ${agent_name}: no symlink at ${dest_link}"
+      SKIPPED=$((SKIPPED + 1))
+    fi
+    continue
+  fi
+
+  # INSTALL モード
+  # 宛先ディレクトリの親を作成
+  if [[ ${DRY_RUN} -eq 0 ]]; then
+    mkdir -p "${dest_dir}"
+  fi
+
+  if [[ -L "${dest_link}" ]]; then
+    current_target="$(readlink "${dest_link}")"
+    if [[ "${current_target}" == "${SKILLS_SRC_DIR}" ]]; then
+      echo "  [skip]    ${agent_name}: already linked (${dest_link})"
+      SKIPPED=$((SKIPPED + 1))
+      continue
+    fi
+    echo "  [WARN]    ${agent_name}: symlink exists but points elsewhere (${current_target}), skipping" >&2
+    echo "            remove manually to relink: rm '${dest_link}'" >&2
+    WARNED=$((WARNED + 1))
+    continue
+  fi
+
+  if [[ -e "${dest_link}" ]]; then
+    echo "  [WARN]    ${agent_name}: ${dest_link} exists and is not a symlink, skipping" >&2
+    WARNED=$((WARNED + 1))
+    continue
+  fi
+
+  echo "  [create]  ${agent_name}: ${dest_link} -> ${SKILLS_SRC_DIR}"
+  if [[ ${DRY_RUN} -eq 0 ]]; then
+    ln -s "${SKILLS_SRC_DIR}" "${dest_link}"
+  fi
+  CREATED=$((CREATED + 1))
+done
+
+echo
+if [[ ${UNINSTALL} -eq 1 ]]; then
+  echo "setup-multi-agent: removed=${REMOVED} skipped=${SKIPPED} warned=${WARNED}"
+else
+  echo "setup-multi-agent: created=${CREATED} replaced=${REPLACED} skipped=${SKIPPED} warned=${WARNED}"
+fi
+
+# verify のヒント
+if [[ ${UNINSTALL} -eq 0 && ${DRY_RUN} -eq 0 && ${CREATED} -gt 0 ]]; then
+  echo
+  echo "次の verify 手順:"
+  echo "  - Codex CLI:  codex --list-skills 2>/dev/null | grep -i kioku"
+  echo "  - Gemini CLI: gemini --list-skills 2>/dev/null | grep -i kioku"
+  echo "  - OpenCode:   ls ~/.opencode/skills/kioku/"
+fi

--- a/scripts/sync-to-app.sh
+++ b/scripts/sync-to-app.sh
@@ -172,7 +172,7 @@ echo "=== sync-to-app: copying from parent to app/ ==="
 # mcp/ は Phase M で追加された独立 npm プロジェクト。node_modules/ はユーザーが
 # `bash scripts/setup-mcp.sh` で導入するため、rsync 側でも除外する。
 # Phase N で追加した build/ と dist/ (MCPB バンドルのビルド成果物) も同様に除外。
-for dir in hooks scripts templates skills tests mcp; do
+for dir in hooks scripts templates skills tests mcp docs .claude-plugin; do
   if [[ -d "${BRAIN_DIR}/${dir}" ]]; then
     # 2026-04-20 security-review HIGH-b1 fix:
     # 旧コードは `--exclude='.git*'` だったため、glob が `.gitignore` まで誤爆し

--- a/tests/setup-multi-agent.test.sh
+++ b/tests/setup-multi-agent.test.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+#
+# setup-multi-agent.test.sh — scripts/setup-multi-agent.sh のスモークテスト
+#
+# 実行: bash tools/claude-brain/tests/setup-multi-agent.test.sh
+#
+# Test cases (plan/claude/26042303 §Phase C Task C-1):
+#   SMA-1: スクリプトが存在し、実行可能
+#   SMA-2: skills/ が不在なら fatal error で exit 1
+#   SMA-3: 初回実行で 3 agent (codex / opencode / gemini) に symlink 作成
+#   SMA-4: 2 回目実行は全て [skip] (冪等性)
+#   SMA-5: 既存非 symlink path は [WARN] でスキップ (破壊しない)
+#   SMA-6: --uninstall で KIOKU が張った symlink のみ削除
+#   SMA-7: --agent=codex で対象 filter が効く
+#   SMA-8: --dry-run は実際に symlink を作らない
+#
+# 方針:
+#   - HOME 環境変数は触らない。KIOKU_*_SKILLS_DIR env var で target dir を override
+#   - mktemp -d で隔離、trap でクリーンアップ
+#   - bats 非依存、自作 assert 関数のみ
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+SETUP_MULTI_AGENT="${REPO_ROOT}/tools/claude-brain/scripts/setup-multi-agent.sh"
+SKILLS_SRC="${REPO_ROOT}/tools/claude-brain/skills"
+
+if [[ ! -f "${SETUP_MULTI_AGENT}" ]]; then
+  echo "FATAL: setup-multi-agent.sh not found at ${SETUP_MULTI_AGENT}" >&2
+  exit 1
+fi
+
+TMPROOT="$(mktemp -d)"
+trap 'rm -rf "${TMPROOT}"' EXIT
+
+PASS=0
+FAIL=0
+
+pass() {
+  PASS=$((PASS + 1))
+  echo "  ok  $1"
+}
+
+fail() {
+  FAIL=$((FAIL + 1))
+  echo "  NG  $1" >&2
+}
+
+assert_symlink_to() {
+  local link="$1"
+  local expected_target="$2"
+  local msg="$3"
+  if [[ -L "${link}" ]]; then
+    local actual
+    actual="$(readlink "${link}")"
+    if [[ "${actual}" == "${expected_target}" ]]; then
+      pass "${msg}"
+    else
+      fail "${msg} (expected->${expected_target}, actual->${actual})"
+    fi
+  else
+    fail "${msg} (not a symlink: ${link})"
+  fi
+}
+
+assert_not_exists() {
+  local path="$1"
+  local msg="$2"
+  if [[ ! -e "${path}" && ! -L "${path}" ]]; then
+    pass "${msg}"
+  else
+    fail "${msg} (path still exists: ${path})"
+  fi
+}
+
+assert_exit_code() {
+  local expected="$1"
+  local actual="$2"
+  local msg="$3"
+  if [[ "${expected}" -eq "${actual}" ]]; then
+    pass "${msg}"
+  else
+    fail "${msg} (expected exit=${expected}, actual=${actual})"
+  fi
+}
+
+# ヘルパー: 隔離された tmp agent skill root を作って script を呼ぶ
+run_setup_multi_agent() {
+  local codex_dir="$1"; shift
+  local opencode_dir="$1"; shift
+  local gemini_dir="$1"; shift
+  KIOKU_CODEX_SKILLS_DIR="${codex_dir}" \
+  KIOKU_OPENCODE_SKILLS_DIR="${opencode_dir}" \
+  KIOKU_GEMINI_SKILLS_DIR="${gemini_dir}" \
+  bash "${SETUP_MULTI_AGENT}" "$@"
+}
+
+# =========================================================================
+# SMA-1: スクリプトが実行可能
+# =========================================================================
+echo "--- SMA-1: script exists and is syntactically valid ---"
+bash -n "${SETUP_MULTI_AGENT}" && pass "bash -n syntax check" || fail "bash -n syntax check failed"
+
+# =========================================================================
+# SMA-3: 初回実行で 3 agent に symlink 作成
+# =========================================================================
+echo "--- SMA-3: initial install creates 3 symlinks ---"
+T3="${TMPROOT}/sma3"
+run_setup_multi_agent "${T3}/codex" "${T3}/opencode" "${T3}/gemini" > /dev/null
+assert_symlink_to "${T3}/codex/kioku" "${SKILLS_SRC}" "codex symlink created"
+assert_symlink_to "${T3}/opencode/kioku" "${SKILLS_SRC}" "opencode symlink created"
+assert_symlink_to "${T3}/gemini/kioku" "${SKILLS_SRC}" "gemini symlink created"
+
+# =========================================================================
+# SMA-4: 2 回目実行は冪等 (全て [skip])
+# =========================================================================
+echo "--- SMA-4: second run is idempotent ---"
+out_second=$(run_setup_multi_agent "${T3}/codex" "${T3}/opencode" "${T3}/gemini" 2>&1)
+if echo "${out_second}" | grep -qE "created=0.*skipped=3"; then
+  pass "second run: created=0 skipped=3"
+else
+  fail "second run not idempotent (got: $(echo "${out_second}" | grep "created="))"
+fi
+
+# =========================================================================
+# SMA-5: 既存非 symlink path は [WARN] でスキップ
+# =========================================================================
+echo "--- SMA-5: existing non-symlink path is skipped with WARN ---"
+T5="${TMPROOT}/sma5"
+mkdir -p "${T5}/codex"
+# 既存の通常ディレクトリを作る (symlink じゃない)
+mkdir "${T5}/codex/kioku"
+out5=$(run_setup_multi_agent "${T5}/codex" "${T5}/opencode" "${T5}/gemini" 2>&1 || true)
+if echo "${out5}" | grep -q "WARN.*codex.*not a symlink"; then
+  pass "non-symlink path triggers WARN"
+else
+  fail "non-symlink WARN not emitted (got: ${out5})"
+fi
+# 既存ディレクトリが破壊されていないこと
+if [[ -d "${T5}/codex/kioku" && ! -L "${T5}/codex/kioku" ]]; then
+  pass "existing directory not clobbered"
+else
+  fail "existing directory was clobbered"
+fi
+
+# =========================================================================
+# SMA-6: --uninstall で KIOKU symlink のみ削除
+# =========================================================================
+echo "--- SMA-6: --uninstall removes only KIOKU-created symlinks ---"
+T6="${TMPROOT}/sma6"
+# install
+run_setup_multi_agent "${T6}/codex" "${T6}/opencode" "${T6}/gemini" > /dev/null
+# 別 target を指す symlink を手動で仕込む (KIOKU が作ったものではない)
+mkdir -p "${T6}/other"
+ln -sfn "${TMPROOT}" "${T6}/other/kioku"
+# uninstall (--uninstall フラグ)
+run_setup_multi_agent "${T6}/codex" "${T6}/opencode" "${T6}/gemini" --uninstall > /dev/null
+# KIOKU symlinks は消えている
+assert_not_exists "${T6}/codex/kioku" "uninstall: codex symlink removed"
+assert_not_exists "${T6}/opencode/kioku" "uninstall: opencode symlink removed"
+assert_not_exists "${T6}/gemini/kioku" "uninstall: gemini symlink removed"
+# 関係ない symlink には触らない
+if [[ -L "${T6}/other/kioku" ]]; then
+  pass "uninstall: unrelated symlink not touched"
+else
+  fail "uninstall: unrelated symlink was deleted"
+fi
+
+# =========================================================================
+# SMA-7: --agent=codex で filter が効く
+# =========================================================================
+echo "--- SMA-7: --agent filter limits target ---"
+T7="${TMPROOT}/sma7"
+run_setup_multi_agent "${T7}/codex" "${T7}/opencode" "${T7}/gemini" --agent=codex > /dev/null
+assert_symlink_to "${T7}/codex/kioku" "${SKILLS_SRC}" "agent=codex: codex linked"
+assert_not_exists "${T7}/opencode/kioku" "agent=codex: opencode NOT linked"
+assert_not_exists "${T7}/gemini/kioku" "agent=codex: gemini NOT linked"
+
+# =========================================================================
+# SMA-8: --dry-run は実際には symlink を作らない
+# =========================================================================
+echo "--- SMA-8: --dry-run does not create symlinks ---"
+T8="${TMPROOT}/sma8"
+out8=$(run_setup_multi_agent "${T8}/codex" "${T8}/opencode" "${T8}/gemini" --dry-run 2>&1)
+if echo "${out8}" | grep -q "DRY RUN"; then
+  pass "dry-run: banner emitted"
+else
+  fail "dry-run: banner not emitted"
+fi
+assert_not_exists "${T8}/codex/kioku" "dry-run: no symlink created (codex)"
+assert_not_exists "${T8}/opencode/kioku" "dry-run: no symlink created (opencode)"
+assert_not_exists "${T8}/gemini/kioku" "dry-run: no symlink created (gemini)"
+
+# =========================================================================
+# SMA-2: skills/ 不在で fatal error (最後に実行、SKILLS_SRC を一時的に非表示化)
+# =========================================================================
+echo "--- SMA-2: missing skills/ src exits 1 ---"
+# 別の repo-like tempdir を作って skills/ を置かずに script をコピー実行
+T2="${TMPROOT}/sma2-repo"
+mkdir -p "${T2}/tools/claude-brain/scripts"
+cp "${SETUP_MULTI_AGENT}" "${T2}/tools/claude-brain/scripts/setup-multi-agent.sh"
+set +e
+(bash "${T2}/tools/claude-brain/scripts/setup-multi-agent.sh" > /dev/null 2>&1)
+rc=$?
+set -e
+assert_exit_code 1 "${rc}" "skills/ missing: exit 1"
+
+# =========================================================================
+# Summary
+# =========================================================================
+echo
+echo "===================="
+echo "PASS=${PASS} FAIL=${FAIL}"
+echo "===================="
+if [[ "${FAIL}" -gt 0 ]]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

parent PR #33 を sync。v0.5.1 から **v0.6.0 に向けた Phase C の先行 sub-task 2 件** を kioku に展開。version は v0.5.1 のまま (v0.6.0 tag は C-3/C-4/C-5 完了後)。

## Changes (7 files)

### 📦 Plugin marketplace (C-2)

- `.claude-plugin/plugin.json` — kioku v0.5.1 manifest、20 keywords
- `.claude-plugin/marketplace.json` — kioku を指す marketplace entry
- `docs/install-guide-plugin.md` — 3 install 方法の比較 + plugin install 手順 + post-install

→ **本 PR merge 後、user は `claude plugin install kioku@megaphone-tokyo` が可能に**

### 🎯 Multi-agent cross-platform (C-1)

- `scripts/setup-multi-agent.sh` — Codex CLI / OpenCode / Gemini CLI に `skills/` を symlink
- `tests/setup-multi-agent.test.sh` — SMA-1〜8、19/19 pass

### 🔄 Infrastructure

- `scripts/sync-to-app.sh` — `.claude-plugin/` + `docs/` を sync 対象に追加
- `mcp/manifest.json` — minor 修正 (parent 側 `parent \` 差異の sync)

## Version status

plugin.json / marketplace.json 両方 **v0.5.1** (current release match)。v0.6.0 tag は Phase C 全完了時 (C-3 Delta tracking / C-4 Bases dashboard / C-5 LP β + Discord 完了後、2026-05 中頃予定)。

## Related

- parent merge PR: https://github.com/megaphone-kurata/claude-tools/pull/33
- 正典: plan/claude/26042303 v2 §Phase C Task C-1 / C-2
- defuddle skip 判定: handoff/open-issues.md §19

## Test

parent 側で Node 47 + Bash 143 全 green 確認済。