### PR TITLE
hotfix: Phase C-4 Hot Cache filename filter

### DIFF
--- a/templates/wiki/meta/dashboard.base
+++ b/templates/wiki/meta/dashboard.base
@@ -25,7 +25,7 @@ views:
     limit: 5
     filters:
       and:
-        - file.name == "hot.md"
+        - 'file.name == "hot"'
     order:
       - file.name
       - updated


### PR DESCRIPTION
parent PR #37 sync. `file.name == "hot.md"` (0 件になる) → `file.name == "hot"` (拡張子なし、Obsidian convention)。実機検証済。