### PR TITLE
docs: v0.7.0 Changelog entry を 10 言語 README に展開 (LEARN#11 mandatory)

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -263,6 +263,21 @@ Si encuentras un problema de seguridad, repórtalo a través de [SECURITY.md](SE
 
 ## Cambios
 
+### 2026-04-28 — v0.7.0: Multi-agente completo — Hook port para Gemini / Codex + paridad de session log automatico + Visualizer α
+
+v0.7.0 cierra el "narrative-implementation gap" abierto en v0.6.0. Donde v0.6.0 hizo a KIOKU **discoverable** (skill symlinks), v0.7.0 lo hace **actively work** — automatic session logging, hot-cache pipeline, y per-agent install scripts.
+
+- **Hook port para Gemini / Codex (Q2)** — `hooks/session-logger.mjs` (591 lineas) refactorizado a core + 3 adapters (`hooks/adapters/{claude,gemini,codex}.mjs`). `scripts/install-hooks-{gemini,codex}.sh` para install de un comando
+- **Multi-agent MCP setup docs (Q1)** — `docs/install-guide-multi-agent.md` (EN+JA) con verify commands
+- **Self-recursion guard agent-aware (§43 fix)** — `buildContext({ agent })` solo aplica el guard para `agent === 'claude'`, Gemini/Codex funcionan dentro del vault dir
+- **Visualizer α (V-2)** — `kioku_generate_viz` MCP tool con `safeJsonForScript` XSS hardening
+- **`verify-multi-agent-e2e.sh` helper** — Verificador interactivo de 6 pasos
+- **Manifest tools array reconcile (§32)** — `mcp/manifest.json` actualizado a 10 tools
+- **README branding fix** — `claude-brain` (codename interno) → `KIOKU` / `kioku-vault` en 10 idiomas (kioku PR #30)
+- Pre-release dogfood: Gemini (2026-04-24) + Codex (2026-04-27/28) verificados end-to-end
+- Tests: **Node 136/136 hook suites + Bash all green**
+- [Release v0.7.0](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.7.0)
+
 ### 2026-04-24 — v0.6.0: Expansion del ecosistema — multi-agente + marketplace de plugins + dashboard Bases + delta tracking + endurecimiento de seguridad
 
 v0.6.0 consolida Phase C: canales de distribucion, dashboards nativos de Obsidian, ingest resistente a regresiones, y actualizacion de politica de seguridad.

--- a/README.fr.md
+++ b/README.fr.md
@@ -326,6 +326,20 @@ Si vous trouvez un probleme de securite, veuillez le signaler via [SECURITY.md](
 
 ## Journal des modifications
 
+### 2026-04-28 — v0.7.0 : Multi-agent complet — Hook port pour Gemini / Codex + parite de session log automatique + Visualizer α
+
+v0.7.0 ferme le "narrative-implementation gap" ouvert dans v0.6.0. La ou v0.6.0 a rendu KIOKU **discoverable** (skill symlinks), v0.7.0 le rend **actively work** — automatic session logging, hot-cache pipeline, et per-agent install scripts.
+
+- **Hook port pour Gemini / Codex (Q2)** — `hooks/session-logger.mjs` (591 lignes) refactorise en core + 3 adapters. `scripts/install-hooks-{gemini,codex}.sh` pour install en une commande
+- **Multi-agent MCP setup docs (Q1)** — `docs/install-guide-multi-agent.md` (EN+JA)
+- **Self-recursion guard agent-aware (§43 fix)** — Gemini/Codex fonctionnent maintenant dans le vault dir
+- **Visualizer α (V-2)** — outil MCP `kioku_generate_viz`
+- **`verify-multi-agent-e2e.sh` helper** — verificateur interactif en 6 etapes
+- **Manifest tools array reconcile (§32)** — `mcp/manifest.json` mis a jour a 10 tools
+- **README branding fix** — `claude-brain` → `KIOKU` / `kioku-vault` dans 10 langues (kioku PR #30)
+- Tests : **Node 136/136 hook suites + Bash all green**
+- [Release v0.7.0](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.7.0)
+
 ### 2026-04-24 — v0.6.0 : Expansion de l'ecosysteme — multi-agent + marketplace de plugins + dashboard Bases + delta tracking + durcissement de la securite
 
 v0.6.0 consolide Phase C : canaux de distribution, dashboards natifs Obsidian, ingest resistant aux regressions, et mise a jour de la politique de securite.

--- a/README.hi.md
+++ b/README.hi.md
@@ -263,6 +263,20 @@ KIOKU एक Hook सिस्टम है जो **सभी Claude Code स�
 
 ## परिवर्तन इतिहास
 
+### 2026-04-28 — v0.7.0: Multi-agent complete — Hook port for Gemini / Codex + automatic session log parity + Visualizer α
+
+v0.7.0 v0.6.0 के narrative-implementation gap को बंद करता है। जहां v0.6.0 ने KIOKU को **discoverable** बनाया (skill symlinks), v0.7.0 इसे **actively work** बनाता है — automatic session logging, hot-cache pipeline, और per-agent install scripts.
+
+- **Hook port for Gemini / Codex (Q2)** — `hooks/session-logger.mjs` (591 lines) को core + 3 adapters में refactor। `scripts/install-hooks-{gemini,codex}.sh` से एक command से install
+- **Multi-agent MCP setup docs (Q1)** — `docs/install-guide-multi-agent.md` (EN+JA)
+- **Self-recursion guard agent-aware (§43 fix)** — Gemini/Codex अब vault dir के अंदर भी काम करते हैं
+- **Visualizer α (V-2)** — `kioku_generate_viz` MCP tool
+- **`verify-multi-agent-e2e.sh` helper** — 6-step interactive verifier
+- **Manifest tools array reconcile (§32)** — `mcp/manifest.json` अब 10 tools
+- **README branding fix** — `claude-brain` → `KIOKU` / `kioku-vault` (10 भाषाओं में, kioku PR #30)
+- Tests: **Node 136/136 hook suites + Bash all green**
+- [Release v0.7.0](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.7.0)
+
 ### 2026-04-24 — v0.6.0: Ecosystem expansion — multi-agent + plugin marketplace + Bases dashboard + delta tracking + security hardening
 
 v0.6.0 Phase C को consolidate करता है।

--- a/README.ja.md
+++ b/README.ja.md
@@ -484,6 +484,22 @@ KIOKU は Claude Code の**全セッション入出力にアクセスする Hook
 
 ## 更新履歴
 
+### 2026-04-28 — v0.7.0: マルチエージェント完全対応 — Gemini / Codex Hook port + 自動 session log parity + Visualizer α
+
+v0.7.0 は v0.6.0 で開けた "narrative-実装 gap" を完全に閉じる release。v0.6.0 で **discoverable** だった (skill symlink) KIOKU が、v0.7.0 では **actively work** する状態に。Gemini / Codex でも **自動 session log + masking pipeline + per-agent install script** が同等動作。Visualizer α の最初の user 可視 MCP tool も同時投入。
+
+- **Gemini / Codex Hook port (Q2)** — `hooks/session-logger.mjs` (591 行 monolithic) を `hooks/session-logger-core.mjs` (agent 非依存 core) + `hooks/adapters/{claude,gemini,codex}.mjs` (per-agent adapter) + `hooks/adapters/_common.mjs` (`safeMain` exit-0 contract + `escapeForSystemMessage` XSS 防御) に refactor。`scripts/install-hooks-{gemini,codex}.sh` で 1 コマンド install。**結果**: Gemini / Codex の session が `$OBSIDIAN_VAULT/session-logs/` に Claude と byte-equivalent な log を生成、masking pipeline も同等
+- **マルチエージェント MCP setup docs (Q1)** — `docs/install-guide-multi-agent.md` (EN) + `.ja.md` (JA) に 3 agent (Codex / Gemini / OpenCode) の MCP config 仕様 (`~/.codex/config.toml` / `~/.gemini/settings.json` / `~/.config/opencode/opencode.json`) と verify command を canonical 化。各 agent section に `Verification status: 未検証 (delegation 環境で install 不可)` banner 明示 (LEARN#10 transparency、Q1 PR #54)
+- **Self-recursion guard agent-aware 化 (§43 fix)** — `buildContext({ agent })` の cwd-in-vault 自動 no-op を `agent === 'claude'` のみに narrow。pre-fix では `cd $OBSIDIAN_VAULT && codex` で session log が silent fail (元々 auto-ingest の Claude 再帰防止 guard が all agent に誤適用)、post-fix では Gemini / Codex も vault 内 cwd で正常 log。pre-release dogfood で発見 + 即 fix (PR #60)
+- **Visualizer α (V-2 + V-3/V-4)** — `kioku_generate_viz` MCP tool が `<vault>/wiki/<title>.html` に snapshot JSON 埋め込み + `safeJsonForScript` (`</`, U+2028/U+2029 escape) + DOM-built 描画 (`innerHTML` 一切無し) で静的 HTML 生成。v0.6 で land した V-1 lib (Timeline Player + Diff Viewer) の user 可視化が完成
+- **`verify-multi-agent-e2e.sh` helper** — 6 step interactive verifier (`bash scripts/verify-multi-agent-e2e.sh --agent=<gemini|codex>`)、CLI install check → hook apply → user-driven session → session-log inspect (frontmatter agent tag + masking spot check + Codex per-turn git-sync 計上) を walk-through。本 release から user 自身が install 後 sanity check 可能
+- **Manifest tools array reconcile (§32)** — `mcp/manifest.json` の `tools` 配列を 8 → 10 (`kioku_ingest_document` + `kioku_generate_viz` 追加)、`long_description` も "ten tools" に更新。Q1 delivery 中の 製作 Claude LEARN#4 precheck で発見
+- **README ブランド統一** — 全 10 言語 README に混入していた `claude-brain` (parent monorepo の internal codename) を `KIOKU` (project name) / `kioku-vault` (user vault example) / repo-root path (`tools/claude-brain/scripts/...` → `scripts/...`) に正規化 (kioku PR #30)
+- **Pre-release dogfood verify** — Gemini (2026-04-24) と Codex (2026-04-27 + 28) を RYU 実機 (Mac mini) で end-to-end 動作確認、§43 を release window 内で発見 + fix。詳細: `handoff/post-release-v0-7-0.md` Pre-release verification log
+- **v0.7.1+ へ defer** — V-1 hotfix (HIGH 4 + Medium 9)、§41 (`agent:` frontmatter field)、§42 (Gemini adapter output duplication)、§34 (buildContext realpath fallback)、SECURITY.ja 残 3 section — `handoff/open-issues.md` で tracked
+- テスト: **Node 136/136 hook suites + Bash 全 suite green**、`npm audit` clean
+- [Release v0.7.0](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.7.0) — `kioku-wiki-0.7.0.mcpb` attached
+
 ### 2026-04-24 — v0.6.0: エコシステム拡張 — マルチエージェント + plugin marketplace + Bases dashboard + delta tracking + セキュリティ強化
 
 v0.6.0 は Phase C を一気に land: 配布チャネル拡大 (Claude Code plugin + multi-agent skills)、Obsidian 標準ダッシュボード、silent regression 防御 ingest、security policy 強化。Visualizer の土台 (v0.7 α 向け) も同時投入。

--- a/README.ko.md
+++ b/README.ko.md
@@ -326,6 +326,20 @@ KIOKU은 **모든 Claude Code 세션 입출력**에 접근하는 Hook 시스템�
 
 ## 변경 이력
 
+### 2026-04-28 — v0.7.0: Multi-agent 완성 — Gemini / Codex Hook port + 자동 session log parity + Visualizer α
+
+v0.7.0는 v0.6.0에서 열린 narrative-implementation gap을 닫는 release. v0.6.0이 KIOKU를 **discoverable** (skill symlinks) 하게 만들었다면, v0.7.0은 **actively work** — automatic session logging, hot-cache pipeline, per-agent install scripts.
+
+- **Gemini / Codex Hook port (Q2)** — `hooks/session-logger.mjs` (591 줄)을 core + 3 adapters로 refactor. `scripts/install-hooks-{gemini,codex}.sh`로 one-command install
+- **Multi-agent MCP setup docs (Q1)** — `docs/install-guide-multi-agent.md` (EN+JA)
+- **Self-recursion guard agent-aware (§43 fix)** — Gemini/Codex가 vault dir 내에서도 정상 작동
+- **Visualizer α (V-2)** — `kioku_generate_viz` MCP tool
+- **`verify-multi-agent-e2e.sh` helper** — 6-step interactive verifier
+- **Manifest tools array reconcile (§32)** — `mcp/manifest.json` 10 tools로 업데이트
+- **README branding fix** — `claude-brain` → `KIOKU` / `kioku-vault` (10개 언어, kioku PR #30)
+- Tests: **Node 136/136 hook suites + Bash all green**
+- [Release v0.7.0](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.7.0)
+
 ### 2026-04-24 — v0.6.0: 에코시스템 확장 — multi-agent + plugin marketplace + Bases dashboard + delta tracking + security hardening
 
 v0.6.0는 Phase C를 한 번에 land.

--- a/README.md
+++ b/README.md
@@ -465,6 +465,22 @@ If you find a security issue, please report it via [SECURITY.md](SECURITY.md) �
 
 ## Changelog
 
+### 2026-04-28 — v0.7.0: Multi-agent complete — Hook port for Gemini / Codex + automatic session log parity + Visualizer α
+
+v0.7.0 closes the narrative-implementation gap that v0.6.0 opened: where v0.6.0 made KIOKU **discoverable** across non-Claude agents (skill symlinks), v0.7.0 makes KIOKU **actively work** across them — automatic session logging, hot-cache pipeline, and per-agent install scripts. Visualizer α also ships its first user-visible MCP tool.
+
+- **Hook port for Gemini / Codex (Q2)** — `hooks/session-logger.mjs` (591 lines, monolithic) refactored into `hooks/session-logger-core.mjs` (agent-agnostic core) + `hooks/adapters/{claude,gemini,codex}.mjs` (per-agent translators) + `hooks/adapters/_common.mjs` (`safeMain` exit-0 contract + `escapeForSystemMessage` XSS defense). `scripts/install-hooks-{gemini,codex}.sh` give one-command install per agent. **Result**: a Gemini or Codex session now produces session logs at `$OBSIDIAN_VAULT/session-logs/` byte-equivalent to Claude's, with masking applied through the same pipeline
+- **Multi-agent MCP setup docs (Q1)** — `docs/install-guide-multi-agent.md` (EN) + `.ja.md` (JA) document the per-agent MCP config (`~/.codex/config.toml`, `~/.gemini/settings.json`, `~/.config/opencode/opencode.json`) with verification commands and `Verification status: Unverified in our environment` banners on each agent section (LEARN#10 transparency, Q1 PR #54)
+- **Self-recursion guard agent-aware (§43 fix)** — `buildContext({ agent })` now narrows the cwd-in-vault no-op rule to `agent === 'claude'` only. Pre-fix, running `cd $OBSIDIAN_VAULT && codex` silently dropped session logs because the guard (originally for auto-ingest re-entrance) fired for all agents. Post-fix, Gemini and Codex log normally even when started from inside the vault. Caught and fixed during pre-release dogfood (PR #60)
+- **Visualizer α (V-2 + V-3/V-4)** — `kioku_generate_viz` MCP tool generates a static HTML page (`<vault>/wiki/<title>.html`) with embedded snapshot JSON, sanitized via `safeJsonForScript` (escapes `</`, U+2028/U+2029) + DOM-built rendering (zero `innerHTML`). The Timeline Player and Diff Viewer surfaces from V-1 lib (already in v0.6) become user-callable
+- **`verify-multi-agent-e2e.sh` helper** — Interactive 6-step verifier (`bash scripts/verify-multi-agent-e2e.sh --agent=<gemini|codex>`) walks through CLI install check → hook apply → user-driven session → session-log inspection (frontmatter agent tag + masking spot check + Codex per-turn git-sync count). Ships in this release for users to confirm their setup beyond the `.mcpb` install
+- **Manifest tools array reconciled (§32)** — `mcp/manifest.json` now lists all 10 MCP tools (was 8; `kioku_ingest_document` and `kioku_generate_viz` were missing since v0.5.0/v0.6.0). `long_description` updated to "ten tools". Catches via 製作 Claude's LEARN#4 precheck during Q1 delivery
+- **README branding fix** — Public READMEs (10 languages) had `claude-brain` (parent monorepo internal codename) leaking through into project descriptions, command paths (`tools/claude-brain/scripts/...`), and vault example names. All references corrected to `KIOKU` / `kioku-vault` / repo-root paths (kioku PR #30)
+- **Pre-release dogfood verify** — Gemini (2026-04-24) and Codex (2026-04-27 + 28) verified end-to-end on RYU's Mac mini before tag publication. §43 caught and fixed in the same release window. Details: `handoff/post-release-v0-7-0.md` Pre-release verification log
+- **Deferred for v0.7.1+** — V-1 hotfix (HIGH 4 + Medium 9 from V-1 review), §41 (`agent:` frontmatter field), §42 (Gemini adapter output duplication), §34 (`buildContext` realpath fallback), `SECURITY.ja.md` remaining 3 sections — all tracked in `handoff/open-issues.md`
+- Tests: **Node 136/136 hook suites + Bash all green**, `npm audit` clean
+- [Release v0.7.0](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.7.0) — `kioku-wiki-0.7.0.mcpb` attached
+
 ### 2026-04-24 — v0.6.0: Ecosystem expansion — multi-agent + plugin marketplace + Bases dashboard + delta tracking + security hardening
 
 v0.6.0 lands Phase C in one shot: distribution channels (Claude Code plugin + multi-agent skills), Obsidian-native dashboards, silent-regression-proof ingest, and security policy upgrades. Visualizer foundations are also land-ready for v0.7.

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -326,6 +326,20 @@ Se voce encontrar um problema de seguranca, por favor reporte via [SECURITY.md](
 
 ## Histórico de mudanças
 
+### 2026-04-28 — v0.7.0: Multi-agente completo — Hook port para Gemini / Codex + paridade de session log automatico + Visualizer α
+
+v0.7.0 fecha o "narrative-implementation gap" aberto em v0.6.0. Onde v0.6.0 tornou KIOKU **discoverable** (skill symlinks), v0.7.0 o torna **actively work** — automatic session logging, hot-cache pipeline, e per-agent install scripts.
+
+- **Hook port para Gemini / Codex (Q2)** — `hooks/session-logger.mjs` (591 linhas) refatorado em core + 3 adapters. `scripts/install-hooks-{gemini,codex}.sh` para install em um comando
+- **Multi-agent MCP setup docs (Q1)** — `docs/install-guide-multi-agent.md` (EN+JA)
+- **Self-recursion guard agent-aware (§43 fix)** — Gemini/Codex agora funcionam dentro do vault dir
+- **Visualizer α (V-2)** — ferramenta MCP `kioku_generate_viz`
+- **`verify-multi-agent-e2e.sh` helper** — verificador interativo em 6 passos
+- **Manifest tools array reconcile (§32)** — `mcp/manifest.json` atualizado para 10 tools
+- **README branding fix** — `claude-brain` → `KIOKU` / `kioku-vault` em 10 idiomas (kioku PR #30)
+- Tests: **Node 136/136 hook suites + Bash all green**
+- [Release v0.7.0](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.7.0)
+
 ### 2026-04-24 — v0.6.0: Expansao do ecossistema — multi-agente + marketplace de plugins + dashboard Bases + delta tracking + endurecimento de seguranca
 
 v0.6.0 consolida Phase C.

--- a/README.ru.md
+++ b/README.ru.md
@@ -331,6 +331,20 @@ KIOKU спроектирован для **совместного использ�
 
 ## История изменений
 
+### 2026-04-28 — v0.7.0: Multi-agent завершён — Hook port для Gemini / Codex + parity автоматического session log + Visualizer α
+
+v0.7.0 закрывает "narrative-implementation gap", открытый в v0.6.0. Где v0.6.0 сделал KIOKU **discoverable** (skill symlinks), v0.7.0 делает его **actively work** — automatic session logging, hot-cache pipeline, per-agent install scripts.
+
+- **Hook port для Gemini / Codex (Q2)** — `hooks/session-logger.mjs` (591 строка) рефакторен в core + 3 adapters. `scripts/install-hooks-{gemini,codex}.sh` для install в одну команду
+- **Multi-agent MCP setup docs (Q1)** — `docs/install-guide-multi-agent.md` (EN+JA)
+- **Self-recursion guard agent-aware (§43 fix)** — Gemini/Codex теперь работают внутри vault dir
+- **Visualizer α (V-2)** — MCP tool `kioku_generate_viz`
+- **`verify-multi-agent-e2e.sh` helper** — интерактивный 6-step verifier
+- **Manifest tools array reconcile (§32)** — `mcp/manifest.json` обновлён до 10 tools
+- **README branding fix** — `claude-brain` → `KIOKU` / `kioku-vault` на 10 языках (kioku PR #30)
+- Tests: **Node 136/136 hook suites + Bash all green**
+- [Release v0.7.0](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.7.0)
+
 ### 2026-04-24 — v0.6.0: Расширение экосистемы — multi-agent + plugin marketplace + Bases dashboard + delta tracking + усиление безопасности
 
 v0.6.0 объединяет Phase C.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -331,6 +331,20 @@ KIOKU 是一个可以访问**所有 Claude Code 会话输入输出**的 Hook 系
 
 ## 更新历史
 
+### 2026-04-28 — v0.7.0：多代理完整支持 — Gemini / Codex Hook port + 自动 session log parity + Visualizer α
+
+v0.7.0 关闭了 v0.6.0 中打开的 narrative-implementation gap。v0.6.0 让 KIOKU **discoverable** (skill symlinks)，v0.7.0 让它 **actively work** — automatic session logging、hot-cache pipeline、per-agent install scripts。
+
+- **Gemini / Codex Hook port (Q2)** — `hooks/session-logger.mjs` (591 行) 重构为 core + 3 adapters。`scripts/install-hooks-{gemini,codex}.sh` 一键 install
+- **Multi-agent MCP setup docs (Q1)** — `docs/install-guide-multi-agent.md` (EN+JA)
+- **Self-recursion guard agent-aware (§43 fix)** — Gemini/Codex 现在可在 vault dir 内正常运行
+- **Visualizer α (V-2)** — MCP 工具 `kioku_generate_viz`
+- **`verify-multi-agent-e2e.sh` helper** — 6 步交互式验证器
+- **Manifest tools array reconcile (§32)** — `mcp/manifest.json` 更新为 10 tools
+- **README branding fix** — `claude-brain` → `KIOKU` / `kioku-vault` 涵盖 10 种语言 (kioku PR #30)
+- Tests: **Node 136/136 hook suites + Bash all green**
+- [Release v0.7.0](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.7.0)
+
 ### 2026-04-24 — v0.6.0：生态系统扩展 — 多代理 + 插件 marketplace + Bases 仪表板 + delta tracking + 安全加固
 
 v0.6.0 整合 Phase C。

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -331,6 +331,20 @@ KIOKU 是一個存取**所有 Claude Code 工作階段 I/O** 的 Hook 系統。
 
 ## 更新歷史
 
+### 2026-04-28 — v0.7.0：多代理完整支援 — Gemini / Codex Hook port + 自動 session log parity + Visualizer α
+
+v0.7.0 關閉了 v0.6.0 中開啟的 narrative-implementation gap。v0.6.0 讓 KIOKU **discoverable** (skill symlinks)，v0.7.0 讓它 **actively work** — automatic session logging、hot-cache pipeline、per-agent install scripts。
+
+- **Gemini / Codex Hook port (Q2)** — `hooks/session-logger.mjs` (591 行) 重構為 core + 3 adapters。`scripts/install-hooks-{gemini,codex}.sh` 一鍵 install
+- **Multi-agent MCP setup docs (Q1)** — `docs/install-guide-multi-agent.md` (EN+JA)
+- **Self-recursion guard agent-aware (§43 fix)** — Gemini/Codex 現在可在 vault dir 內正常運行
+- **Visualizer α (V-2)** — MCP 工具 `kioku_generate_viz`
+- **`verify-multi-agent-e2e.sh` helper** — 6 步互動式驗證器
+- **Manifest tools array reconcile (§32)** — `mcp/manifest.json` 更新為 10 tools
+- **README branding fix** — `claude-brain` → `KIOKU` / `kioku-vault` 涵蓋 10 種語言 (kioku PR #30)
+- Tests: **Node 136/136 hook suites + Bash all green**
+- [Release v0.7.0](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.7.0)
+
 ### 2026-04-24 — v0.6.0：生態系統擴展 — 多代理 + 插件 marketplace + Bases 儀表板 + delta tracking + 安全強化
 
 v0.6.0 整合 Phase C。


### PR DESCRIPTION
## Summary

v0.7.0 release 公開直前の README Changelog 追加 (parent release PR #61 merged 後の kioku-side 直接 push、LEARN#11 sync boundary cycle Step 4)。

10 言語に v0.7.0 entry を上に追加 (v0.6.0 entry より上)。EN/JA は full prose 形式、他 8 言語は compact bulleted (各言語の v0.6.0 style mirror)。

## 内容 (全 10 言語共通の柱)

- Q2 Hook port (Gemini/Codex 自動 session log)
- Q1 multi-agent MCP setup docs
- §43 buildContext agent-aware fix
- Visualizer α (kioku_generate_viz MCP tool)
- verify-multi-agent-e2e.sh helper
- §32 manifest tools 10 reconcile
- README branding fix (kioku PR #30)
- Pre-release dogfood verify (Gemini 4/24 + Codex 4/27-28)

## Next step (本 PR merge 後)

- post-release-sync.sh で parent app/ 整合
- .mcpb build (10 tools metadata verify)
- tag v0.7.0 + GitHub Release publish + .mcpb attach

🤖 Generated with [Claude Code](https://claude.com/claude-code)