### PR TITLE
docs: §44 install syntax fix (10 README + parent sync)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,5 @@
 {
-  "name": "kioku-marketplace",
+  "name": "megaphone-tokyo",
   "owner": {
     "name": "megaphone-tokyo",
     "url": "https://github.com/megaphone-tokyo"

--- a/README.es.md
+++ b/README.es.md
@@ -283,7 +283,7 @@ v0.7.0 cierra el "narrative-implementation gap" abierto en v0.6.0. Donde v0.6.0 
 v0.6.0 consolida Phase C: canales de distribucion, dashboards nativos de Obsidian, ingest resistente a regresiones, y actualizacion de politica de seguridad.
 
 - **Multi-agente cross-platform (C-1)** — `scripts/setup-multi-agent.sh` crea symlinks en Codex / OpenCode / Gemini CLI. 19/19 aserciones Bash
-- **Marketplace Claude Code (C-2)** — `claude marketplace add megaphone-tokyo/kioku && claude plugin install kioku@megaphone-tokyo`
+- **Marketplace Claude Code (C-2)** — `claude plugin marketplace add megaphone-tokyo/kioku && claude plugin install kioku@megaphone-tokyo`
 - **Delta tracking sha256 (C-3)** — Archivos MD colocados en `raw-sources/<subdir>/*.md` ahora participan en la deteccion delta. 82/82 aserciones auto-ingest
 - **Dashboard Obsidian Bases (C-4)** — `templates/wiki/meta/dashboard.base` con 9 vistas
 - **Cimientos Visualizer (V-1, v0.7)** — `mcp/lib/git-history.mjs` + `mcp/lib/wiki-snapshot.mjs`, 14/14 aserciones Node

--- a/README.fr.md
+++ b/README.fr.md
@@ -345,7 +345,7 @@ v0.7.0 ferme le "narrative-implementation gap" ouvert dans v0.6.0. La ou v0.6.0 
 v0.6.0 consolide Phase C : canaux de distribution, dashboards natifs Obsidian, ingest resistant aux regressions, et mise a jour de la politique de securite.
 
 - **Multi-agent cross-platform (C-1)** — `scripts/setup-multi-agent.sh` cree des symlinks dans Codex / OpenCode / Gemini CLI. 19/19 assertions Bash
-- **Marketplace Claude Code (C-2)** — `claude marketplace add megaphone-tokyo/kioku && claude plugin install kioku@megaphone-tokyo`
+- **Marketplace Claude Code (C-2)** — `claude plugin marketplace add megaphone-tokyo/kioku && claude plugin install kioku@megaphone-tokyo`
 - **Delta tracking sha256 (C-3)** — Les fichiers MD places dans `raw-sources/<subdir>/*.md` participent a la detection delta. 82/82 assertions auto-ingest
 - **Dashboard Obsidian Bases (C-4)** — `templates/wiki/meta/dashboard.base` avec 9 vues
 - **Fondations Visualizer (V-1, v0.7)** — `mcp/lib/git-history.mjs` + `mcp/lib/wiki-snapshot.mjs`, 14/14 assertions Node

--- a/README.hi.md
+++ b/README.hi.md
@@ -282,7 +282,7 @@ v0.7.0 v0.6.0 के narrative-implementation gap को बंद करता 
 v0.6.0 Phase C को consolidate करता है।
 
 - **Multi-agent cross-platform (C-1)** — `scripts/setup-multi-agent.sh` Codex CLI / OpenCode / Gemini CLI में KIOKU skills symlink। 19/19 Bash assertions
-- **Claude Code plugin marketplace (C-2)** — `claude marketplace add megaphone-tokyo/kioku && claude plugin install kioku@megaphone-tokyo` से install
+- **Claude Code plugin marketplace (C-2)** — `claude plugin marketplace add megaphone-tokyo/kioku && claude plugin install kioku@megaphone-tokyo` से install
 - **Raw MD sha256 delta tracking (C-3)** — `raw-sources/<subdir>/*.md` के MD files भी sha256 delta detection में participate। 82/82 auto-ingest assertions
 - **Obsidian Bases dashboard (C-4)** — `templates/wiki/meta/dashboard.base` में 9 views
 - **Visualizer foundations (V-1, v0.7 preparation)** — `mcp/lib/git-history.mjs` + `mcp/lib/wiki-snapshot.mjs`, 14/14 Node assertions

--- a/README.ja.md
+++ b/README.ja.md
@@ -505,7 +505,7 @@ v0.7.0 は v0.6.0 で開けた "narrative-実装 gap" を完全に閉じる rele
 v0.6.0 は Phase C を一気に land: 配布チャネル拡大 (Claude Code plugin + multi-agent skills)、Obsidian 標準ダッシュボード、silent regression 防御 ingest、security policy 強化。Visualizer の土台 (v0.7 α 向け) も同時投入。
 
 - **マルチエージェント cross-platform (C-1)** — `scripts/setup-multi-agent.sh` で Codex CLI / OpenCode / Gemini CLI に KIOKU skills を symlink 配置。19/19 Bash アサーション (SMA-1..8)
-- **Claude Code plugin marketplace (C-2)** — `claude marketplace add megaphone-tokyo/kioku && claude plugin install kioku@megaphone-tokyo` で install 可能。`docs/install-guide-plugin.md` で 3 install 方法比較
+- **Claude Code plugin marketplace (C-2)** — `claude plugin marketplace add megaphone-tokyo/kioku && claude plugin install kioku@megaphone-tokyo` で install 可能。`docs/install-guide-plugin.md` で 3 install 方法比較
 - **Raw MD sha256 delta tracking (C-3)** — user が `raw-sources/<subdir>/*.md` に直接配置した MD も sha256 delta 検出対象に。82/82 auto-ingest assertions (新規 F23-F27)
 - **Obsidian Bases dashboard (C-4)** — `templates/wiki/meta/dashboard.base` に KIOKU wiki 構造に合わせた 9 view (Hot Cache / Active Projects / Recent Activity / Concepts / Design Decisions / Analyses / Patterns / Bugs / Stale Pages)
 - **Visualizer 土台 (V-1、v0.7 α 準備)** — `mcp/lib/git-history.mjs` + `mcp/lib/wiki-snapshot.mjs`、14/14 Node アサーション。user 可視効果はまだなし

--- a/README.ko.md
+++ b/README.ko.md
@@ -345,7 +345,7 @@ v0.7.0는 v0.6.0에서 열린 narrative-implementation gap을 닫는 release. v0
 v0.6.0는 Phase C를 한 번에 land.
 
 - **멀티 에이전트 cross-platform (C-1)** — `scripts/setup-multi-agent.sh`로 Codex / OpenCode / Gemini CLI에 KIOKU skills symlink. 19/19 Bash assertions
-- **Claude Code plugin marketplace (C-2)** — `claude marketplace add megaphone-tokyo/kioku && claude plugin install kioku@megaphone-tokyo`
+- **Claude Code plugin marketplace (C-2)** — `claude plugin marketplace add megaphone-tokyo/kioku && claude plugin install kioku@megaphone-tokyo`
 - **Raw MD sha256 delta tracking (C-3)** — `raw-sources/<subdir>/*.md` MD도 sha256 delta 검출 대상. 82/82 auto-ingest assertions
 - **Obsidian Bases dashboard (C-4)** — `templates/wiki/meta/dashboard.base` 9 view
 - **Visualizer 기반 (V-1, v0.7 α 준비)** — `mcp/lib/git-history.mjs` + `mcp/lib/wiki-snapshot.mjs` + 14/14 Node assertions

--- a/README.md
+++ b/README.md
@@ -486,7 +486,7 @@ v0.7.0 closes the narrative-implementation gap that v0.6.0 opened: where v0.6.0 
 v0.6.0 lands Phase C in one shot: distribution channels (Claude Code plugin + multi-agent skills), Obsidian-native dashboards, silent-regression-proof ingest, and security policy upgrades. Visualizer foundations are also land-ready for v0.7.
 
 - **Multi-agent cross-platform (C-1)** — `scripts/setup-multi-agent.sh` symlinks KIOKU skills into Codex CLI / OpenCode / Gemini CLI. 19/19 Bash assertions (SMA-1..8)
-- **Claude Code plugin marketplace (C-2)** — `claude marketplace add megaphone-tokyo/kioku && claude plugin install kioku@megaphone-tokyo`. `docs/install-guide-plugin.md` compares 3 install paths
+- **Claude Code plugin marketplace (C-2)** — `claude plugin marketplace add megaphone-tokyo/kioku && claude plugin install kioku@megaphone-tokyo`. `docs/install-guide-plugin.md` compares 3 install paths
 - **Raw MD sha256 delta tracking (C-3)** — User-placed `raw-sources/<subdir>/*.md` files now participate in sha256-based delta detection. 82/82 auto-ingest assertions (new F23-F27)
 - **Obsidian Bases dashboard (C-4)** — `templates/wiki/meta/dashboard.base` ships 9 views tailored to KIOKU's wiki structure
 - **Visualizer foundation (V-1, preparing v0.7)** — `mcp/lib/git-history.mjs` + `mcp/lib/wiki-snapshot.mjs` with 14/14 Node assertions. No user-facing surface yet

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -345,7 +345,7 @@ v0.7.0 fecha o "narrative-implementation gap" aberto em v0.6.0. Onde v0.6.0 torn
 v0.6.0 consolida Phase C.
 
 - **Multi-agente cross-platform (C-1)** — `scripts/setup-multi-agent.sh` cria symlinks no Codex / OpenCode / Gemini CLI. 19/19 asserções Bash
-- **Marketplace Claude Code (C-2)** — `claude marketplace add megaphone-tokyo/kioku && claude plugin install kioku@megaphone-tokyo`
+- **Marketplace Claude Code (C-2)** — `claude plugin marketplace add megaphone-tokyo/kioku && claude plugin install kioku@megaphone-tokyo`
 - **Delta tracking sha256 (C-3)** — Arquivos MD em `raw-sources/<subdir>/*.md` participam da deteccao delta. 82/82 asserções auto-ingest
 - **Dashboard Obsidian Bases (C-4)** — `templates/wiki/meta/dashboard.base` com 9 views
 - **Fundacoes Visualizer (V-1, v0.7)** — `mcp/lib/git-history.mjs` + `mcp/lib/wiki-snapshot.mjs`, 14/14 asserções Node

--- a/README.ru.md
+++ b/README.ru.md
@@ -350,7 +350,7 @@ v0.7.0 закрывает "narrative-implementation gap", открытый в v0
 v0.6.0 объединяет Phase C.
 
 - **Multi-agent cross-platform (C-1)** — `scripts/setup-multi-agent.sh` создаёт symlinks в Codex / OpenCode / Gemini CLI. 19/19 Bash-утверждений
-- **Claude Code plugin marketplace (C-2)** — `claude marketplace add megaphone-tokyo/kioku && claude plugin install kioku@megaphone-tokyo`
+- **Claude Code plugin marketplace (C-2)** — `claude plugin marketplace add megaphone-tokyo/kioku && claude plugin install kioku@megaphone-tokyo`
 - **Raw MD sha256 delta tracking (C-3)** — MD в `raw-sources/<subdir>/*.md` участвуют в sha256-дельта. 82/82 auto-ingest утверждений
 - **Obsidian Bases dashboard (C-4)** — `templates/wiki/meta/dashboard.base` с 9 видами
 - **Основы Visualizer (V-1, v0.7)** — `mcp/lib/git-history.mjs` + `mcp/lib/wiki-snapshot.mjs`, 14/14 Node-утверждений

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -350,7 +350,7 @@ v0.7.0 关闭了 v0.6.0 中打开的 narrative-implementation gap。v0.6.0 让 K
 v0.6.0 整合 Phase C。
 
 - **多代理 cross-platform (C-1)** — `scripts/setup-multi-agent.sh` 将 KIOKU skills 符号链接到 Codex / OpenCode / Gemini CLI。19/19 Bash 断言
-- **Claude Code plugin marketplace (C-2)** — `claude marketplace add megaphone-tokyo/kioku && claude plugin install kioku@megaphone-tokyo`
+- **Claude Code plugin marketplace (C-2)** — `claude plugin marketplace add megaphone-tokyo/kioku && claude plugin install kioku@megaphone-tokyo`
 - **Raw MD sha256 delta tracking (C-3)** — `raw-sources/<subdir>/*.md` 的 MD 参与 sha256 delta 检测。82/82 auto-ingest 断言
 - **Obsidian Bases 仪表板 (C-4)** — `templates/wiki/meta/dashboard.base` 9 种视图
 - **Visualizer 基础 (V-1，v0.7 α 准备)** — `mcp/lib/git-history.mjs` + `mcp/lib/wiki-snapshot.mjs`，14/14 Node 断言

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -350,7 +350,7 @@ v0.7.0 關閉了 v0.6.0 中開啟的 narrative-implementation gap。v0.6.0 讓 K
 v0.6.0 整合 Phase C。
 
 - **多代理 cross-platform (C-1)** — `scripts/setup-multi-agent.sh` 將 KIOKU skills 符號連結到 Codex / OpenCode / Gemini CLI。19/19 Bash 斷言
-- **Claude Code plugin marketplace (C-2)** — `claude marketplace add megaphone-tokyo/kioku && claude plugin install kioku@megaphone-tokyo`
+- **Claude Code plugin marketplace (C-2)** — `claude plugin marketplace add megaphone-tokyo/kioku && claude plugin install kioku@megaphone-tokyo`
 - **Raw MD sha256 delta tracking (C-3)** — `raw-sources/<subdir>/*.md` 的 MD 參與 sha256 delta 檢測。82/82 auto-ingest 斷言
 - **Obsidian Bases 儀表板 (C-4)** — `templates/wiki/meta/dashboard.base` 9 種視圖
 - **Visualizer 基礎 (V-1，v0.7 α 準備)** — `mcp/lib/git-history.mjs` + `mcp/lib/wiki-snapshot.mjs`，14/14 Node 斷言

--- a/docs/install-guide-plugin.md
+++ b/docs/install-guide-plugin.md
@@ -25,7 +25,7 @@ KIOKU は 3 つのインストール方法があります:
 
 ```bash
 # 1. marketplace を登録 (初回のみ)
-claude marketplace add megaphone-tokyo/kioku
+claude plugin marketplace add megaphone-tokyo/kioku
 
 # 2. plugin install
 claude plugin install kioku@megaphone-tokyo
@@ -141,7 +141,7 @@ rm ~/Library/LaunchAgents/com.kioku.*.plist
 
 | 症状 | 原因 | 解決 |
 |---|---|---|
-| `claude plugin install` で not found | marketplace 未登録 | `claude marketplace add megaphone-tokyo/kioku` を先に実行 |
+| `claude plugin install` で not found | marketplace 未登録 | `claude plugin marketplace add megaphone-tokyo/kioku` を先に実行 |
 | session log が生成されない | Hook が `~/.claude/settings.json` に入っていない | `install-hooks.sh --apply` を再実行 |
 | hot.md が LLM に届かない | `$OBSIDIAN_VAULT` env 未設定 / Vault 外シムリンク escape | `echo $OBSIDIAN_VAULT` で確認、`realpath` で link 先確認 |
 | auto-ingest が動かない | LaunchAgent / cron 未インストール | `install-schedule.sh` を実行 / `launchctl list | grep kioku` で確認 |


### PR DESCRIPTION
## Summary

- 10 README files (1 per language): \`claude marketplace add\` → \`claude plugin marketplace add\` (Claude Code v2.1.89 syntax)
- Parent sync (commit \`dc1716e\`): \`marketplace.json\` name rename + \`install-guide-plugin.md\` syntax fix

## Background (§44)

v0.7.0 release 後の install path verification で判明した docs ↔ 実装 drift を解消。

1. **identifier**: parent \`marketplace.json\` name を \`kioku-marketplace\` → \`megaphone-tokyo\` に rename (parent PR #64 で land 済、本 PR の \`dc1716e\` 経由で kioku next に到達)
2. **command syntax**: 10 README + install-guide で \`claude marketplace add\` → \`claude plugin marketplace add\` (本 PR で land)

LEARN#11 sync boundary trap 回避のため、README は parent → kioku の sync-to-app では運ばれない。本 PR で kioku 側に直接 commit + 親 repo からの sync commit を同梱。

## Test plan

- [x] \`claude plugin marketplace add megaphone-tokyo/kioku\` 後、\`kioku@megaphone-tokyo\` で install できることを RYU 環境で確認 (parent PR で検証済)
- [ ] post-release-sync で parent app/ が kioku main と整合 (next step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)