### PR TITLE
v0.6.0 — Ecosystem expansion (multi-agent + plugin marketplace + Bases + delta + security)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "KIOKU: Hardened LLM Wiki for Claude Code / Claude Desktop by megaphone-tokyo",
-    "version": "0.5.1"
+    "version": "0.6.0"
   },
   "plugins": [
     {
@@ -17,7 +17,7 @@
         "ref": "main"
       },
       "description": "Hardened LLM Wiki for Claude Code + Claude Desktop. Automatic conversation → Obsidian Vault knowledge base. Hot cache + PostCompact hook + secret masking + Git sync.",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "author": {
         "name": "megaphone-tokyo",
         "url": "https://github.com/megaphone-tokyo"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kioku",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "KIOKU — Hardened LLM Wiki for Claude Code + Claude Desktop. Automatic conversation capture to Obsidian Vault, Karpathy LLM Wiki pattern, hot cache + PostCompact hook, secret masking, cross-machine Git sync. Research/legal/enterprise-grade memory for Claude.",
   "author": {
     "name": "megaphone-tokyo",

--- a/mcp/manifest.json
+++ b/mcp/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "kioku-wiki",
   "display_name": "KIOKU Wiki",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Read, search, and write your KIOKU Obsidian Wiki from Claude Desktop or Claude Code.",
   "long_description": "KIOKU is a personal knowledge base ('second brain') built on top of an Obsidian Vault. This MCP server exposes eight tools (kioku_search, kioku_read, kioku_list, kioku_write_note, kioku_write_wiki, kioku_delete, kioku_ingest_pdf, kioku_ingest_url) so that Claude Desktop and Claude Code can browse and update the Wiki without leaving the chat. All operations are local stdio — nothing leaves your machine. See https://github.com/megaphone-tokyo/kioku for the full project.",
   "author": {

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kioku-mcp",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "description": "KIOKU local MCP server (Wiki read/list/search/write_note/write_wiki/delete) for Claude Desktop and Claude Code.",


### PR DESCRIPTION
parent PR #46 sync。Phase C 全 feature land。

## 内容
- Multi-agent cross-platform (C-1)
- Claude Code plugin marketplace (C-2)
- Raw MD sha256 delta tracking (C-3)
- Obsidian Bases dashboard (C-4)
- SECURITY policy upgrade (C-5a、EN + JA 4/7)
- V-1 Visualizer 土台 (v0.7 α 準備)
- LEARN#10 組織知化

## 用 README Changelog 10 言語
EN full / JA full / 他 8 言語 compact

## Release
merge 後 v0.6.0 tag + .mcpb publish を PM が実行。
