### PR TITLE
v0.6 Phase C-3: raw-sources/*.md sha256-based delta detection

### DIFF
--- a/mcp/lib/git-history.mjs
+++ b/mcp/lib/git-history.mjs
@@ -1,0 +1,175 @@
+// git-history.mjs — Git 履歴を Visualizer (Phase D α) から読むための read-only 抽象
+//
+// 使い方:
+//   const commits = await getFileHistory(vaultDir, { since: '2026-01-01', subPath: 'wiki/' });
+//   const content = await getFileContentAtCommit(vaultDir, sha, 'wiki/index.md');
+//
+// Security / Trust boundary:
+//   - 全て **spawn('git', [...])** で argv 配列渡し (shell injection 回避、KIOKU 既存 pattern 踏襲)
+//   - vaultDir は cwd としてのみ使用 (ディレクトリ存在確認は呼び出し側)
+//   - 非 git repo / git 未インストール時は `null` または空配列を返す (fail-safe)
+//   - 外部ネットワーク一切なし、git fetch/push は呼ばない (read-only: log, show, rev-parse)
+//   - stdout は size cap でくくる (非常に大きな repo 対応、現状 16 MiB 上限)
+//
+// 正典: plan/claude/26042402_visualizer-concept-sketch.md §View 1 / §View 2
+
+import { spawn } from 'node:child_process';
+
+const MAX_STDOUT_BYTES = 16 * 1024 * 1024; // 16 MiB
+const GIT_CMD = 'git';
+
+export class GitHistoryError extends Error {
+  constructor(message, code = 'git_error') {
+    super(message);
+    this.name = 'GitHistoryError';
+    this.code = code;
+  }
+}
+
+// 内部: git コマンドを spawn で実行し、stdout/stderr/code を返す
+// args は必ず配列で渡す (shell injection 回避)
+async function runGit(cwd, args) {
+  if (!Array.isArray(args) || args.some((a) => typeof a !== 'string')) {
+    throw new GitHistoryError('git args must be array of strings', 'invalid_args');
+  }
+  return new Promise((resolve) => {
+    const child = spawn(GIT_CMD, args, {
+      cwd,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env, GIT_TERMINAL_PROMPT: '0', LC_ALL: 'C' },
+    });
+    const stdoutChunks = [];
+    const stderrChunks = [];
+    let stdoutBytes = 0;
+    let truncated = false;
+
+    child.stdout.on('data', (chunk) => {
+      if (stdoutBytes + chunk.length > MAX_STDOUT_BYTES) {
+        truncated = true;
+        const remaining = MAX_STDOUT_BYTES - stdoutBytes;
+        if (remaining > 0) {
+          stdoutChunks.push(chunk.subarray(0, remaining));
+          stdoutBytes = MAX_STDOUT_BYTES;
+        }
+        child.kill('SIGTERM');
+        return;
+      }
+      stdoutChunks.push(chunk);
+      stdoutBytes += chunk.length;
+    });
+    child.stderr.on('data', (chunk) => stderrChunks.push(chunk));
+    child.on('error', (err) => {
+      // ENOENT (git not installed) etc. — resolve で error を返す (throw しない)
+      resolve({ code: -1, stdout: '', stderr: err.message, truncated: false, error: err });
+    });
+    child.on('close', (code) => {
+      resolve({
+        code,
+        stdout: Buffer.concat(stdoutChunks).toString('utf8'),
+        stderr: Buffer.concat(stderrChunks).toString('utf8'),
+        truncated,
+      });
+    });
+  });
+}
+
+// vaultDir が git repo かどうか判定 (rev-parse --git-dir で安価に)
+export async function isGitRepo(vaultDir) {
+  if (typeof vaultDir !== 'string' || vaultDir.length === 0) return false;
+  const res = await runGit(vaultDir, ['rev-parse', '--is-inside-work-tree']);
+  if (res.code !== 0) return false;
+  return res.stdout.trim() === 'true';
+}
+
+// since は ISO 8601 date (例: "2026-01-01") もしくは git が受理する任意書式
+// subPath は vault-relative (例: "wiki/" / "wiki/index.md")、空なら全体
+// maxCommits は安全上限 (default 1000)
+// 返り値: [{ sha, shortSha, timestamp (ms since epoch), author, subject, files: [paths...] }]
+// git が無い or repo じゃない場合は空配列
+export async function getFileHistory(vaultDir, options = {}) {
+  if (!(await isGitRepo(vaultDir))) return [];
+  const { since, subPath = '', maxCommits = 1000 } = options;
+  if (typeof maxCommits !== 'number' || maxCommits < 1 || maxCommits > 100000) {
+    throw new GitHistoryError('maxCommits out of range (1..100000)', 'invalid_args');
+  }
+  if (typeof subPath !== 'string') {
+    throw new GitHistoryError('subPath must be string', 'invalid_args');
+  }
+  const args = [
+    'log',
+    '--name-only',
+    '--no-decorate',
+    '--no-merges',
+    `--max-count=${maxCommits}`,
+    // 区切り用の sentinel を使う (改行を含むファイル名にも耐える想定、
+    // ただし git は newline 含むパスを別の escape で出すので完全ではない)
+    '--format=COMMIT\x1f%H\x1f%h\x1f%ct\x1f%an\x1f%s',
+  ];
+  if (since) args.push(`--since=${since}`);
+  args.push('--');
+  if (subPath) args.push(subPath);
+
+  const res = await runGit(vaultDir, args);
+  if (res.code !== 0) return [];
+  return parseGitLogOutput(res.stdout);
+}
+
+// 単一 commit の指定ファイル内容を取得、不在時は null
+export async function getFileContentAtCommit(vaultDir, sha, relPath) {
+  if (typeof sha !== 'string' || !/^[0-9a-f]{4,40}$/.test(sha)) {
+    throw new GitHistoryError('invalid sha format', 'invalid_args');
+  }
+  if (typeof relPath !== 'string' || relPath.length === 0) {
+    throw new GitHistoryError('relPath must be non-empty string', 'invalid_args');
+  }
+  if (relPath.includes('\0') || relPath.length > 4096) {
+    throw new GitHistoryError('invalid relPath', 'invalid_args');
+  }
+  const res = await runGit(vaultDir, ['show', `${sha}:${relPath}`]);
+  if (res.code !== 0) {
+    // non-existent file at that commit は正常ケース → null
+    return null;
+  }
+  return res.stdout;
+}
+
+// 指定 commit での wiki/ 配下の md file 一覧 (path のみ)
+// 実際の tree を ls-tree で listing (log より確実)
+export async function listFilesAtCommit(vaultDir, sha, { subPath = 'wiki/' } = {}) {
+  if (typeof sha !== 'string' || !/^[0-9a-f]{4,40}$/.test(sha)) {
+    throw new GitHistoryError('invalid sha format', 'invalid_args');
+  }
+  const args = ['ls-tree', '-r', '--name-only', sha];
+  if (subPath) args.push('--', subPath);
+  const res = await runGit(vaultDir, args);
+  if (res.code !== 0) return [];
+  return res.stdout.split('\n').filter((l) => l.length > 0);
+}
+
+// 内部 parser: git log の stdout を commit 配列に
+// format: "COMMIT\x1f<sha>\x1f<short>\x1f<unixtime>\x1f<author>\x1f<subject>\n<file>\n<file>\n\nCOMMIT..."
+export function parseGitLogOutput(stdout) {
+  if (typeof stdout !== 'string' || stdout.length === 0) return [];
+  const commits = [];
+  const blocks = stdout.split('COMMIT\x1f').slice(1); // 先頭は空
+  for (const block of blocks) {
+    const lines = block.split('\n');
+    const headerLine = lines[0];
+    if (!headerLine) continue;
+    const parts = headerLine.split('\x1f');
+    if (parts.length < 5) continue;
+    const [sha, shortSha, ctStr, author, subject] = parts;
+    const ts = Number(ctStr);
+    if (!Number.isFinite(ts)) continue;
+    const files = lines.slice(1).filter((l) => l.length > 0);
+    commits.push({
+      sha,
+      shortSha,
+      timestamp: ts * 1000, // ms since epoch
+      author,
+      subject,
+      files,
+    });
+  }
+  return commits;
+}

--- a/mcp/lib/wiki-snapshot.mjs
+++ b/mcp/lib/wiki-snapshot.mjs
@@ -1,0 +1,207 @@
+// wiki-snapshot.mjs — 指定 git commit での wiki/ 配下のスナップショットを構築
+//
+// 使い方:
+//   const snap = await buildWikiSnapshot(vaultDir, sha);
+//   // snap = { sha, timestamp, pages: [...], links: [...] }
+//
+// Visualizer (Phase D α) が時系列 animation / diff を生成するための input。
+//
+// 設計原則 (plan/claude/26042402 §Security / Trust boundary):
+//   - 本文 (body) は snapshot に含めない (frontmatter + wikilink のみ、漏洩 blast radius 限定)
+//   - applyMasks() を frontmatter 値に適用 (secret 漏洩防御、既存 KIOKU pattern)
+//   - git-history.mjs の spawn-based safe command 経由で read-only
+
+import { parseFrontmatter } from './frontmatter.mjs';
+import { findWikilinks } from './wikilinks.mjs';
+import { maskText as applyMasks } from '../../scripts/lib/masking.mjs';
+import { getFileContentAtCommit, listFilesAtCommit } from './git-history.mjs';
+
+export class WikiSnapshotError extends Error {
+  constructor(message, code = 'snapshot_error') {
+    super(message);
+    this.name = 'WikiSnapshotError';
+    this.code = code;
+  }
+}
+
+// 指定 commit での wiki/ スナップショットを構築
+//
+// 返り値:
+// {
+//   sha: '<full sha>',
+//   timestamp: <ms since epoch、呼び出し側で指定 or null>,
+//   pages: [{
+//     path: 'wiki/concepts/jwt.md',         // vault-relative
+//     name: 'jwt',                           // basename without extension
+//     folder: 'wiki/concepts',               // parent folder (nav/group 用)
+//     type: 'concept',                       // frontmatter type
+//     tags: ['auth', 'security'],            // frontmatter tags
+//     title: 'JWT Authentication',           // frontmatter title (あれば)
+//     wikilinks: ['oauth2', 'session-token'],// [[wikilink]] targets (extension なし)
+//     frontmatter: { ... applyMasks 適用済 } // all frontmatter, secret masked
+//   }, ...],
+//   links: [{ from: 'jwt', to: 'oauth2' }, ...]  // edges (derived from wikilinks)
+// }
+export async function buildWikiSnapshot(vaultDir, sha, options = {}) {
+  if (typeof vaultDir !== 'string' || vaultDir.length === 0) {
+    throw new WikiSnapshotError('vaultDir required', 'invalid_args');
+  }
+  if (typeof sha !== 'string' || !/^[0-9a-f]{4,40}$/.test(sha)) {
+    throw new WikiSnapshotError('invalid sha', 'invalid_args');
+  }
+  const { subPath = 'wiki/', timestamp = null } = options;
+
+  const files = await listFilesAtCommit(vaultDir, sha, { subPath });
+  const mdFiles = files.filter((p) => p.endsWith('.md'));
+
+  const pages = [];
+  const linkSet = new Set(); // 重複 edges を除くため Set of "from\x1fto"
+  for (const relPath of mdFiles) {
+    const content = await getFileContentAtCommit(vaultDir, sha, relPath);
+    if (content === null) continue; // 取得失敗 (rename etc.) は skip
+    const page = parsePage(relPath, content);
+    pages.push(page);
+    for (const target of page.wikilinks) {
+      linkSet.add(`${page.name}\x1f${target}`);
+    }
+  }
+
+  const links = Array.from(linkSet).map((pair) => {
+    const [from, to] = pair.split('\x1f');
+    return { from, to };
+  });
+
+  return { sha, timestamp, pages, links };
+}
+
+// 内部: 1 page を parse
+// frontmatter + wikilinks 抽出、applyMasks で secret 伏字化
+function parsePage(relPath, content) {
+  const parsed = parseFrontmatter(content);
+  // parseFrontmatter() は { data, body } を返す (mcp/lib/frontmatter.mjs 正典)
+  const rawFrontmatter = parsed?.data ?? {};
+  const body = parsed?.body ?? content;
+
+  // frontmatter values に applyMasks を適用
+  const masked = maskFrontmatter(rawFrontmatter);
+
+  const name = basenameWithoutExt(relPath);
+  const folder = parentFolder(relPath);
+  const wikilinks = findWikilinks(body);
+
+  return {
+    path: relPath,
+    name,
+    folder,
+    type: typeof masked.type === 'string' ? masked.type : null,
+    tags: Array.isArray(masked.tags)
+      ? masked.tags.filter((t) => typeof t === 'string')
+      : [],
+    title: typeof masked.title === 'string' ? masked.title : null,
+    wikilinks,
+    frontmatter: masked,
+  };
+}
+
+// frontmatter の各 string value に applyMasks を適用 (shallow)
+// array / nested object は再帰で walk
+function maskFrontmatter(obj) {
+  if (obj === null || typeof obj !== 'object') return obj;
+  if (Array.isArray(obj)) {
+    return obj.map((v) => maskValue(v));
+  }
+  const out = {};
+  for (const [k, v] of Object.entries(obj)) {
+    out[k] = maskValue(v);
+  }
+  return out;
+}
+
+function maskValue(v) {
+  if (typeof v === 'string') return applyMasks(v);
+  if (Array.isArray(v)) return v.map((x) => maskValue(x));
+  if (v !== null && typeof v === 'object') return maskFrontmatter(v);
+  return v;
+}
+
+function basenameWithoutExt(relPath) {
+  const last = relPath.split('/').pop() ?? '';
+  return last.replace(/\.md$/, '');
+}
+
+function parentFolder(relPath) {
+  const parts = relPath.split('/');
+  parts.pop();
+  return parts.join('/');
+}
+
+// 2 snapshot 間の diff を計算 (View 2 Diff Viewer 用)
+// 返り値: { added: [names], removed: [names], modified: [names], linkAdded: [{from,to}], linkRemoved: [{from,to}] }
+export function diffSnapshots(beforeSnap, afterSnap) {
+  if (!beforeSnap || !afterSnap) {
+    throw new WikiSnapshotError('two snapshots required', 'invalid_args');
+  }
+  const beforeByName = indexByName(beforeSnap.pages);
+  const afterByName = indexByName(afterSnap.pages);
+
+  const added = [];
+  const removed = [];
+  const modified = [];
+
+  for (const [name, page] of afterByName) {
+    if (!beforeByName.has(name)) {
+      added.push(name);
+    } else {
+      // shallow compare: tags / type / title / wikilinks 配列
+      const prev = beforeByName.get(name);
+      if (
+        prev.type !== page.type ||
+        prev.title !== page.title ||
+        !arrayEqual(prev.tags, page.tags) ||
+        !arrayEqual(prev.wikilinks, page.wikilinks)
+      ) {
+        modified.push(name);
+      }
+    }
+  }
+  for (const [name] of beforeByName) {
+    if (!afterByName.has(name)) removed.push(name);
+  }
+
+  const beforeEdges = edgeSet(beforeSnap.links);
+  const afterEdges = edgeSet(afterSnap.links);
+  const linkAdded = [];
+  const linkRemoved = [];
+  for (const key of afterEdges) if (!beforeEdges.has(key)) linkAdded.push(splitEdgeKey(key));
+  for (const key of beforeEdges) if (!afterEdges.has(key)) linkRemoved.push(splitEdgeKey(key));
+
+  return { added, removed, modified, linkAdded, linkRemoved };
+}
+
+function indexByName(pages) {
+  const m = new Map();
+  for (const p of pages) m.set(p.name, p);
+  return m;
+}
+
+function edgeSet(links) {
+  const s = new Set();
+  for (const l of links) s.add(`${l.from}\x1f${l.to}`);
+  return s;
+}
+
+function splitEdgeKey(key) {
+  const [from, to] = key.split('\x1f');
+  return { from, to };
+}
+
+function arrayEqual(a, b) {
+  if (!Array.isArray(a) || !Array.isArray(b)) return false;
+  if (a.length !== b.length) return false;
+  const sa = [...a].sort();
+  const sb = [...b].sort();
+  for (let i = 0; i < sa.length; i += 1) {
+    if (sa[i] !== sb[i]) return false;
+  }
+  return true;
+}

--- a/scripts/auto-ingest.sh
+++ b/scripts/auto-ingest.sh
@@ -34,6 +34,36 @@ elapsed_seconds() {
 }
 
 # -----------------------------------------------------------------------------
+# Raw MD sha256 計算 helper (v0.6 Phase C-3)
+# -----------------------------------------------------------------------------
+# raw-sources/<subdir>/<name>.md (fetched/ 以外、ユーザー直接配置) の source_sha256 を
+# 決定する。優先順位:
+#   1. raw MD の frontmatter に `source_sha256: "<64hex>"` があれば、その値を返す
+#   2. 無ければ file binary の sha256 を shasum -a 256 (macOS/BSD) または
+#      sha256sum (Linux) で計算して返す
+#   3. どちらも利用できなければ空文字列 (無判定 = 旧挙動)
+# PDF chunk / EPUB 章 / DOCX / fetched/ は既に source_sha256 を frontmatter に持つため
+# この helper は使わない (既存 .cache/extracted/ loop と fetched/ branch で別 awk)。
+compute_raw_md_sha() {
+  local file="$1"
+  local fm_sha
+  fm_sha="$(awk -F'"' '
+    /^source_sha256:[[:space:]]+"[0-9a-f]{64}"/ { print $2; exit }
+  ' "${file}" 2>/dev/null || true)"
+  if [[ -n "${fm_sha}" ]]; then
+    printf '%s' "${fm_sha}"
+    return 0
+  fi
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "${file}" 2>/dev/null | awk '{print $1}'
+  elif command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "${file}" 2>/dev/null | awk '{print $1}'
+  else
+    printf ''
+  fi
+}
+
+# -----------------------------------------------------------------------------
 # Lockfile (機能 2.1 / VULN-012 完全版)
 # -----------------------------------------------------------------------------
 # MCP (mcp/lib/lock.mjs) と同じ `.kioku-mcp.lock` を共有して cron × MCP の排他を成立させる。
@@ -378,6 +408,45 @@ if [[ -d "${RAW_SOURCES_DIR}" ]] && [[ -f "${EXTRACT_URL_SCRIPT}" ]]; then
   done < <(find "${RAW_SOURCES_DIR}" -type f -name "urls.txt" 2>/dev/null)
 fi
 
+# -----------------------------------------------------------------------------
+# Raw MD sha256 sidecar 生成 (v0.6 Phase C-3)
+# -----------------------------------------------------------------------------
+#
+# raw-sources/<subdir>/<name>.md (fetched/ 以外) の sha256 を .cache/raw-md-sha/ に
+# sidecar として書き出す。LLM は `--allowedTools Write,Read,Edit` で起動されるため
+# shasum を実行できない。raw MD に source_sha256 frontmatter が無いケースでも summary
+# に正しい sha256 を設定できるよう、cron がここで計算した値を sidecar 経由で LLM に渡す。
+#
+# 命名規約: .cache/raw-md-sha/<subdir>-<flat_name>.sha256
+#   - <flat_name> は raw MD の subdir 配下パス (例: nested/foo.md) の `/` を `-` に
+#     変換した形 (raw-sources MD 集計ループの flat_name と同じ規約)
+#   - summary ファイル名 (wiki/summaries/<subdir>-<flat_name>) と 1:1 対応
+#
+# 内容: 64hex + 改行 1 つの 1 行テキスト。LLM が Read してそのまま source_sha256 に
+# コピーしやすい最小フォーマット。
+#
+# 削除: raw MD が削除されても sidecar は残る (後続 PR で GC 検討)。現状は害なし
+# (orphan sidecar は summary 側 sha256 と照合されないだけ)。
+RAW_MD_SHA_DIR="${OBSIDIAN_VAULT}/.cache/raw-md-sha"
+if [[ -d "${RAW_SOURCES_DIR}" ]]; then
+  mkdir -p "${RAW_MD_SHA_DIR}"
+  chmod 0700 "${RAW_MD_SHA_DIR}" 2>/dev/null || true
+  while IFS= read -r f; do
+    [[ -z "${f}" ]] && continue
+    rel="${f#${RAW_SOURCES_DIR}/}"
+    [[ "${rel}" != */* ]] && continue
+    name="${rel#*/}"
+    # fetched/ 配下は extract-url.sh が frontmatter に source_sha256 を書くので sidecar 不要
+    [[ "${name}" == fetched/* ]] && continue
+    subdir="${rel%%/*}"
+    flat_name="${name//\//-}"
+    sha="$(compute_raw_md_sha "${f}" 2>/dev/null || true)"
+    if [[ -n "${sha}" ]]; then
+      printf '%s\n' "${sha}" > "${RAW_MD_SHA_DIR}/${subdir}-${flat_name}.sha256"
+    fi
+  done < <(find "${RAW_SOURCES_DIR}" -type f -name "*.md" 2>/dev/null)
+fi
+
 # `ingested: false` を含む session-log ファイル数をカウント。
 # session-logs/ 直下の *.md のみ対象 (.claude-brain/ 等のサブディレクトリは除外)。
 UNPROCESSED_LOGS=0
@@ -426,6 +495,22 @@ if [[ -d "${RAW_SOURCES_DIR}" ]]; then
       src_sha="$(awk -F'"' '
         /^source_sha256:[[:space:]]+"[0-9a-f]{64}"/ { print $2; exit }
       ' "${f}" 2>/dev/null || true)"
+      if [[ -n "${src_sha}" ]]; then
+        sum_sha="$(awk -F'"' '
+          /^source_sha256:[[:space:]]+"[0-9a-f]{64}"/ { print $2; exit }
+        ' "${summary}" 2>/dev/null || true)"
+        if [[ -z "${sum_sha}" || "${src_sha}" != "${sum_sha}" ]]; then
+          UNPROCESSED_SOURCES=$((UNPROCESSED_SOURCES + 1))
+        fi
+      fi
+    else
+      # v0.6 Phase C-3: fetched/ 以外の raw MD (ユーザー直接配置 / handler 経由でない .md)
+      # にも sha256-based delta detection を適用する。
+      # src_sha = raw MD の frontmatter source_sha256 があればそれ、無ければ file binary
+      #           sha256 (compute_raw_md_sha が 2 段で決定)。
+      # sum_sha = summary の frontmatter source_sha256。
+      # 不一致なら再 Ingest 対象。LLM は後段プロンプトで sidecar 経由に sha256 を書き戻す。
+      src_sha="$(compute_raw_md_sha "${f}")"
       if [[ -n "${src_sha}" ]]; then
         sum_sha="$(awk -F'"' '
           /^source_sha256:[[:space:]]+"[0-9a-f]{64}"/ { print $2; exit }
@@ -524,6 +609,11 @@ CLAUDE.md のスキーマに従って、session-logs/ にある ingested: false 
 - サマリーのフォーマットは templates/notes/source-summary.md または Vault の CLAUDE.md の規約に従う (要約 / 重要なポイント / Wiki への影響)
 - 関連する既存 wiki ページには相互リンクを追加 (raw-sources/ からの事実で既存ページを補強または矛盾を指摘)
 - raw-sources/ は読み取り専用。raw-sources/ のファイルそのものを編集しないこと
+- **source_sha256 の記録 (v0.6 Phase C-3)**: raw-sources/<subdir>/<name>.md から summary を新規作成または更新するときは、対応する wiki/summaries/<subdir>-<flat_name>.md の frontmatter に `source_sha256: "<64hex>"` を必ず設定すること。値は以下の順序で決定する:
+  1. raw MD の frontmatter に `source_sha256: "<64hex>"` があれば、その値を 1 文字違わずコピー
+  2. raw MD に frontmatter source_sha256 が無い場合は、cron が事前計算した sidecar `.cache/raw-md-sha/<subdir>-<flat_name>.sha256` を Read して、中身の 64hex (末尾改行は除く) をコピー。`<flat_name>` は raw MD の subdir 配下パスの `/` を `-` に置換した形 (例: `nested/foo.md` → `nested-foo.md`)
+  3. sidecar も見つからない場合は source_sha256 を設定しない (冪等判定が効かず毎回 re-ingest されるが、副作用はない)
+  この source_sha256 は次回 cron の冪等判定に使われるため正確にコピーすること。raw MD の内容が変わらない限り同じ値が再利用され、LLM の無駄呼び出しを防ぐ。fetched/ 配下の MD は既存通り raw MD の frontmatter から直接コピー (sidecar は生成されない)
 
 追加の取り込み対象 (PDF 由来の .cache/extracted/):
 - .cache/extracted/<subdir>--<stem>-pp<NNN>-<MMM>.md は raw-sources/<subdir>/<stem>.pdf から shell で抽出された中間 MD。raw-sources/ の .md と同等の扱いで Ingest すること

--- a/tests/auto-ingest.test.sh
+++ b/tests/auto-ingest.test.sh
@@ -946,6 +946,203 @@ else
 fi
 
 # -----------------------------------------------------------------------------
+# v0.6 Phase C-3 (Raw MD sha256 delta detection) — F23 / F24 / F25 / F26 / F27
+# -----------------------------------------------------------------------------
+# F23: raw MD frontmatter source_sha256 が summary と一致 → 再 Ingest しない
+# F24: raw MD frontmatter source_sha256 が summary と不一致 → UNPROCESSED_SOURCES++
+# F25: raw MD に frontmatter 無し + summary の source_sha256 が file binary sha256 と
+#      一致 → 再 Ingest しない (file-binary fallback 成功経路)
+# F26: raw MD に frontmatter 無し + summary の source_sha256 が file binary sha256 と
+#      不一致 (raw MD 改変後) → UNPROCESSED_SOURCES++
+# F27: raw MD に frontmatter 無しの場合 sidecar `.cache/raw-md-sha/<subdir>-<flat>.sha256`
+#      が生成される (LLM 向け受け渡し経路) / fetched/ 配下は sidecar 不生成
+# -----------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# Helper: raw MD の file binary sha256 を計算 (test fixture 用)
+# ---------------------------------------------------------------------------
+sha256_of_file() {
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" 2>/dev/null | awk '{print $1}'
+  else
+    sha256sum "$1" 2>/dev/null | awk '{print $1}'
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Test F23: raw MD frontmatter source_sha256 一致 → 再 Ingest しない
+# ---------------------------------------------------------------------------
+echo "test F23: raw MD frontmatter sha256 match → skip"
+VAULT_F23="$(make_vault vault-f23)"
+mkdir -p "${VAULT_F23}/raw-sources/articles" "${VAULT_F23}/wiki/summaries"
+cat > "${VAULT_F23}/raw-sources/articles/karpathy-note.md" <<'EOF'
+---
+title: "Karpathy Note"
+source_sha256: "1111111111111111111111111111111111111111111111111111111111111111"
+---
+body
+EOF
+cat > "${VAULT_F23}/wiki/summaries/articles-karpathy-note.md" <<'EOF'
+---
+title: "Karpathy Note summary"
+source_sha256: "1111111111111111111111111111111111111111111111111111111111111111"
+---
+summary
+EOF
+set +e
+out_f23="$(
+  PATH="${STUB_DIR}:${PATH}" \
+  OBSIDIAN_VAULT="${VAULT_F23}" \
+  KIOKU_DRY_RUN=1 \
+  bash "${AUTO_INGEST}" 2>&1
+)"
+rc=$?
+set -e
+assert_eq "0" "${rc}" "F23 exit code 0"
+assert_contains "${out_f23}" "No unprocessed logs or raw-sources" "F23 matching frontmatter sha256 not re-ingested"
+
+# ---------------------------------------------------------------------------
+# Test F24: raw MD frontmatter source_sha256 不一致 → UNPROCESSED_SOURCES++
+# ---------------------------------------------------------------------------
+echo "test F24: raw MD frontmatter sha256 mismatch → re-ingest"
+VAULT_F24="$(make_vault vault-f24)"
+mkdir -p "${VAULT_F24}/raw-sources/articles" "${VAULT_F24}/wiki/summaries"
+cat > "${VAULT_F24}/raw-sources/articles/note.md" <<'EOF'
+---
+title: "Note"
+source_sha256: "2222222222222222222222222222222222222222222222222222222222222222"
+---
+new body
+EOF
+cat > "${VAULT_F24}/wiki/summaries/articles-note.md" <<'EOF'
+---
+title: "Note (stale summary)"
+source_sha256: "3333333333333333333333333333333333333333333333333333333333333333"
+---
+old summary
+EOF
+set +e
+out_f24="$(
+  PATH="${STUB_DIR}:${PATH}" \
+  OBSIDIAN_VAULT="${VAULT_F24}" \
+  KIOKU_DRY_RUN=1 \
+  bash "${AUTO_INGEST}" 2>&1
+)"
+rc=$?
+set -e
+assert_eq "0" "${rc}" "F24 exit code 0"
+assert_contains "${out_f24}" "Found 0 unprocessed log(s) and 1 unprocessed raw-source" "F24 mismatched frontmatter sha256 re-ingested"
+
+# ---------------------------------------------------------------------------
+# Test F25: raw MD 無 frontmatter + summary の sha256 が file binary と一致 → skip
+# ---------------------------------------------------------------------------
+echo "test F25: raw MD without frontmatter + summary sha matches file-binary → skip"
+VAULT_F25="$(make_vault vault-f25)"
+mkdir -p "${VAULT_F25}/raw-sources/articles" "${VAULT_F25}/wiki/summaries"
+# frontmatter なしの raw MD を配置
+cat > "${VAULT_F25}/raw-sources/articles/plain.md" <<'EOF'
+# plain markdown
+
+no frontmatter here
+EOF
+# file の binary sha256 を summary に書き込む
+RAW_SHA_F25="$(sha256_of_file "${VAULT_F25}/raw-sources/articles/plain.md")"
+cat > "${VAULT_F25}/wiki/summaries/articles-plain.md" <<EOF
+---
+title: "Plain summary"
+source_sha256: "${RAW_SHA_F25}"
+---
+summary
+EOF
+set +e
+out_f25="$(
+  PATH="${STUB_DIR}:${PATH}" \
+  OBSIDIAN_VAULT="${VAULT_F25}" \
+  KIOKU_DRY_RUN=1 \
+  bash "${AUTO_INGEST}" 2>&1
+)"
+rc=$?
+set -e
+assert_eq "0" "${rc}" "F25 exit code 0"
+assert_contains "${out_f25}" "No unprocessed logs or raw-sources" "F25 file-binary sha256 fallback matches → skip"
+
+# ---------------------------------------------------------------------------
+# Test F26: raw MD 無 frontmatter + summary の sha256 が file binary と不一致 → re-ingest
+# ---------------------------------------------------------------------------
+echo "test F26: raw MD without frontmatter + summary sha stale → re-ingest"
+VAULT_F26="$(make_vault vault-f26)"
+mkdir -p "${VAULT_F26}/raw-sources/articles" "${VAULT_F26}/wiki/summaries"
+# raw MD (frontmatter なし) + 古い summary に (意図的に) 異なる sha
+cat > "${VAULT_F26}/raw-sources/articles/plain.md" <<'EOF'
+# updated content
+
+first line changed
+EOF
+cat > "${VAULT_F26}/wiki/summaries/articles-plain.md" <<'EOF'
+---
+title: "Plain (stale)"
+source_sha256: "0000000000000000000000000000000000000000000000000000000000000000"
+---
+summary
+EOF
+set +e
+out_f26="$(
+  PATH="${STUB_DIR}:${PATH}" \
+  OBSIDIAN_VAULT="${VAULT_F26}" \
+  KIOKU_DRY_RUN=1 \
+  bash "${AUTO_INGEST}" 2>&1
+)"
+rc=$?
+set -e
+assert_eq "0" "${rc}" "F26 exit code 0"
+assert_contains "${out_f26}" "Found 0 unprocessed log(s) and 1 unprocessed raw-source" "F26 file-binary sha256 mismatch → re-ingest"
+
+# ---------------------------------------------------------------------------
+# Test F27: sidecar `.cache/raw-md-sha/<subdir>-<flat>.sha256` 生成
+# ---------------------------------------------------------------------------
+echo "test F27: raw MD sha256 sidecar generation"
+VAULT_F27="$(make_vault vault-f27)"
+mkdir -p "${VAULT_F27}/raw-sources/articles" "${VAULT_F27}/raw-sources/ideas/fetched"
+# 直接配置の raw MD (sidecar 生成対象)
+cat > "${VAULT_F27}/raw-sources/articles/note.md" <<'EOF'
+# raw md direct
+
+no frontmatter
+EOF
+# fetched/ 配下 (sidecar 不生成、既存 MED-c1 経路)
+cat > "${VAULT_F27}/raw-sources/ideas/fetched/host-slug.md" <<'EOF'
+---
+title: "fetched"
+source_sha256: "4444444444444444444444444444444444444444444444444444444444444444"
+---
+body
+EOF
+set +e
+PATH="${STUB_DIR}:${PATH}" \
+  OBSIDIAN_VAULT="${VAULT_F27}" \
+  KIOKU_DRY_RUN=1 \
+  bash "${AUTO_INGEST}" >/dev/null 2>&1
+rc=$?
+set -e
+assert_eq "0" "${rc}" "F27 exit code 0"
+EXPECTED_SHA_F27="$(sha256_of_file "${VAULT_F27}/raw-sources/articles/note.md")"
+SIDECAR_F27="${VAULT_F27}/.cache/raw-md-sha/articles-note.md.sha256"
+if [[ -f "${SIDECAR_F27}" ]]; then
+  pass "F27 sidecar created for non-fetched raw MD"
+  ACTUAL_SHA_F27="$(tr -d '[:space:]' < "${SIDECAR_F27}")"
+  assert_eq "${EXPECTED_SHA_F27}" "${ACTUAL_SHA_F27}" "F27 sidecar content matches file binary sha256"
+else
+  fail "F27 sidecar NOT created for non-fetched raw MD at ${SIDECAR_F27}"
+fi
+# fetched/ には sidecar を作らない
+FETCHED_SIDECAR_F27="${VAULT_F27}/.cache/raw-md-sha/ideas-fetched-host-slug.md.sha256"
+if [[ -f "${FETCHED_SIDECAR_F27}" ]]; then
+  fail "F27 sidecar should NOT be created for fetched/ MD"
+else
+  pass "F27 no sidecar for fetched/ MD (frontmatter path preferred)"
+fi
+
+# -----------------------------------------------------------------------------
 # サマリ
 # -----------------------------------------------------------------------------
 echo

--- a/tests/mcp/git-history.test.mjs
+++ b/tests/mcp/git-history.test.mjs
@@ -1,0 +1,229 @@
+// git-history.test.mjs — lib/git-history.mjs のユニットテスト (Phase D α V-1)
+//
+// 実行: node --test tools/claude-brain/tests/mcp/git-history.test.mjs
+//
+// 方針:
+//   - 実 Vault に触らない (mktemp -d で fixture git repo を作る)
+//   - ネットワークなし
+//   - trap 相当で tmpdir クリーンアップ
+//   - spawn-based git 呼び出しを実機 git で検証 (git 未インストール環境では skip)
+//
+// ケース (VIZ-GH-1 〜 6):
+//   VIZ-GH-1: 非 git dir で isGitRepo() === false
+//   VIZ-GH-2: git init 直後の isGitRepo() === true
+//   VIZ-GH-3: commit 履歴を getFileHistory() が時系列で返す
+//   VIZ-GH-4: subPath filter が機能する (wiki/ 限定で一部 commit のみ)
+//   VIZ-GH-5: getFileContentAtCommit() で過去 commit の内容取得、不在は null
+//   VIZ-GH-6: listFilesAtCommit() が指定 commit の md file を列挙
+
+import { test, describe, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  isGitRepo,
+  getFileHistory,
+  getFileContentAtCommit,
+  listFilesAtCommit,
+  parseGitLogOutput,
+} from '../../mcp/lib/git-history.mjs';
+
+// helper: spawn で git コマンドを実行して exit code 0 を待つ
+function runCmd(cwd, cmd, args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, { cwd, stdio: 'ignore' });
+    child.on('error', reject);
+    child.on('close', (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`${cmd} ${args.join(' ')} exited ${code}`));
+    });
+  });
+}
+
+// git が PATH に無い環境での早期 skip 判定
+async function hasGit() {
+  return new Promise((resolve) => {
+    const child = spawn('git', ['--version'], { stdio: 'ignore' });
+    child.on('error', () => resolve(false));
+    child.on('close', (code) => resolve(code === 0));
+  });
+}
+
+async function makeFixtureRepo() {
+  const root = await mkdtemp(join(tmpdir(), 'kioku-git-history-test-'));
+  await runCmd(root, 'git', ['init', '-b', 'main']);
+  await runCmd(root, 'git', ['config', 'user.email', 'test@example.com']);
+  await runCmd(root, 'git', ['config', 'user.name', 'Test User']);
+  return root;
+}
+
+describe('git-history (Phase D α V-1)', () => {
+  let gitAvailable = true;
+
+  before(async () => {
+    gitAvailable = await hasGit();
+  });
+
+  test('VIZ-GH-1: 非 git dir で isGitRepo() === false', async () => {
+    if (!gitAvailable) return;
+    const root = await mkdtemp(join(tmpdir(), 'kioku-git-nongit-'));
+    try {
+      const ok = await isGitRepo(root);
+      assert.equal(ok, false);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('VIZ-GH-2: git init 後の isGitRepo() === true', async () => {
+    if (!gitAvailable) return;
+    const root = await makeFixtureRepo();
+    try {
+      const ok = await isGitRepo(root);
+      assert.equal(ok, true);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('VIZ-GH-3: commit 履歴が時系列で返る (新しい順)', async () => {
+    if (!gitAvailable) return;
+    const root = await makeFixtureRepo();
+    try {
+      await mkdir(join(root, 'wiki'), { recursive: true });
+      await writeFile(join(root, 'wiki', 'a.md'), '# A\n');
+      await runCmd(root, 'git', ['add', '-A']);
+      await runCmd(root, 'git', ['commit', '-m', 'first']);
+
+      await new Promise((r) => setTimeout(r, 1100)); // 1s 以上空けて commit 時刻を差別化
+      await writeFile(join(root, 'wiki', 'b.md'), '# B\n');
+      await runCmd(root, 'git', ['add', '-A']);
+      await runCmd(root, 'git', ['commit', '-m', 'second']);
+
+      const commits = await getFileHistory(root, { subPath: 'wiki/' });
+      assert.equal(commits.length, 2);
+      // 新しい順 (second が先頭)
+      assert.equal(commits[0].subject, 'second');
+      assert.equal(commits[1].subject, 'first');
+      // timestamp 降順
+      assert.ok(commits[0].timestamp >= commits[1].timestamp);
+      // files 配列に touched file が入る
+      assert.ok(commits[0].files.includes('wiki/b.md'));
+      assert.ok(commits[1].files.includes('wiki/a.md'));
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('VIZ-GH-4: subPath filter — 非 wiki/ commit は除外', async () => {
+    if (!gitAvailable) return;
+    const root = await makeFixtureRepo();
+    try {
+      await mkdir(join(root, 'wiki'), { recursive: true });
+      await mkdir(join(root, 'other'), { recursive: true });
+      await writeFile(join(root, 'wiki', 'x.md'), '# X\n');
+      await runCmd(root, 'git', ['add', '-A']);
+      await runCmd(root, 'git', ['commit', '-m', 'wiki change']);
+
+      await new Promise((r) => setTimeout(r, 1100));
+      await writeFile(join(root, 'other', 'y.md'), '# Y\n');
+      await runCmd(root, 'git', ['add', '-A']);
+      await runCmd(root, 'git', ['commit', '-m', 'other change']);
+
+      const commits = await getFileHistory(root, { subPath: 'wiki/' });
+      assert.equal(commits.length, 1);
+      assert.equal(commits[0].subject, 'wiki change');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('VIZ-GH-5: getFileContentAtCommit() — 過去 commit の内容取得、不在は null', async () => {
+    if (!gitAvailable) return;
+    const root = await makeFixtureRepo();
+    try {
+      await mkdir(join(root, 'wiki'), { recursive: true });
+      await writeFile(join(root, 'wiki', 'hot.md'), '# Version 1\n');
+      await runCmd(root, 'git', ['add', '-A']);
+      await runCmd(root, 'git', ['commit', '-m', 'v1']);
+      const commits1 = await getFileHistory(root, { subPath: 'wiki/' });
+      const v1sha = commits1[0].sha;
+
+      await new Promise((r) => setTimeout(r, 1100));
+      await writeFile(join(root, 'wiki', 'hot.md'), '# Version 2\n');
+      await runCmd(root, 'git', ['add', '-A']);
+      await runCmd(root, 'git', ['commit', '-m', 'v2']);
+      const commits2 = await getFileHistory(root, { subPath: 'wiki/' });
+      const v2sha = commits2[0].sha;
+
+      // v1 時点の内容取得
+      const v1 = await getFileContentAtCommit(root, v1sha, 'wiki/hot.md');
+      assert.match(v1, /Version 1/);
+
+      // v2 時点の内容取得
+      const v2 = await getFileContentAtCommit(root, v2sha, 'wiki/hot.md');
+      assert.match(v2, /Version 2/);
+
+      // 不在 file → null
+      const nada = await getFileContentAtCommit(root, v1sha, 'wiki/does-not-exist.md');
+      assert.equal(nada, null);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('VIZ-GH-6: listFilesAtCommit() — 指定 commit の md 列挙', async () => {
+    if (!gitAvailable) return;
+    const root = await makeFixtureRepo();
+    try {
+      await mkdir(join(root, 'wiki', 'concepts'), { recursive: true });
+      await writeFile(join(root, 'wiki', 'index.md'), '# Index\n');
+      await writeFile(join(root, 'wiki', 'concepts', 'jwt.md'), '# JWT\n');
+      await writeFile(join(root, 'wiki', 'concepts', 'oauth.md'), '# OAuth\n');
+      await writeFile(join(root, 'wiki', 'image.png'), 'binary\n'); // 非 md
+      await runCmd(root, 'git', ['add', '-A']);
+      await runCmd(root, 'git', ['commit', '-m', 'init']);
+      const commits = await getFileHistory(root, { subPath: 'wiki/' });
+      const sha = commits[0].sha;
+
+      const files = await listFilesAtCommit(root, sha, { subPath: 'wiki/' });
+      // md + png 全部返る (呼び出し側で md filter する想定)
+      assert.ok(files.includes('wiki/index.md'));
+      assert.ok(files.includes('wiki/concepts/jwt.md'));
+      assert.ok(files.includes('wiki/concepts/oauth.md'));
+      assert.ok(files.includes('wiki/image.png'));
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('VIZ-GH-7: invalid sha は throw', async () => {
+    await assert.rejects(
+      () => getFileContentAtCommit('/tmp', 'not-a-sha', 'wiki/x.md'),
+      /invalid sha/,
+    );
+    await assert.rejects(
+      () => listFilesAtCommit('/tmp', 'xyz!!!', { subPath: 'wiki/' }),
+      /invalid sha/,
+    );
+  });
+
+  test('VIZ-GH-8: parseGitLogOutput unit (stdout parser)', () => {
+    const stdout =
+      'COMMIT\x1fabc123def456\x1fabc123d\x1f1700000000\x1fAlice\x1ffirst commit\nwiki/a.md\nwiki/b.md\n\n' +
+      'COMMIT\x1ffeed1234\x1ffeed123\x1f1700000100\x1fBob\x1fsecond commit\nwiki/c.md\n\n';
+    const commits = parseGitLogOutput(stdout);
+    assert.equal(commits.length, 2);
+    assert.equal(commits[0].sha, 'abc123def456');
+    assert.equal(commits[0].shortSha, 'abc123d');
+    assert.equal(commits[0].timestamp, 1700000000 * 1000);
+    assert.equal(commits[0].author, 'Alice');
+    assert.equal(commits[0].subject, 'first commit');
+    assert.deepEqual(commits[0].files, ['wiki/a.md', 'wiki/b.md']);
+    assert.equal(commits[1].sha, 'feed1234');
+    assert.deepEqual(commits[1].files, ['wiki/c.md']);
+  });
+});

--- a/tests/mcp/wiki-snapshot.test.mjs
+++ b/tests/mcp/wiki-snapshot.test.mjs
@@ -1,0 +1,269 @@
+// wiki-snapshot.test.mjs — lib/wiki-snapshot.mjs のユニットテスト (Phase D α V-1)
+//
+// 実行: node --test tools/claude-brain/tests/mcp/wiki-snapshot.test.mjs
+//
+// ケース (VIZ-WS-1 〜 6):
+//   VIZ-WS-1: 単一 commit snapshot が pages + links を正しく抽出
+//   VIZ-WS-2: frontmatter 値が applyMasks() で伏字化される
+//   VIZ-WS-3: wikilinks が findWikilinks と同じ結果 (extension なし target)
+//   VIZ-WS-4: diffSnapshots 追加 page を added に計上
+//   VIZ-WS-5: diffSnapshots 削除 page を removed に計上
+//   VIZ-WS-6: diffSnapshots wikilink の追加/削除を linkAdded / linkRemoved に分離
+
+import { test, describe, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { buildWikiSnapshot, diffSnapshots } from '../../mcp/lib/wiki-snapshot.mjs';
+import { getFileHistory } from '../../mcp/lib/git-history.mjs';
+
+function runCmd(cwd, cmd, args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, { cwd, stdio: 'ignore' });
+    child.on('error', reject);
+    child.on('close', (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`${cmd} ${args.join(' ')} exited ${code}`));
+    });
+  });
+}
+
+async function hasGit() {
+  return new Promise((resolve) => {
+    const child = spawn('git', ['--version'], { stdio: 'ignore' });
+    child.on('error', () => resolve(false));
+    child.on('close', (code) => resolve(code === 0));
+  });
+}
+
+async function makeFixtureRepo() {
+  const root = await mkdtemp(join(tmpdir(), 'kioku-wiki-snapshot-test-'));
+  await runCmd(root, 'git', ['init', '-b', 'main']);
+  await runCmd(root, 'git', ['config', 'user.email', 'test@example.com']);
+  await runCmd(root, 'git', ['config', 'user.name', 'Test User']);
+  await mkdir(join(root, 'wiki', 'concepts'), { recursive: true });
+  return root;
+}
+
+describe('wiki-snapshot (Phase D α V-1)', () => {
+  let gitAvailable = true;
+
+  before(async () => {
+    gitAvailable = await hasGit();
+  });
+
+  test('VIZ-WS-1: 単一 commit snapshot が pages + links を抽出', async () => {
+    if (!gitAvailable) return;
+    const root = await makeFixtureRepo();
+    try {
+      await writeFile(
+        join(root, 'wiki', 'index.md'),
+        `---
+title: Wiki Index
+type: index
+---
+
+# Wiki
+
+- [[concepts/jwt]]
+- [[concepts/oauth]]
+`,
+      );
+      await writeFile(
+        join(root, 'wiki', 'concepts', 'jwt.md'),
+        `---
+type: concept
+tags: [auth, security]
+---
+
+# JWT
+
+関連: [[oauth]]
+`,
+      );
+      await writeFile(
+        join(root, 'wiki', 'concepts', 'oauth.md'),
+        `---
+type: concept
+tags: [auth]
+---
+
+# OAuth
+`,
+      );
+      await runCmd(root, 'git', ['add', '-A']);
+      await runCmd(root, 'git', ['commit', '-m', 'init wiki']);
+
+      const commits = await getFileHistory(root, { subPath: 'wiki/' });
+      const sha = commits[0].sha;
+      const snap = await buildWikiSnapshot(root, sha);
+
+      assert.equal(snap.sha, sha);
+      assert.equal(snap.pages.length, 3);
+
+      const byName = new Map(snap.pages.map((p) => [p.name, p]));
+      assert.ok(byName.has('index'));
+      assert.ok(byName.has('jwt'));
+      assert.ok(byName.has('oauth'));
+
+      // frontmatter 展開
+      assert.equal(byName.get('jwt').type, 'concept');
+      assert.deepEqual(byName.get('jwt').tags, ['auth', 'security']);
+
+      // wikilinks
+      assert.deepEqual(byName.get('index').wikilinks.sort(), ['concepts/jwt', 'concepts/oauth']);
+      assert.deepEqual(byName.get('jwt').wikilinks, ['oauth']);
+
+      // links edges: index→concepts/jwt, index→concepts/oauth, jwt→oauth
+      assert.equal(snap.links.length, 3);
+      const edgeSet = new Set(snap.links.map((l) => `${l.from}→${l.to}`));
+      assert.ok(edgeSet.has('index→concepts/jwt'));
+      assert.ok(edgeSet.has('index→concepts/oauth'));
+      assert.ok(edgeSet.has('jwt→oauth'));
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('VIZ-WS-2: frontmatter の secret-like 値が applyMasks で伏字化', async () => {
+    if (!gitAvailable) return;
+    const root = await makeFixtureRepo();
+    try {
+      // frontmatter に fake API key を入れる (applyMasks が検出する pattern)
+      await writeFile(
+        join(root, 'wiki', 'leaky.md'),
+        `---
+type: note
+debug_key: "sk-ant-api03-0123456789abcdefghij0123456789abcdefghij"
+---
+
+# Leaky note
+`,
+      );
+      await runCmd(root, 'git', ['add', '-A']);
+      await runCmd(root, 'git', ['commit', '-m', 'leaky']);
+
+      const commits = await getFileHistory(root, { subPath: 'wiki/' });
+      const snap = await buildWikiSnapshot(root, commits[0].sha);
+      const page = snap.pages.find((p) => p.name === 'leaky');
+      assert.ok(page);
+      const debugKey = page.frontmatter.debug_key;
+      assert.ok(!debugKey.includes('0123456789abcdef'), 'raw key leaked to snapshot');
+      assert.match(debugKey, /\*{3,}/);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('VIZ-WS-3: wikilinks が空本文 / alias 付きも処理', async () => {
+    if (!gitAvailable) return;
+    const root = await makeFixtureRepo();
+    try {
+      await writeFile(join(root, 'wiki', 'empty.md'), '# Empty\n\n(no links)\n');
+      await writeFile(
+        join(root, 'wiki', 'alias.md'),
+        '# Alias Test\n\n[[target|Display]] のリンク\n',
+      );
+      await runCmd(root, 'git', ['add', '-A']);
+      await runCmd(root, 'git', ['commit', '-m', 'alias']);
+
+      const commits = await getFileHistory(root, { subPath: 'wiki/' });
+      const snap = await buildWikiSnapshot(root, commits[0].sha);
+
+      const empty = snap.pages.find((p) => p.name === 'empty');
+      assert.deepEqual(empty.wikilinks, []);
+
+      const alias = snap.pages.find((p) => p.name === 'alias');
+      assert.deepEqual(alias.wikilinks, ['target']);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('VIZ-WS-4/5/6: diffSnapshots — 追加/削除/modified + link diff', async () => {
+    if (!gitAvailable) return;
+    const root = await makeFixtureRepo();
+    try {
+      // commit 1: 2 pages, 1 link
+      await writeFile(
+        join(root, 'wiki', 'a.md'),
+        '---\ntype: concept\n---\n# A\n\n[[b]]\n',
+      );
+      await writeFile(
+        join(root, 'wiki', 'b.md'),
+        '---\ntype: concept\n---\n# B\n',
+      );
+      await runCmd(root, 'git', ['add', '-A']);
+      await runCmd(root, 'git', ['commit', '-m', 'v1']);
+      const commits1 = await getFileHistory(root, { subPath: 'wiki/' });
+      const sha1 = commits1[0].sha;
+
+      // commit 2: add c (new page + new link), modify b (tags 追加), delete nothing
+      await new Promise((r) => setTimeout(r, 1100));
+      await writeFile(
+        join(root, 'wiki', 'b.md'),
+        '---\ntype: concept\ntags: [updated]\n---\n# B\n\n[[c]]\n',
+      );
+      await writeFile(
+        join(root, 'wiki', 'c.md'),
+        '---\ntype: concept\n---\n# C\n',
+      );
+      await runCmd(root, 'git', ['add', '-A']);
+      await runCmd(root, 'git', ['commit', '-m', 'v2']);
+      const commits2 = await getFileHistory(root, { subPath: 'wiki/' });
+      const sha2 = commits2[0].sha;
+
+      const snap1 = await buildWikiSnapshot(root, sha1);
+      const snap2 = await buildWikiSnapshot(root, sha2);
+      const d = diffSnapshots(snap1, snap2);
+
+      // added: c
+      assert.deepEqual(d.added, ['c']);
+      // modified: b (tags 追加 + wikilink 追加)
+      assert.ok(d.modified.includes('b'));
+      // removed: なし
+      assert.deepEqual(d.removed, []);
+      // linkAdded: b→c
+      assert.ok(d.linkAdded.some((l) => l.from === 'b' && l.to === 'c'));
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('VIZ-WS-7: diffSnapshots — page 削除を正しく記録', async () => {
+    if (!gitAvailable) return;
+    const root = await makeFixtureRepo();
+    try {
+      await writeFile(join(root, 'wiki', 'keep.md'), '# Keep\n');
+      await writeFile(join(root, 'wiki', 'deleteme.md'), '# DeleteMe\n');
+      await runCmd(root, 'git', ['add', '-A']);
+      await runCmd(root, 'git', ['commit', '-m', 'v1']);
+      const commits1 = await getFileHistory(root, { subPath: 'wiki/' });
+
+      await new Promise((r) => setTimeout(r, 1100));
+      await rm(join(root, 'wiki', 'deleteme.md'));
+      await runCmd(root, 'git', ['add', '-A']);
+      await runCmd(root, 'git', ['commit', '-m', 'v2 deleted']);
+      const commits2 = await getFileHistory(root, { subPath: 'wiki/' });
+
+      const snap1 = await buildWikiSnapshot(root, commits1[0].sha);
+      const snap2 = await buildWikiSnapshot(root, commits2[0].sha);
+      const d = diffSnapshots(snap1, snap2);
+
+      assert.deepEqual(d.removed, ['deleteme']);
+      assert.deepEqual(d.added, []);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('VIZ-WS-8: invalid sha は throw', async () => {
+    await assert.rejects(
+      () => buildWikiSnapshot('/tmp', 'not-a-sha'),
+      /invalid sha/,
+    );
+  });
+});


### PR DESCRIPTION
parent PR #45 sync。raw-sources/<subdir>/*.md (fetched/以外の user 直配置 MD) に sha256 delta 検出を追加。既存 sha256 pipeline と対称な else arm 拡張 + sidecar 中間 file (.cache/raw-md-sha/) + INGEST_PROMPT 指示追記。

## 背景
DOCX/EPUB/PDF/fetched MD は既に sha256 delta 済、raw MD のみ漏れていた narrow gap (製作 Claude の LEARN#4 precheck で PM handoff の 3 factual error を発見、scope 4-6h→1-2h 縮小)。

## Test
- auto-ingest.test.sh: 82/82 green (既存 70 + 新規 F23-F27 12)
- Bash cross-suite: 11 suite clean
- Node MCP: 217/217 green

## Defer
- handoff/open-issues.md §22 に sidecar orphan GC を記録 (機能影響なし、次回 .cache/ 関連 PR に混入予定)

## Related
- parent PR #45
- LEARN#4 (precheck) + LEARN#10 (PM handoff verify) 双方向 safety net が機能した事例
