### PR TITLE
v0.7.1 release: multi-agent agent: field + hardening 5 件 + workflow codification

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "KIOKU: Hardened LLM Wiki for Claude Code / Claude Desktop by megaphone-tokyo",
-    "version": "0.7.0"
+    "version": "0.7.1"
   },
   "plugins": [
     {
@@ -17,7 +17,7 @@
         "ref": "main"
       },
       "description": "Hardened LLM Wiki for Claude Code + Claude Desktop. Automatic conversation → Obsidian Vault knowledge base. Hot cache + PostCompact hook + secret masking + Git sync.",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "author": {
         "name": "megaphone-tokyo",
         "url": "https://github.com/megaphone-tokyo"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kioku",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "KIOKU — Hardened LLM Wiki for Claude Code + Claude Desktop. Automatic conversation capture to Obsidian Vault, Karpathy LLM Wiki pattern, hot cache + PostCompact hook, secret masking, cross-machine Git sync. Research/legal/enterprise-grade memory for Claude.",
   "author": {
     "name": "megaphone-tokyo",

--- a/hooks/adapters/_common.mjs
+++ b/hooks/adapters/_common.mjs
@@ -4,18 +4,28 @@
 // agent に依存しない sanitizer を提供する。core (session-logger-core.mjs)
 // と重複する logic は置かず、adapter boundary 固有のもののみ。
 
+import { homedir } from 'node:os';
+import { join, sep } from 'node:path';
+import { realpath } from 'node:fs/promises';
+
+// §38 fix: process listener register を module-scope gate で 1 process 内 1 回のみに
+// 限定する。以前は safeMain 呼び出し毎に process.on(...) が register され、同一
+// process 内で safeMain が複数回実行 (test harness で複数 adapter を import +
+// 起動する scenario など) されると listener が累積し MaxListenersExceededWarning
+// に到達する risk があった (open-issues §38、原典 plan/claude/26042408 §3 item 7)。
+let _crashListenersRegistered = false;
+
 /**
- * 全 adapter の entry は必ず safeMain を経由する (MF5、plan 26042405 §Task 3)。
- * Claude Code / Gemini CLI / Codex CLI のどれでも hook が throw したり
- * unhandledRejection を発生させても、**exit 0 を返して親 CLI をブロックしない** 契約。
+ * `unhandledRejection` / `uncaughtException` の crash listener を idempotent
+ * に register する。同一 process 内で複数回呼んでも追加 listener を生まない。
  *
- * 使い方:
- *   import { safeMain } from './_common.mjs';
- *   safeMain(async () => { ... });  // ファイル末尾で呼ぶ
- *
- * @param {() => Promise<void>} entryFn
+ * test 用に export している: safeMain 全体を実行すると entry 完了時に
+ * `process.exit(0)` が走り test process が落ちるため、gate logic だけを
+ * 直接 unit test するための分離 entry。production では safeMain から透過的
+ * に呼ばれるため adapter は import 不要。
  */
-export function safeMain(entryFn) {
+export function ensureCrashListenersIdempotent() {
+  if (_crashListenersRegistered) return;
   process.on('unhandledRejection', (err) => {
     try {
       process.stderr.write(`[claude-brain] unhandledRejection: ${err && err.message}\n`);
@@ -33,13 +43,101 @@ export function safeMain(entryFn) {
     }
     process.exit(0);
   });
+  _crashListenersRegistered = true;
+}
 
+/**
+ * 全 adapter の entry は必ず safeMain を経由する (MF5、plan 26042405 §Task 3)。
+ * Claude Code / Gemini CLI / Codex CLI のどれでも hook が throw したり
+ * unhandledRejection を発生させても、**exit 0 を返して親 CLI をブロックしない** 契約。
+ *
+ * 使い方:
+ *   import { safeMain } from './_common.mjs';
+ *   safeMain(async () => { ... });  // ファイル末尾で呼ぶ
+ *
+ * @param {() => Promise<void>} entryFn
+ */
+export function safeMain(entryFn) {
+  ensureCrashListenersIdempotent();
   Promise.resolve()
     .then(() => entryFn())
     .then(
       () => process.exit(0),
       () => process.exit(0),
     );
+}
+
+// -----------------------------------------------------------------------------
+// §36 fix: transcript path safe-root boundary check
+// -----------------------------------------------------------------------------
+
+// agent 別 transcript safe root allowlist。
+// CLI (Claude Code / Gemini CLI / Codex CLI) が信用できる前提で、敵対的 hook stdin
+// injection (CLI binary が compromised される scenario) に対する defense-in-depth。
+// 現実的 threat model に入る前に、agent-specific 既知 path 以外を core が読み込む
+// 経路を塞ぐ (open-issues §36、原典 plan/claude/26042408 §3 item 4)。
+//
+// homedir() は呼び出し時に評価して HOME env 変更 (test harness) を反映する。
+function computeTranscriptSafeRoots(agent) {
+  const home = homedir();
+  const map = {
+    claude: [join(home, '.claude', 'projects')],
+    // Gemini CLI は research/gemini-cli-hook-spec.md で transcript_path 確定なし。
+    // 既知候補 (.gemini/chats / .gemini/sessions) を共に許容。
+    gemini: [join(home, '.gemini', 'chats'), join(home, '.gemini', 'sessions')],
+    codex: [join(home, '.codex', 'sessions')],
+  };
+  return map[agent] || null;
+}
+
+export class TranscriptPathError extends Error {
+  constructor(reason) {
+    super(`assertTranscriptInRoot: ${reason}`);
+    this.code = reason;
+  }
+}
+
+/**
+ * `transcript_path` が agent 既知の safe root subpath か prefix check する。
+ * realpath を通すため symlink escape も検出する。`/etc/passwd` 等 vault 外
+ * 任意 path を core (session-logger-core.mjs) に渡さないための adapter boundary
+ * gate。
+ *
+ * - 不適切な agent / 非文字列 path / realpath 失敗 → throw `TranscriptPathError`
+ * - safe root subpath → resolve した real path を返す
+ * - safe root 外 → throw `TranscriptPathError('OUTSIDE_SAFE_ROOTS')`
+ *
+ * @param {'claude'|'gemini'|'codex'} agent
+ * @param {string} transcriptPath
+ * @returns {Promise<string>} resolved real path (safe)
+ */
+export async function assertTranscriptInRoot(agent, transcriptPath) {
+  if (typeof transcriptPath !== 'string' || transcriptPath.length === 0) {
+    throw new TranscriptPathError('PATH_NOT_STRING');
+  }
+  const roots = computeTranscriptSafeRoots(agent);
+  if (!roots) throw new TranscriptPathError('UNKNOWN_AGENT');
+
+  let realTranscript;
+  try {
+    realTranscript = await realpath(transcriptPath);
+  } catch (err) {
+    throw new TranscriptPathError(`REALPATH_FAILED:${(err && err.code) || 'UNKNOWN'}`);
+  }
+
+  for (const root of roots) {
+    let realRoot;
+    try {
+      realRoot = await realpath(root);
+    } catch {
+      // root が存在しない agent (このマシンに該当 CLI 未 install) は skip
+      continue;
+    }
+    if (realTranscript === realRoot || realTranscript.startsWith(realRoot + sep)) {
+      return realTranscript;
+    }
+  }
+  throw new TranscriptPathError('OUTSIDE_SAFE_ROOTS');
 }
 
 /**

--- a/hooks/adapters/claude.mjs
+++ b/hooks/adapters/claude.mjs
@@ -13,7 +13,7 @@
 import { pathToFileURL } from 'node:url';
 
 import { buildContext, envTruthy, ingestNormalizedEvent, readStdin } from '../session-logger-core.mjs';
-import { escapeForSystemMessage, safeMain } from './_common.mjs';
+import { assertTranscriptInRoot, escapeForSystemMessage, safeMain } from './_common.mjs';
 
 // -----------------------------------------------------------------------------
 // Claude Code v2 hook_event_name → NormalizedEvent.eventName
@@ -142,6 +142,18 @@ export async function main() {
 
   const normEv = claudePayloadToNormalizedEvent(payload);
   if (!normEv) return;
+
+  // §36 fix: transcript_path を core が無条件で stat/open/read する前に safe root
+  // boundary check。allowlist 外 (敵対的 stdin injection 等) は transcriptPath
+  // field を drop して silent fallback (Claude には inline text 無いので assistant_stop
+  // は no-op 化、log は欠損するが filesystem boundary は保護される)。
+  if (normEv.eventName === 'assistant_stop' && normEv.assistantResponse?.transcriptPath) {
+    try {
+      await assertTranscriptInRoot(normEv.agent, normEv.assistantResponse.transcriptPath);
+    } catch {
+      delete normEv.assistantResponse.transcriptPath;
+    }
+  }
 
   try {
     await ingestNormalizedEvent(normEv, ctx);

--- a/hooks/adapters/codex.mjs
+++ b/hooks/adapters/codex.mjs
@@ -22,7 +22,7 @@
 import { pathToFileURL } from 'node:url';
 
 import { buildContext, envTruthy, ingestNormalizedEvent, readStdin } from '../session-logger-core.mjs';
-import { safeMain } from './_common.mjs';
+import { assertTranscriptInRoot, safeMain } from './_common.mjs';
 
 // -----------------------------------------------------------------------------
 // Codex CLI hook_event_name → NormalizedEvent.eventName
@@ -133,6 +133,16 @@ export async function main() {
 
   const normEv = codexPayloadToNormalizedEvent(payload);
   if (!normEv) return;
+
+  // §36 fix: transcript_path safe root boundary check (Codex は inline
+  // `last_assistant_message` を持つため transcriptPath drop でも text fallback で続行)。
+  if (normEv.eventName === 'assistant_stop' && normEv.assistantResponse?.transcriptPath) {
+    try {
+      await assertTranscriptInRoot(normEv.agent, normEv.assistantResponse.transcriptPath);
+    } catch {
+      delete normEv.assistantResponse.transcriptPath;
+    }
+  }
 
   try {
     await ingestNormalizedEvent(normEv, ctx);

--- a/hooks/adapters/gemini.mjs
+++ b/hooks/adapters/gemini.mjs
@@ -13,7 +13,7 @@
 import { pathToFileURL } from 'node:url';
 
 import { buildContext, envTruthy, ingestNormalizedEvent, readStdin } from '../session-logger-core.mjs';
-import { safeMain } from './_common.mjs';
+import { assertTranscriptInRoot, safeMain } from './_common.mjs';
 
 // -----------------------------------------------------------------------------
 // Gemini CLI hook_event_name → NormalizedEvent.eventName
@@ -166,6 +166,17 @@ export async function main() {
 
   const normEv = geminiPayloadToNormalizedEvent(payload);
   if (!normEv) return;
+
+  // §36 fix: transcript_path safe root boundary check (allowlist 外は drop、
+  // Gemini は inline `prompt_response` text を別途持つため assistant_stop は
+  // text fallback で続行可能)。
+  if (normEv.eventName === 'assistant_stop' && normEv.assistantResponse?.transcriptPath) {
+    try {
+      await assertTranscriptInRoot(normEv.agent, normEv.assistantResponse.transcriptPath);
+    } catch {
+      delete normEv.assistantResponse.transcriptPath;
+    }
+  }
 
   try {
     await ingestNormalizedEvent(normEv, ctx);

--- a/hooks/session-logger-core.mjs
+++ b/hooks/session-logger-core.mjs
@@ -274,28 +274,87 @@ export function newSessionEntry(fileName, isoDate, transcriptPath) {
 // index.lock (SF1: BLUE-CORE-CONCURRENT-1 / 3 child proc 並列 100 event)
 // -----------------------------------------------------------------------------
 
+// §33 fix: process.kill(pid, 0) で alive check (open-issues §33、原典 plan/
+// claude/26042408 §3 item 1)。EPERM は existence の証 (kill perm は無いが process は
+// 存在)、ESRCH は no-such-process。それ以外は alive 扱いで保守的に倒す
+// (race の中で誤って alive な lock を奪わない pessimistic 判定)。
+function isProcessAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    if (err && err.code === 'EPERM') return true;
+    return false;
+  }
+}
+
+async function readLockPid(lockPath) {
+  try {
+    const content = await readFile(lockPath, 'utf8');
+    const parsed = parseInt(content.trim(), 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+// §33 fix: index.lock TOCTOU race 対策 (open-issues §33)。
+//
+// 旧実装の race window:
+//   1. process A が 'wx' で lock 取得、PID=A を write
+//   2. process B が stat(lock) → mtime stale 判定 → unlink → 'wx' で再取得
+//      (A の lock を steal してしまう)、PID=B を write
+//   3. process A は自分が lock を所有していると思って index 書き込み、release で
+//      lockPath を unlink → B の現有 lock を消す事故が起き得る
+//
+// 防御 2 段:
+//   (a) **Steal 前に PID alive check**: stale な mtime でも owner PID が alive なら
+//       steal しない (process が遅いだけかもしれない)。dead PID / unparseable /
+//       自 PID (orphan) のみ steal する。
+//   (b) **取得後に content re-verify**: 'wx' 成功直後に lock の中身を読み戻し、
+//       自分の PID が残っていることを確認する。race で奪われていたら retry。
 async function acquireIndexLock(ctx) {
   const lockPath = `${ctx.indexPath}.lock`;
-  const deadline = Date.now() + 5_000; // 5s 待機上限
+  const deadline = Date.now() + 5_000;
+  const myPid = String(process.pid);
   while (true) {
     try {
       const fh = await open(lockPath, 'wx', 0o600);
       try {
-        await fh.write(String(process.pid));
+        await fh.write(myPid);
       } finally {
         await fh.close();
+      }
+      // (b) 取得後 content verify: race で奪われた場合 retry
+      const ownerPid = await readLockPid(lockPath);
+      if (ownerPid !== process.pid) {
+        if (Date.now() > deadline) {
+          throw new Error('index.lock timeout');
+        }
+        await new Promise((r) => setTimeout(r, 10 + Math.random() * 30));
+        continue;
       }
       return lockPath;
     } catch (err) {
       if (!err || err.code !== 'EEXIST') {
         throw err;
       }
-      // 既存 lock: 古ければ steal
+      // 既存 lock: stale 判定 + (a) PID alive check で steal 可否を決定
       try {
         const s = await stat(lockPath);
         if (Date.now() - s.mtimeMs > INDEX_LOCK_STALE_MS) {
-          await unlink(lockPath);
-          continue;
+          const ownerPid = await readLockPid(lockPath);
+          if (ownerPid === null || !isProcessAlive(ownerPid)) {
+            // 安全に steal: unparseable content / dead owner
+            // (自 pid match は steal 条件にしない: 同 Node process 内の Promise.all
+            //  並列 ingest で全 instance が process.pid を共有するため、self-pid
+            //  shortcut は in-process double-acquire 事故を起こす)
+            await unlink(lockPath).catch(() => {});
+            continue;
+          }
+          // alive owner: stale mtime でも steal しない (process が遅いだけかも)、
+          // deadline まで待機 retry
         }
       } catch {
         // stat 失敗 → 次周回で再 open 試行
@@ -325,6 +384,12 @@ export function buildFrontmatter(normEv, ts) {
   const lines = [
     '---',
     'type: session-log',
+    // §41 fix (v0.7.1): agent field を type: 直後に emit。multi-agent (claude /
+    // gemini / codex) の session log を frontmatter で識別可能にする。
+    // normEv.agent は validateNormalizedEvent (BLUE-CORE-VAL-5) で AGENT_NAMES
+    // closed enum 検証済のため theoretical injection 不可。defense-in-depth で
+    // yamlSafeValue を必ず通す (既存 cwd / sessionId と同じ pattern)。
+    `agent: ${yamlSafeValue(normEv.agent)}`,
     `session_id: ${yamlSafeValue(normEv.sessionId)}`,
     `hostname: ${yamlSafeValue(hostname())}`,
     `cwd: ${yamlSafeValue(normEv.cwd || '')}`,
@@ -521,7 +586,12 @@ async function handleToolUse(normEv, ctx, index, entry, ts) {
 
 async function handleSessionEnd(normEv, ctx, index, entry, ts) {
   const c = entry.counters;
-  const exitReason = normEv.sessionEnd?.reason || 'unknown';
+  // §35 fix: reason は CLI が現状 enum 文字列のみを入れるが、将来 vendor schema
+  // drift で free-form 文字列に拡張される可能性に備え、他の user-controlled
+  // field と同様 mask + yamlSafeValue を必ず通す (open-issues §35、原典 plan/
+  // claude/26042408 §3 item 3)。
+  const rawReason = normEv.sessionEnd?.reason || 'unknown';
+  const exitReason = yamlSafeValue(mask(rawReason));
   const body = [
     '',
     '---',
@@ -588,7 +658,20 @@ export async function buildContext({ agent = 'claude' } = {}) {
       const realVault = await realpath(vault);
       const realCwd = await realpath(process.cwd());
       if (realCwd === realVault || realCwd.startsWith(realVault + '/')) return null;
-    } catch {
+    } catch (err) {
+      // §34 fix: realpath 失敗 (EROFS / ENOENT / EACCES on symlink target 等) は
+      // throw せず literal path で best-effort fallback compare を継続する。
+      // 観測性のため KIOKU_DEBUG=1 のときだけ stderr に warn を出す
+      // (open-issues §34、原典 plan/claude/26042408 §3 item 2)。
+      if (envTruthy(process.env.KIOKU_DEBUG)) {
+        try {
+          process.stderr.write(
+            `[claude-brain] buildContext realpath fallback: ${(err && err.message) || 'unknown'}\n`,
+          );
+        } catch {
+          /* ignore */
+        }
+      }
       const cwd = process.cwd();
       if (cwd === vault || cwd.startsWith(vault + '/')) return null;
     }

--- a/mcp/manifest.json
+++ b/mcp/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "kioku-wiki",
   "display_name": "KIOKU Wiki",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Read, search, and write your KIOKU Obsidian Wiki from Claude Desktop or Claude Code.",
   "long_description": "KIOKU is a personal knowledge base ('second brain') built on top of an Obsidian Vault. This MCP server exposes ten tools (kioku_search, kioku_read, kioku_list, kioku_write_note, kioku_write_wiki, kioku_delete, kioku_ingest_pdf, kioku_ingest_url, kioku_ingest_document, kioku_generate_viz) so that Claude Desktop and Claude Code can browse and update the Wiki without leaving the chat. All operations are local stdio — nothing leaves your machine. See https://github.com/megaphone-tokyo/kioku for the full project.",
   "author": {

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kioku-mcp",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": true,
   "type": "module",
   "description": "KIOKU local MCP server (Wiki read/list/search/write_note/write_wiki/delete) for Claude Desktop and Claude Code.",

--- a/scripts/verify-multi-agent-e2e.sh
+++ b/scripts/verify-multi-agent-e2e.sh
@@ -312,16 +312,15 @@ verify_session_logs() {
   echo ""
 
   # agent tag check (frontmatter 内 agent: <agent>)
-  # v0.7.0 時点: buildFrontmatter は agent field を emit しない (byte-identical regression guard
-  # 優先のため)、open-issues §41 AGENT-FRONTMATTER-FIELD で v0.7.1 実装予定。
-  # → 検出できなくても informational only、他の evidence (session_id 新規 / date 今日 /
-  #   mtime recent / hostname 一致 / filename = 入力 prompt) で Gemini/Codex session
-  #   であることは判定可能。
+  # v0.7.1 §41: buildFrontmatter は `agent: <agent>` field を type: 直後に emit する。
+  # multi-agent indexing / filtering の整合性のため必須化済 (open-issues §41 RESOLVED)。
   if grep -E "^agent:\s*${AGENT}\s*$" "${newest}" >/dev/null 2>&1; then
     success "frontmatter に 'agent: ${AGENT}' あり"
   else
-    info "frontmatter に 'agent: ${AGENT}' field 不在 (v0.7.0 既知、open-issues §41 で v0.7.1 実装予定)"
-    info "  他の evidence で session 由来を判定してください (filename / session_id / mtime)"
+    fail "frontmatter に 'agent: ${AGENT}' field 不在 (v0.7.1 §41 で実装済のはず、buildFrontmatter を再確認)"
+    echo "  期待: 最新 session log の冒頭 frontmatter に '^agent: ${AGENT}\$' line"
+    echo "  file: ${newest}"
+    exit 1
   fi
 
   # masking spot check — sk-proj- / sk-ant- / ghp_ 等の unmasked API key

--- a/tests/hooks/adapters/_common.test.mjs
+++ b/tests/hooks/adapters/_common.test.mjs
@@ -1,0 +1,187 @@
+// tests/hooks/adapters/_common.test.mjs — v0.7.1 hardening unit tests
+//
+// Targets: hooks/adapters/_common.mjs
+// Test prefixes:
+//   - BLUE-COMMON-LISTENER-IDEMPOTENT-* : §38 fix (process listener gate idempotent)
+//   - BLUE-COMMON-TRANSCRIPT-ROOT-*     : §36 fix (assertTranscriptInRoot allowlist)
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, mkdir, writeFile, symlink, realpath } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  ensureCrashListenersIdempotent,
+  assertTranscriptInRoot,
+  TranscriptPathError,
+} from '../../../hooks/adapters/_common.mjs';
+
+// -----------------------------------------------------------------------------
+// BLUE-COMMON-LISTENER-IDEMPOTENT (§38)
+// -----------------------------------------------------------------------------
+
+describe('_common: BLUE-COMMON-LISTENER-IDEMPOTENT process listener gate', () => {
+  test('BLUE-COMMON-LISTENER-IDEMPOTENT-1: 5 calls add at most 1 listener', () => {
+    const beforeUR = process.listenerCount('unhandledRejection');
+    const beforeUE = process.listenerCount('uncaughtException');
+    for (let i = 0; i < 5; i++) ensureCrashListenersIdempotent();
+    const deltaUR = process.listenerCount('unhandledRejection') - beforeUR;
+    const deltaUE = process.listenerCount('uncaughtException') - beforeUE;
+    assert.ok(
+      deltaUR <= 1,
+      `unhandledRejection delta=${deltaUR}, expected <= 1 (gate must prevent accumulation)`,
+    );
+    assert.ok(
+      deltaUE <= 1,
+      `uncaughtException delta=${deltaUE}, expected <= 1 (gate must prevent accumulation)`,
+    );
+  });
+
+  test('BLUE-COMMON-LISTENER-IDEMPOTENT-2: subsequent calls add 0 listeners', () => {
+    // Ensure gate is locked first (prior test may already have done this)
+    ensureCrashListenersIdempotent();
+    const baselineUR = process.listenerCount('unhandledRejection');
+    const baselineUE = process.listenerCount('uncaughtException');
+    for (let i = 0; i < 10; i++) ensureCrashListenersIdempotent();
+    assert.equal(
+      process.listenerCount('unhandledRejection'),
+      baselineUR,
+      'subsequent calls must not register additional unhandledRejection listeners',
+    );
+    assert.equal(
+      process.listenerCount('uncaughtException'),
+      baselineUE,
+      'subsequent calls must not register additional uncaughtException listeners',
+    );
+  });
+});
+
+// -----------------------------------------------------------------------------
+// BLUE-COMMON-TRANSCRIPT-ROOT (§36)
+// -----------------------------------------------------------------------------
+
+async function withFakeHome(fn) {
+  const tmp = await mkdtemp(join(tmpdir(), 'kioku-tx-root-'));
+  const originalHome = process.env.HOME;
+  try {
+    process.env.HOME = tmp;
+    await fn(tmp);
+  } finally {
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    await rm(tmp, { recursive: true, force: true });
+  }
+}
+
+describe('_common: BLUE-COMMON-TRANSCRIPT-ROOT assertTranscriptInRoot', () => {
+  test('BLUE-COMMON-TRANSCRIPT-ROOT-CLAUDE-PASS: claude path inside ~/.claude/projects passes', async () => {
+    await withFakeHome(async (home) => {
+      const dir = join(home, '.claude', 'projects');
+      await mkdir(dir, { recursive: true });
+      const safe = join(dir, 'session-abcdef.jsonl');
+      await writeFile(safe, '{}');
+      const resolved = await assertTranscriptInRoot('claude', safe);
+      // resolved は realpath 経由なので macOS の /var → /private/var resolution を考慮し
+      // 入力 path の realpath と一致すること、かつ safe root subpath であることを assert。
+      const expected = await realpath(safe);
+      assert.equal(resolved, expected);
+      const safeRoot = await realpath(dir);
+      assert.ok(
+        resolved === safeRoot || resolved.startsWith(safeRoot + '/'),
+        `resolved=${resolved} must be inside ${safeRoot}`,
+      );
+    });
+  });
+
+  test('BLUE-COMMON-TRANSCRIPT-ROOT-CLAUDE-OUTSIDE: claude path outside throws OUTSIDE_SAFE_ROOTS', async () => {
+    await withFakeHome(async (home) => {
+      // file exists but is outside ~/.claude/projects
+      const dir = join(home, '.claude', 'projects');
+      await mkdir(dir, { recursive: true });
+      const outside = join(home, 'other-place.jsonl');
+      await writeFile(outside, '{}');
+      await assert.rejects(
+        () => assertTranscriptInRoot('claude', outside),
+        (err) => err instanceof TranscriptPathError && err.code === 'OUTSIDE_SAFE_ROOTS',
+        'claude transcript outside ~/.claude/projects must throw',
+      );
+    });
+  });
+
+  test('BLUE-COMMON-TRANSCRIPT-ROOT-GEMINI-OUTSIDE: gemini path outside throws OUTSIDE_SAFE_ROOTS', async () => {
+    await withFakeHome(async (home) => {
+      const safeDir = join(home, '.gemini', 'chats');
+      await mkdir(safeDir, { recursive: true });
+      const outside = join(home, 'evil.json');
+      await writeFile(outside, '{}');
+      await assert.rejects(
+        () => assertTranscriptInRoot('gemini', outside),
+        (err) => err instanceof TranscriptPathError && err.code === 'OUTSIDE_SAFE_ROOTS',
+        'gemini transcript outside safe roots must throw',
+      );
+    });
+  });
+
+  test('BLUE-COMMON-TRANSCRIPT-ROOT-CODEX-OUTSIDE: codex path outside throws OUTSIDE_SAFE_ROOTS', async () => {
+    await withFakeHome(async (home) => {
+      const safeDir = join(home, '.codex', 'sessions');
+      await mkdir(safeDir, { recursive: true });
+      const outside = join(home, 'attack.jsonl');
+      await writeFile(outside, '{}');
+      await assert.rejects(
+        () => assertTranscriptInRoot('codex', outside),
+        (err) => err instanceof TranscriptPathError && err.code === 'OUTSIDE_SAFE_ROOTS',
+        'codex transcript outside ~/.codex/sessions must throw',
+      );
+    });
+  });
+
+  test('BLUE-COMMON-TRANSCRIPT-ROOT-SYMLINK-ESCAPE: symlink inside safe root pointing outside throws', async () => {
+    await withFakeHome(async (home) => {
+      const safeDir = join(home, '.claude', 'projects');
+      await mkdir(safeDir, { recursive: true });
+      const evilTarget = join(home, 'outside-target.jsonl');
+      await writeFile(evilTarget, 'pwned');
+      const escapeLink = join(safeDir, 'escape.jsonl');
+      await symlink(evilTarget, escapeLink);
+      await assert.rejects(
+        () => assertTranscriptInRoot('claude', escapeLink),
+        (err) => err instanceof TranscriptPathError && err.code === 'OUTSIDE_SAFE_ROOTS',
+        'symlink in safe root pointing outside must throw (realpath resolves before prefix check)',
+      );
+    });
+  });
+
+  test('BLUE-COMMON-TRANSCRIPT-ROOT-NONSTRING: non-string path throws PATH_NOT_STRING', async () => {
+    await assert.rejects(
+      () => assertTranscriptInRoot('claude', null),
+      (err) => err instanceof TranscriptPathError && err.code === 'PATH_NOT_STRING',
+    );
+    await assert.rejects(
+      () => assertTranscriptInRoot('claude', ''),
+      (err) => err instanceof TranscriptPathError && err.code === 'PATH_NOT_STRING',
+    );
+  });
+
+  test('BLUE-COMMON-TRANSCRIPT-ROOT-UNKNOWN-AGENT: unknown agent throws UNKNOWN_AGENT', async () => {
+    await withFakeHome(async (home) => {
+      const f = join(home, 'x.jsonl');
+      await writeFile(f, '{}');
+      await assert.rejects(
+        () => assertTranscriptInRoot('openai', f),
+        (err) => err instanceof TranscriptPathError && err.code === 'UNKNOWN_AGENT',
+      );
+    });
+  });
+
+  test('BLUE-COMMON-TRANSCRIPT-ROOT-MISSING-FILE: realpath failure throws REALPATH_FAILED', async () => {
+    await withFakeHome(async (home) => {
+      const missing = join(home, '.claude', 'projects', 'no-such-file.jsonl');
+      await assert.rejects(
+        () => assertTranscriptInRoot('claude', missing),
+        (err) => err instanceof TranscriptPathError && /^REALPATH_FAILED/.test(err.code),
+      );
+    });
+  });
+});

--- a/tests/hooks/session-logger-core.test.mjs
+++ b/tests/hooks/session-logger-core.test.mjs
@@ -10,7 +10,7 @@
 
 import { test, describe } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtemp, rm, readFile, readdir, mkdir, writeFile } from 'node:fs/promises';
+import { mkdtemp, rm, readFile, readdir, mkdir, writeFile, symlink, utimes } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { Readable } from 'node:stream';
@@ -231,6 +231,50 @@ describe('session-logger-core: BLUE-CORE-YAML-INJ frontmatter safety', () => {
     assert.match(fm, /cwd: '[^\n]*attacker[^\n]*'/);
     // The trailing `---\n` should still exist at the end as the closing fence
     assert.match(fm, /---\n$/);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// BLUE-CORE-AGENT-FRONTMATTER (§41): buildFrontmatter agent field emission
+// -----------------------------------------------------------------------------
+
+describe('session-logger-core: BLUE-CORE-AGENT-FRONTMATTER buildFrontmatter agent field', () => {
+  const ts = {
+    iso: '2026-04-28T10:00:00+09:00',
+    compactDate: '20260428',
+    compactTime: '100000',
+    clock: '10:00:00',
+  };
+
+  test('BLUE-CORE-AGENT-FRONTMATTER-1: agent field emitted immediately after type: line for all 3 agents', () => {
+    for (const agent of ['claude', 'gemini', 'codex']) {
+      const normEv = makeNormEv({ agent });
+      const fm = buildFrontmatter(normEv, ts);
+      // 厳密 ordering を pin: type: の直後に agent: が来る
+      assert.match(
+        fm,
+        new RegExp(`^---\\ntype: session-log\\nagent: ${agent}\\nsession_id: `),
+        `agent=${agent}: type:\\nagent:${agent}\\nsession_id 順で出る`,
+      );
+    }
+  });
+
+  test('BLUE-CORE-AGENT-FRONTMATTER-2: agent value goes through yamlSafeValue + frontmatter delim count unchanged (defense-in-depth)', () => {
+    // validateNormalizedEvent (BLUE-CORE-VAL-5) で agent enum 制約済のため
+    // theoretical injection は不可だが、buildFrontmatter 自体の防御層も pin。
+    // 各 agent で:
+    //   - 単一の closing `---\n` (injection なし)
+    //   - 末尾 `---\n` (closing fence 維持)
+    //   - validateNormalizedEvent との整合 (agent value が AGENT_NAMES set 通り plain string)
+    for (const agent of ['claude', 'gemini', 'codex']) {
+      const normEv = makeNormEv({ agent });
+      const fm = buildFrontmatter(normEv, ts);
+      const delimCount = fm.split('\n---\n').length - 1;
+      assert.equal(delimCount, 1, `agent=${agent}: exactly one closing delim`);
+      assert.match(fm, /---\n$/, `agent=${agent}: trailing closing fence intact`);
+      // plain enum string は yamlSafeValue で quote されない (passthrough)
+      assert.match(fm, new RegExp(`\\nagent: ${agent}\\n`));
+    }
   });
 });
 
@@ -538,6 +582,179 @@ describe('session-logger-core: BLUE-CORE-CWD-VAULT self-recursion guard agent-aw
       } else {
         process.env.OBSIDIAN_VAULT = originalVault;
       }
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+// -----------------------------------------------------------------------------
+// BLUE-CORE-EXIT-REASON-MASK (§35): handleSessionEnd で reason field を mask + yamlSafeValue
+// -----------------------------------------------------------------------------
+
+describe('session-logger-core: BLUE-CORE-EXIT-REASON-MASK §35', () => {
+  test('BLUE-CORE-EXIT-REASON-MASK-1: reason に API key が含まれてもマスクされる', async () => {
+    const { root, ctx } = await createCtx();
+    try {
+      // 先に session を establish
+      await ingestNormalizedEvent(makeNormEv({ sessionId: 'reason-mask-1' }), ctx);
+      // session_end with API key in reason
+      const apiKey = 'sk-ant-' + 'a'.repeat(40);
+      await ingestNormalizedEvent(
+        {
+          sessionId: 'reason-mask-1',
+          eventName: 'session_end',
+          agent: 'claude',
+          timestamp: new Date(),
+          sessionEnd: { reason: `exit due to leaked ${apiKey} value` },
+          cwd: '/tmp',
+        },
+        ctx,
+      );
+      const files = (await readdir(ctx.sessionLogsDir)).filter((f) => f.endsWith('.md'));
+      const content = await readFile(join(ctx.sessionLogsDir, files[0]), 'utf8');
+      assert.ok(
+        !content.includes(apiKey),
+        'raw API key must not appear in session log (mask 適用)',
+      );
+      assert.match(content, /sk-ant-\*\*\*/, 'masked placeholder で置換されている');
+      assert.match(content, /- exit_reason:/, 'exit_reason field がそのまま書き込まれている');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('BLUE-CORE-EXIT-REASON-MASK-2: reason に YAML 構造文字 (colon/quote) が含まれても yamlSafeValue で escape', async () => {
+    const { root, ctx } = await createCtx();
+    try {
+      await ingestNormalizedEvent(makeNormEv({ sessionId: 'reason-yaml-1' }), ctx);
+      await ingestNormalizedEvent(
+        {
+          sessionId: 'reason-yaml-1',
+          eventName: 'session_end',
+          agent: 'claude',
+          timestamp: new Date(),
+          sessionEnd: { reason: "logout: it's done" },
+          cwd: '/tmp',
+        },
+        ctx,
+      );
+      const files = (await readdir(ctx.sessionLogsDir)).filter((f) => f.endsWith('.md'));
+      const content = await readFile(join(ctx.sessionLogsDir, files[0]), 'utf8');
+      // yamlSafeValue は colon-bearing string を single-quote で wrap、内部 single quote は ''
+      assert.match(content, /- exit_reason: 'logout: it''s done'/);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+// -----------------------------------------------------------------------------
+// BLUE-CORE-REALPATH-FALLBACK (§34): buildContext realpath 失敗時 throw せず literal 経路 fallback
+// -----------------------------------------------------------------------------
+
+describe('session-logger-core: BLUE-CORE-REALPATH-FALLBACK §34', () => {
+  test('BLUE-CORE-REALPATH-FALLBACK-1: vault が dangling symlink でも throw せず null 返却 (fail-safe)', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'kioku-realpath-fb-'));
+    const originalVault = process.env.OBSIDIAN_VAULT;
+    try {
+      // dangling symlink: realpath() throws ENOENT
+      const dangling = join(tmp, 'dangling-vault');
+      await symlink(join(tmp, 'no-such-target'), dangling);
+      process.env.OBSIDIAN_VAULT = dangling;
+      let ctx;
+      let threw = false;
+      try {
+        ctx = await buildContext({ agent: 'claude' });
+      } catch {
+        threw = true;
+      }
+      assert.equal(threw, false, 'realpath ENOENT でも buildContext は throw せず');
+      assert.equal(
+        ctx,
+        null,
+        'dangling vault: stat fallback で null 返却 (fail-safe)',
+      );
+    } finally {
+      if (originalVault === undefined) delete process.env.OBSIDIAN_VAULT;
+      else process.env.OBSIDIAN_VAULT = originalVault;
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('BLUE-CORE-REALPATH-FALLBACK-2: vault 存在 + cwd 外側で realpath 経路成功 → ctx 返却', async () => {
+    // 通常 happy path、realpath が両方成功する scenario でも ctx が出ることを pin。
+    const tmp = await mkdtemp(join(tmpdir(), 'kioku-realpath-happy-'));
+    const sessionLogsDir = join(tmp, 'session-logs');
+    const internalDir = join(sessionLogsDir, '.claude-brain');
+    await mkdir(internalDir, { recursive: true });
+    const originalVault = process.env.OBSIDIAN_VAULT;
+    try {
+      process.env.OBSIDIAN_VAULT = tmp;
+      // cwd は test runner の cwd (vault 外)
+      const ctx = await buildContext({ agent: 'claude' });
+      assert.ok(ctx, 'realpath happy path: ctx 返却');
+      assert.equal(ctx.vault, tmp);
+    } finally {
+      if (originalVault === undefined) delete process.env.OBSIDIAN_VAULT;
+      else process.env.OBSIDIAN_VAULT = originalVault;
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
+// -----------------------------------------------------------------------------
+// BLUE-CORE-LOCK-TOCTOU (§33): index.lock stale + dead PID stealing race
+// -----------------------------------------------------------------------------
+
+describe('session-logger-core: BLUE-CORE-LOCK-TOCTOU §33', () => {
+  test('BLUE-CORE-LOCK-TOCTOU-1: stale lock with dead PID is stolen (single ingest)', async () => {
+    const { root, ctx } = await createCtx();
+    try {
+      const lockPath = `${ctx.indexPath}.lock`;
+      // PID 2147483646 (max int32 - 1) は実機で存在しない PID として安全に "dead" を示す
+      await writeFile(lockPath, '2147483646', { encoding: 'utf8', mode: 0o600 });
+      const pastDate = new Date(Date.now() - 41_000); // > INDEX_LOCK_STALE_MS (30s)
+      await utimes(lockPath, pastDate, pastDate);
+
+      const intent = await ingestNormalizedEvent(
+        makeNormEv({ sessionId: 'toctou-dead-1' }),
+        ctx,
+      );
+      assert.deepEqual(intent, { type: 'none' });
+      const files = (await readdir(ctx.sessionLogsDir)).filter((f) => f.endsWith('.md'));
+      assert.equal(files.length, 1);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('BLUE-CORE-LOCK-TOCTOU-2: 5 concurrent ingest racing on stale dead-PID orphan all succeed', async () => {
+    const { root, ctx } = await createCtx();
+    try {
+      const lockPath = `${ctx.indexPath}.lock`;
+      // 同時に複数 ingest が stale orphan lock の steal を試みる scenario。
+      // dead PID の orphan を植え、5 ingest を並列発火。1 ingest が steal +
+      // 'wx' で lock を取得、他は alive owner (= 取得した ingest 自身) で stale
+      // 判定が不成立になり wait/retry → 全 ingest が serial に lock を取り
+      // saveIndex 完了する (in-process 同 pid double-acquire を起こさない)。
+      await writeFile(lockPath, '2147483646', { encoding: 'utf8', mode: 0o600 });
+      const pastDate = new Date(Date.now() - 41_000);
+      await utimes(lockPath, pastDate, pastDate);
+
+      const events = Array.from({ length: 5 }, (_, i) => ({
+        sessionId: `toctou-race-${String(i).padStart(4, '0')}`,
+        eventName: 'user_prompt',
+        agent: 'claude',
+        timestamp: new Date(Date.now() + i),
+        userPrompt: { text: `prompt ${i}` },
+        cwd: '/tmp',
+      }));
+      await Promise.all(events.map((e) => ingestNormalizedEvent(e, ctx)));
+
+      const indexRaw = await readFile(ctx.indexPath, 'utf8');
+      const index = JSON.parse(indexRaw);
+      assert.equal(Object.keys(index.sessions).length, 5);
+    } finally {
       await rm(root, { recursive: true, force: true });
     }
   });

--- a/tests/hooks/session-logger.test.mjs
+++ b/tests/hooks/session-logger.test.mjs
@@ -433,11 +433,20 @@ describe('session-logger: Edit / Write / MultiEdit', () => {
   });
 });
 
+// §36 fix (v0.7.1): Claude adapter は transcript_path を ~/.claude/projects/ 配下
+// にしか accept しない (TRANSCRIPT_SAFE_ROOTS allowlist)。test 用に HOME を
+// tmp root に上書きし、transcript を ${HOME}/.claude/projects/ 配下に置く。
+async function makeSafeTranscript(root) {
+  const projectsDir = join(root, '.claude', 'projects');
+  await mkdir(projectsDir, { recursive: true });
+  return join(projectsDir, 'transcript.jsonl');
+}
+
 describe('session-logger: Stop handler with transcript', () => {
   test('extracts assistant text from transcript and tracks offset', async () => {
     const { root, vault } = await createVault();
     try {
-      const transcript = join(root, 'transcript.jsonl');
+      const transcript = await makeSafeTranscript(root);
       const lines = [
         JSON.stringify({
           type: 'user',
@@ -461,14 +470,14 @@ describe('session-logger: Stop handler with transcript', () => {
         cwd: '/tmp',
         prompt: 'stop test',
         transcript_path: transcript,
-      });
+      }, { HOME: root });
       await runHook(vault, {
         session_id: 'test-session-0050',
         hook_event_name: 'Stop',
         cwd: '/tmp',
         stop_reason: 'end_turn',
         transcript_path: transcript,
-      });
+      }, { HOME: root });
 
       const body = await readFirstSessionFile(vault);
       assert.match(body, /## Assistant/);
@@ -486,7 +495,7 @@ describe('session-logger: Stop handler with transcript', () => {
   test('second Stop only reads newly appended lines (differential)', async () => {
     const { root, vault } = await createVault();
     try {
-      const transcript = join(root, 'transcript.jsonl');
+      const transcript = await makeSafeTranscript(root);
       const first = JSON.stringify({
         type: 'assistant',
         message: { role: 'assistant', content: [{ type: 'text', text: 'First reply.' }] },
@@ -499,14 +508,14 @@ describe('session-logger: Stop handler with transcript', () => {
         cwd: '/tmp',
         prompt: 'diff test',
         transcript_path: transcript,
-      });
+      }, { HOME: root });
       await runHook(vault, {
         session_id: 'test-session-0051',
         hook_event_name: 'Stop',
         cwd: '/tmp',
         stop_reason: 'end_turn',
         transcript_path: transcript,
-      });
+      }, { HOME: root });
 
       const second = JSON.stringify({
         type: 'assistant',
@@ -520,7 +529,7 @@ describe('session-logger: Stop handler with transcript', () => {
         cwd: '/tmp',
         stop_reason: 'end_turn',
         transcript_path: transcript,
-      });
+      }, { HOME: root });
 
       const body = await readFirstSessionFile(vault);
       // both replies present, but first should not be duplicated
@@ -536,7 +545,7 @@ describe('session-logger: Stop handler with transcript', () => {
   test('transcript truncation resets offset to 0', async () => {
     const { root, vault } = await createVault();
     try {
-      const transcript = join(root, 'transcript.jsonl');
+      const transcript = await makeSafeTranscript(root);
       const big = JSON.stringify({
         type: 'assistant',
         message: { role: 'assistant', content: [{ type: 'text', text: 'padding padding padding padding' }] },
@@ -549,14 +558,14 @@ describe('session-logger: Stop handler with transcript', () => {
         cwd: '/tmp',
         prompt: 'rotate test',
         transcript_path: transcript,
-      });
+      }, { HOME: root });
       await runHook(vault, {
         session_id: 'test-session-0052',
         hook_event_name: 'Stop',
         cwd: '/tmp',
         stop_reason: 'end_turn',
         transcript_path: transcript,
-      });
+      }, { HOME: root });
 
       // truncate (rotate)
       const tiny = JSON.stringify({
@@ -571,10 +580,44 @@ describe('session-logger: Stop handler with transcript', () => {
         cwd: '/tmp',
         stop_reason: 'end_turn',
         transcript_path: transcript,
-      });
+      }, { HOME: root });
 
       const body = await readFirstSessionFile(vault);
       assert.match(body, /after rotate/);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('§36: transcript_path outside ~/.claude/projects/ is silently dropped (boundary check)', async () => {
+    const { root, vault } = await createVault();
+    try {
+      // 敵対的 stdin injection 想定: transcript_path が allowlist 外 (/tmp/...)
+      const evilTranscript = join(root, 'evil.jsonl');
+      const evilLine = JSON.stringify({
+        type: 'assistant',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'INJECTED CONTENT' }] },
+      });
+      await writeFile(evilTranscript, evilLine + '\n', 'utf8');
+
+      await runHook(vault, {
+        session_id: 'test-session-0053',
+        hook_event_name: 'UserPromptSubmit',
+        cwd: '/tmp',
+        prompt: 'boundary test',
+        transcript_path: evilTranscript,
+      }, { HOME: root });
+      await runHook(vault, {
+        session_id: 'test-session-0053',
+        hook_event_name: 'Stop',
+        cwd: '/tmp',
+        stop_reason: 'end_turn',
+        transcript_path: evilTranscript,
+      }, { HOME: root });
+
+      const body = await readFirstSessionFile(vault);
+      // Stop が transcript を読まないため、injected 内容は session log に出ない
+      assert.doesNotMatch(body, /INJECTED CONTENT/, 'allowlist 外 transcript の内容は logger に取り込まれてはならない');
     } finally {
       await rm(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

v0.7.1 release sync from parent repo (Step 4/8 of LEARN#11 cascade).

## What's bundled

### 🔀 Multi-agent indexing (§41、4/30 RYU 実機 verified)
- \`buildFrontmatter\` に \`agent: <agent>\` field を emit (Claude / Gemini / Codex の 3 agent で frontmatter parity)
- BLUE-CORE-AGENT-FRONTMATTER-1/2 で厳密 ordering pin (test 155/155 pass)
- \`verify-multi-agent-e2e.sh\` の agent field check を informational → fail 昇格

### 🛡 Hardening 5 件 (§33-38、PR #70 land 済)
- §33 INDEX-LOCK-TOCTOU-RACE: PID alive check + post-acquire content verify、jitter retry で thundering herd 回避
- §34 BUILD-CONTEXT-REALPATH-FALLBACK: realpath 失敗時の literal fallback + KIOKU_DEBUG warn
- §35 EXIT-REASON-MASK-COVERAGE: \`sessionEnd.reason\` を mask + yamlSafeValue 経由で frontmatter 書き込み
- §36 TRANSCRIPT-PATH-VAULT-BOUNDARY: \`assertTranscriptInRoot\` agent-specific allowlist + 3 adapter wire (symlink escape 検出)
- §38 COMMON-MJS-GLOBAL-LISTENER-ACCUMULATION: \`ensureCrashListenersIdempotent\` で listener 累積防止

### 📚 Docs codify (§37、PR #67 land 済)
- \`docs/install-guide-multi-agent.{md,ja.md}\` に Codex per-turn commit warning 追加

### 🔢 Version bump 5 places (0.7.0 → 0.7.1)
- \`mcp/package.json\` / \`mcp/manifest.json\` / \`.claude-plugin/plugin.json\` / \`.claude-plugin/marketplace.json\` (metadata + plugins[0])

## Test result (PR #70 + #74 で independent verified)

| suite | pass | fail |
|---|---|---|
| Hook Node tests | 155 | 0 |
| 非 Hook Node tests | 389 | 0 |
| Bash install-hooks (claude/gemini/codex) | all pass | 0 |

## 4/30 実機 verified (RYU、Mac mini)

| Agent | session_id | agent: field | masking |
|---|---|---|---|
| codex | 019ddce8-... | ✅ \`agent: codex\` | ✅ pass |
| gemini | f8b1aeb3-... | ✅ \`agent: gemini\` | ✅ pass |

## Cascade status

- [x] Step 1: parent release PR #79 (5 places version bump)
- [x] Step 2: parent PR #79 merged
- [x] Step 3: sync-to-app
- [x] Step 4: kioku next → main PR (本 PR)
- [ ] Step 5: kioku 側 README PR (10 言語 v0.7.1 Changelog 直接 push、LEARN#11 mandatory)
- [ ] Step 6: post-release-sync (parent app/ 整合)
- [ ] Step 7: .mcpb build + GitHub Release tag publish
- [ ] Step 8: marketing handoff 作成

## Note

README Changelog (10 言語) は **本 PR に含まれない** — 別途 Step 5 で kioku 側に直接 push する flow (LEARN#11 sync boundary trap 回避 mandatory pattern)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)