### PR TITLE
v0.6 prep: Phase C-4 Bases dashboard wiring (setup-vault + test)

### DIFF
--- a/scripts/setup-vault.sh
+++ b/scripts/setup-vault.sh
@@ -134,6 +134,7 @@ DIRS=(
   "wiki/people"
   "wiki/summaries"
   "wiki/analyses"
+  "wiki/meta"
   "templates"
 )
 
@@ -214,6 +215,11 @@ copy_if_missing \
 copy_if_missing \
   "${TEMPLATES_DIR}/wiki/hot.md" \
   "${OBSIDIAN_VAULT}/wiki/hot.md"
+
+# v0.6 Phase C-4: Obsidian Bases dashboard (wiki/meta/ 配下、user が Obsidian で開く)
+copy_if_missing \
+  "${TEMPLATES_DIR}/wiki/meta/dashboard.base" \
+  "${OBSIDIAN_VAULT}/wiki/meta/dashboard.base"
 
 copy_if_missing \
   "${TEMPLATES_DIR}/notes/concept.md" \

--- a/templates/wiki/meta/dashboard.base
+++ b/templates/wiki/meta/dashboard.base
@@ -1,0 +1,111 @@
+filters:
+  and:
+    - file.inFolder("wiki")
+    - 'file.ext == "md"'
+    - '!file.inFolder("wiki/summaries")'
+
+formulas:
+  age_days: '(now() - file.mtime).days'
+
+properties:
+  type:
+    displayName: "Type"
+  status:
+    displayName: "Status"
+  updated:
+    displayName: "Updated"
+  tech_stack:
+    displayName: "Tech Stack"
+  formula.age_days:
+    displayName: "Days Since Edit"
+
+views:
+  - type: table
+    name: "Hot Cache (v0.5.1 短期記憶)"
+    limit: 5
+    filters:
+      and:
+        - file.name == "hot.md"
+    order:
+      - file.name
+      - updated
+      - formula.age_days
+
+  - type: list
+    name: "Active Projects"
+    filters:
+      and:
+        - file.inFolder("wiki/projects")
+        - 'status == "active"'
+    order:
+      - file.name
+      - updated
+      - tech_stack
+
+  - type: table
+    name: "Recent Activity (全 wiki/、直近 20 件)"
+    limit: 20
+    order:
+      - formula.age_days
+      - file.name
+      - type
+      - status
+    groupBy:
+      property: type
+      direction: ASC
+
+  - type: list
+    name: "Concepts"
+    filters:
+      and:
+        - file.inFolder("wiki/concepts")
+    order:
+      - file.name
+      - updated
+      - formula.age_days
+
+  - type: list
+    name: "Design Decisions"
+    filters:
+      and:
+        - file.inFolder("wiki/decisions")
+    order:
+      - formula.age_days
+      - file.name
+
+  - type: list
+    name: "Analyses (LLM 自動要約 / 比較)"
+    filters:
+      and:
+        - file.inFolder("wiki/analyses")
+    order:
+      - formula.age_days
+      - file.name
+
+  - type: list
+    name: "Patterns"
+    filters:
+      and:
+        - file.inFolder("wiki/patterns")
+    order:
+      - formula.age_days
+      - file.name
+
+  - type: list
+    name: "Bugs / Edge Cases"
+    filters:
+      and:
+        - file.inFolder("wiki/bugs")
+    order:
+      - formula.age_days
+      - file.name
+
+  - type: list
+    name: "Stale Pages (30 日以上 更新なし、要 revisit)"
+    limit: 15
+    filters:
+      and:
+        - 'formula.age_days > 30'
+    order:
+      - formula.age_days
+      - file.name

--- a/tests/setup-vault.test.sh
+++ b/tests/setup-vault.test.sh
@@ -135,6 +135,19 @@ if grep -q '^type: hot-cache$' "${VAULT}/wiki/hot.md" 2>/dev/null; then
 else
   fail "wiki/hot.md should have frontmatter 'type: hot-cache' (HOT-V1)"
 fi
+# DB-V1 (v0.6 Phase C-4): Obsidian Bases dashboard 配置
+assert_dir_exists "${VAULT}/wiki/meta" "wiki/meta dir created (DB-V1)"
+assert_file_exists "${VAULT}/wiki/meta/dashboard.base" "wiki/meta/dashboard.base placed (DB-V1)"
+if grep -q '^filters:$' "${VAULT}/wiki/meta/dashboard.base" 2>/dev/null; then
+  pass "dashboard.base has filters: section (DB-V1)"
+else
+  fail "dashboard.base should have 'filters:' root key (DB-V1)"
+fi
+if grep -q 'name: "Hot Cache' "${VAULT}/wiki/meta/dashboard.base" 2>/dev/null; then
+  pass "dashboard.base references Hot Cache view (DB-V1)"
+else
+  fail "dashboard.base should include Hot Cache view (DB-V1)"
+fi
 assert_file_exists "${VAULT}/templates/concept.md" "templates/concept.md placed"
 assert_file_exists "${VAULT}/templates/project.md" "templates/project.md placed"
 assert_file_exists "${VAULT}/templates/decision.md" "templates/decision.md placed"
@@ -178,19 +191,24 @@ echo "test: idempotency"
 echo "user-edited content" > "${VAULT}/wiki/index.md"
 # HOT-V2: hot.md への user 編集も idempotent に保たれること
 printf -- '---\ntype: hot-cache\nupdated: 2026-05-03\n---\n\n## Recent Context\n- user wrote this\n' > "${VAULT}/wiki/hot.md"
+# DB-V2: dashboard.base の user カスタマイズも idempotent に保たれること (v0.6 Phase C-4)
+printf -- 'filters:\n  and:\n    - file.inFolder("wiki")\n\nviews:\n  - type: table\n    name: "My Custom View"\n' > "${VAULT}/wiki/meta/dashboard.base"
 user_claude_hash_before="$(shasum "${VAULT}/CLAUDE.md" | awk '{print $1}')"
 user_index_hash_before="$(shasum "${VAULT}/wiki/index.md" | awk '{print $1}')"
 user_hot_hash_before="$(shasum "${VAULT}/wiki/hot.md" | awk '{print $1}')"
+user_base_hash_before="$(shasum "${VAULT}/wiki/meta/dashboard.base" | awk '{print $1}')"
 
 OBSIDIAN_VAULT="${VAULT}" bash "${SETUP_VAULT}" >/dev/null
 
 user_claude_hash_after="$(shasum "${VAULT}/CLAUDE.md" | awk '{print $1}')"
 user_index_hash_after="$(shasum "${VAULT}/wiki/index.md" | awk '{print $1}')"
 user_hot_hash_after="$(shasum "${VAULT}/wiki/hot.md" | awk '{print $1}')"
+user_base_hash_after="$(shasum "${VAULT}/wiki/meta/dashboard.base" | awk '{print $1}')"
 
 assert_eq "${user_claude_hash_before}" "${user_claude_hash_after}" "CLAUDE.md unchanged on re-run"
 assert_eq "${user_index_hash_before}" "${user_index_hash_after}" "user-edited wiki/index.md preserved"
 assert_eq "${user_hot_hash_before}" "${user_hot_hash_after}" "user-edited wiki/hot.md preserved (HOT-V2)"
+assert_eq "${user_base_hash_before}" "${user_base_hash_after}" "user-edited dashboard.base preserved (DB-V2)"
 
 # -----------------------------------------------------------------------------
 # Test 6: 既存 CLAUDE.md がある場合 CLAUDE.brain.md に退避


### PR DESCRIPTION
## Summary

parent PR #34 を sync。Obsidian Bases dashboard の setup-vault 配置 + test 追加。

## Changes (3 files)

- `templates/wiki/meta/dashboard.base` — 9 view 定義 (Hot Cache / Active Projects / Recent Activity / Concepts / Decisions / Analyses / Patterns / Bugs / Stale)
- `scripts/setup-vault.sh` — wiki/meta/ + dashboard.base 冪等 copy
- `tests/setup-vault.test.sh` — DB-V1 (配置) + DB-V2 (idempotent) 5 assertions

## 使い方

setup-vault.sh 再実行 (既存 user は実行すると `wiki/meta/dashboard.base` が追加配置) → Obsidian で `wiki/meta/dashboard.base` を開けば 9 view 表示。

v0.5.1 user が後追いで dashboard を得るには setup-vault 再実行 or `templates/wiki/meta/dashboard.base` を手動で vault にコピー。

## Related

- parent PR: https://github.com/megaphone-kurata/claude-tools/pull/34
- 仕様書: context/24-bases-dashboard.md