### PR TITLE
Sync from parent (defer docs §37/§39/§40)

### DIFF
--- a/docs/install-guide-multi-agent.ja.md
+++ b/docs/install-guide-multi-agent.ja.md
@@ -129,6 +129,27 @@ tool 名が見えるはずです。Codex の MCP tool 表示方法は活発に�
 schema 齟齬が見つかった場合は [Issues](https://github.com/megaphone-tokyo/kioku/issues)
 で報告お願いします。
 
+### Per-turn commit に関する注意 (Hook port も併用する場合のみ)
+
+`bash scripts/install-hooks-codex.sh --apply` (Q2 Hook port、v0.7.0) を
+実行した場合のみ該当します。**Codex CLI には `SessionEnd` event が無い** ため、
+KIOKU は Claude のセッション終了時 `git add/commit/push` を **`Stop` event (=
+turn 終了) で代替** しています。つまり **1 Codex session で数十 commit が
+発生し得る** — `wiki/` / `raw-sources/` / `templates/` / `CLAUDE.md` を
+変更した turn ごとに 1 commit。変更が無い turn は git が空 commit を拒否
+するので silent skip されます (turn 数ではなく実 edit 数で bound)。
+
+`git log` の noise が許容できない場合:
+
+- `git log --oneline` で定期的に実 churn を確認
+- 2 段目 git-sync hook のみを disable: `~/.codex/hooks.json` の `Stop`
+  配列 2 番目の shell one-liner entry を削除 (1 段目の
+  `node hooks/adapters/codex.mjs` entry は残す → session log local 記録は継続、
+  GitHub 自動 push のみ停止)
+- これは bug ではなく既知の設計トレードオフ。Codex CLI 側の SessionEnd
+  サポートは [issue #17333](https://github.com/openai/codex/issues/17333) で
+  追跡中
+
 ## Gemini CLI
 
 出典: [google-gemini/gemini-cli — `docs/tools/mcp-server.md`](https://github.com/google-gemini/gemini-cli/blob/main/docs/tools/mcp-server.md)

--- a/docs/install-guide-multi-agent.md
+++ b/docs/install-guide-multi-agent.md
@@ -128,6 +128,26 @@ listing is not obvious.
 report any schema mismatch observed against a specific Codex CLI version via
 [Issues](https://github.com/megaphone-tokyo/kioku/issues).
 
+### Note on per-turn commits (only if you also install the Hook port)
+
+If you have run `bash scripts/install-hooks-codex.sh --apply` (Q2 Hook port,
+v0.7.0), be aware that **Codex CLI lacks a `SessionEnd` event**, so KIOKU
+emulates the Claude end-of-session `git add/commit/push` step on the `Stop`
+event (= turn end). This means **a single Codex session can produce dozens of
+commits** — one per turn that touched `wiki/` / `raw-sources/` / `templates/` /
+`CLAUDE.md`. Turns with no changes are silently skipped (git refuses empty
+commits), so the count is bounded by actual edits, not by turn count alone.
+
+If the resulting `git log` noise is unacceptable for your workflow:
+
+- Inspect with `git log --oneline` periodically to gauge real churn.
+- Disable only the second-stage git-sync hook by removing the shell one-liner
+  entry from `~/.codex/hooks.json` (the `Stop` array's second element). The
+  first-stage `node hooks/adapters/codex.mjs` entry will continue to record
+  session logs locally — only the auto-push to GitHub stops.
+- This is a known design trade-off, not a bug. SessionEnd support is tracked
+  in Codex CLI [issue #17333](https://github.com/openai/codex/issues/17333).
+
 ## Gemini CLI
 
 Source: [google-gemini/gemini-cli — `docs/tools/mcp-server.md`](https://github.com/google-gemini/gemini-cli/blob/main/docs/tools/mcp-server.md)


### PR DESCRIPTION
## Summary

Parent repo v0.7.1 docs front-load:

- §37 CODEX-PER-TURN-PUSH-DOC: \`docs/install-guide-multi-agent.md\` + \`.ja.md\` の Codex CLI section に「Note on per-turn commits」追加 (Hook port 利用時のみ該当)

(§39 LEARN#13 / §40 LEARN#14 は parent-only な \`.claude/rules/code-style.md\` 編集のため本 sync には含まれない)

## Origin

- Parent PR: https://github.com/megaphone-kurata/claude-tools/pull/67
- Origin issue: \`handoff/open-issues.md\` §37 (2026-04-24 Q2 PR #56 review defer、2026-04-28 RESOLVED)

🤖 Generated with [Claude Code](https://claude.com/claude-code)