### PR TITLE
docs: v0.7.1 Changelog entry を 10 言語 README に展開 (LEARN#11 mandatory)

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -263,6 +263,25 @@ Si encuentras un problema de seguridad, repórtalo a través de [SECURITY.md](SE
 
 ## Cambios
 
+### 2026-04-30 — v0.7.1: Pulido — campo `agent:` en frontmatter + 5 endurecimientos + codificacion de workflow
+
+v0.7.1 pule la narrativa multi-agente que aterrizo en v0.7.0: cada session log ahora lleva su identidad de agente en el frontmatter, cinco endurecimientos discretos (lock TOCTOU, realpath fallback, exit-reason masking, transcript-path boundary, listener accumulation), y las reglas de workflow obtienen codificacion de drift bidireccional.
+
+- **Campo `agent:` en frontmatter (§41)** — `buildFrontmatter` ahora emite `agent: <claude|gemini|codex>` justo despues de `type: session-log`. Antes los session logs de Gemini y Codex eran indistinguibles por frontmatter solo. Verificado end-to-end el 2026-04-30 con sesiones fresh codex (`019ddce8-...`) y gemini (`f8b1aeb3-...`)
+- **5 endurecimientos (§33-36, §38)** en `hooks/session-logger-core.mjs` + `hooks/adapters/_common.mjs`:
+  - **§33 INDEX-LOCK-TOCTOU-RACE** — defensa de 2 etapas: PID alive check antes de robar lock stale + content re-verify post-acquire con jitter retry
+  - **§34 BUILD-CONTEXT-REALPATH-FALLBACK** — fallo de `realpath` ahora hace fallback a comparacion literal en vez de throw. `KIOKU_DEBUG=1` warns a stderr
+  - **§35 EXIT-REASON-MASK-COVERAGE** — `sessionEnd.reason` ahora pasa por `applyMasks()` + `yamlSafeValue()` antes del frontmatter
+  - **§36 TRANSCRIPT-PATH-VAULT-BOUNDARY** — nuevo `assertTranscriptInRoot(agent, path)` con allowlist `~/.{claude,gemini,codex}/{projects,chats,sessions}/`, rechaza paths externos al vault y symlink escapes
+  - **§38 COMMON-MJS-GLOBAL-LISTENER-ACCUMULATION** — registro de listener de `safeMain` ahora gated por flag de module-scope, eliminando `MaxListenersExceededWarning` en test harnesses
+- **Hot fix de install path (§44)** — `marketplace.json` `name` renombrado `kioku-marketplace` → `megaphone-tokyo` para que la sintaxis documentada `claude plugin install kioku@megaphone-tokyo` funcione. 10 README + `docs/install-guide-plugin.md` actualizados a sintaxis Claude Code v2.1.89 (`claude plugin marketplace add ...`)
+- **Doc Codex per-turn commit (§37)** — `docs/install-guide-multi-agent.{md,ja.md}` Codex section gana nota sobre per-turn commits (solo usuarios de Hook port)
+- **2 nuevas reglas de code-style (§39 LEARN#13 / §40 LEARN#14)** — `.claude/rules/code-style.md`: regex literal control-char escape mandatory + ESM entry gate pattern
+- **Codificacion de workflow (parent-only)** — LEARN#10 reverse drift codificado: PM mental-model drift puede ir en *cualquier* direccion. `git log -10 origin/main --oneline` ahora es precheck mandatorio
+- **Verificador script graduado** — `scripts/verify-multi-agent-e2e.sh` Step 6 agent field check pasa de informational a fail signal (`exit 1`)
+- Tests: **Node 155/155 hook suites + 389 non-hook + Bash todos green**, `npm audit` clean
+- [Release v0.7.1](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.7.1)
+
 ### 2026-04-28 — v0.7.0: Multi-agente completo — Hook port para Gemini / Codex + paridad de session log automatico + Visualizer α
 
 v0.7.0 cierra el "narrative-implementation gap" abierto en v0.6.0. Donde v0.6.0 hizo a KIOKU **discoverable** (skill symlinks), v0.7.0 lo hace **actively work** — automatic session logging, hot-cache pipeline, y per-agent install scripts.

--- a/README.fr.md
+++ b/README.fr.md
@@ -326,6 +326,25 @@ Si vous trouvez un probleme de securite, veuillez le signaler via [SECURITY.md](
 
 ## Journal des modifications
 
+### 2026-04-30 — v0.7.1 : Polissage — champ `agent:` dans frontmatter + 5 durcissements + codification du workflow
+
+v0.7.1 polit la narrative multi-agent atterrie en v0.7.0 : chaque session log porte maintenant son identite d'agent dans le frontmatter, cinq durcissements discrets (lock TOCTOU, realpath fallback, exit-reason masking, transcript-path boundary, listener accumulation), et les regles de workflow gagnent une codification de drift bidirectionnelle.
+
+- **Champ `agent:` dans frontmatter (§41)** — `buildFrontmatter` emet maintenant `agent: <claude|gemini|codex>` immediatement apres `type: session-log`. Verifie end-to-end le 2026-04-30 contre des sessions fresh codex (`019ddce8-...`) et gemini (`f8b1aeb3-...`)
+- **5 durcissements (§33-36, §38)** dans `hooks/session-logger-core.mjs` + `hooks/adapters/_common.mjs`:
+  - **§33 INDEX-LOCK-TOCTOU-RACE** — defense en 2 etapes : PID alive check + content re-verify post-acquire avec jitter retry
+  - **§34 BUILD-CONTEXT-REALPATH-FALLBACK** — echec de `realpath` fait maintenant fallback vers comparaison litterale au lieu de throw
+  - **§35 EXIT-REASON-MASK-COVERAGE** — `sessionEnd.reason` passe maintenant par `applyMasks()` + `yamlSafeValue()` avant le frontmatter
+  - **§36 TRANSCRIPT-PATH-VAULT-BOUNDARY** — nouveau `assertTranscriptInRoot(agent, path)` avec allowlist `~/.{claude,gemini,codex}/{projects,chats,sessions}/`
+  - **§38 COMMON-MJS-GLOBAL-LISTENER-ACCUMULATION** — enregistrement de listener de `safeMain` maintenant gated par flag de module-scope
+- **Hot fix install path (§44)** — `marketplace.json` `name` renomme `kioku-marketplace` → `megaphone-tokyo`. 10 README + `docs/install-guide-plugin.md` mis a jour vers la syntaxe Claude Code v2.1.89 (`claude plugin marketplace add ...`)
+- **Doc Codex per-turn commit (§37)** — `docs/install-guide-multi-agent.{md,ja.md}` Codex section gagne note sur per-turn commits
+- **2 nouvelles regles de code-style (§39 LEARN#13 / §40 LEARN#14)** — regex literal control-char escape mandatory + ESM entry gate pattern
+- **Codification de workflow (parent-only)** — LEARN#10 reverse drift codifie : `git log -10 origin/main --oneline` est maintenant precheck mandatoire avant delegation handoff
+- **Verificateur script gradue** — `scripts/verify-multi-agent-e2e.sh` Step 6 agent field check passe de informational a fail signal (`exit 1`)
+- Tests : **Node 155/155 hook suites + 389 non-hook + Bash tous green**, `npm audit` clean
+- [Release v0.7.1](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.7.1)
+
 ### 2026-04-28 — v0.7.0 : Multi-agent complet — Hook port pour Gemini / Codex + parite de session log automatique + Visualizer α
 
 v0.7.0 ferme le "narrative-implementation gap" ouvert dans v0.6.0. La ou v0.6.0 a rendu KIOKU **discoverable** (skill symlinks), v0.7.0 le rend **actively work** — automatic session logging, hot-cache pipeline, et per-agent install scripts.

--- a/README.hi.md
+++ b/README.hi.md
@@ -263,6 +263,25 @@ KIOKU एक Hook सिस्टम है जो **सभी Claude Code स�
 
 ## परिवर्तन इतिहास
 
+### 2026-04-30 — v0.7.1: Polish — frontmatter में `agent:` field + 5 hardening + workflow codification
+
+v0.7.1 v0.7.0 में ship हुई multi-agent narrative को polish करता है: हर session log अब अपनी agent identity frontmatter में रखता है, पाँच quiet hardening fixes (lock TOCTOU, realpath fallback, exit-reason masking, transcript-path boundary, listener accumulation), और workflow rules में bidirectional drift codification।
+
+- **`agent:` frontmatter field (§41)** — `buildFrontmatter` अब `type: session-log` के तुरंत बाद `agent: <claude|gemini|codex>` emit करता है। पहले Gemini और Codex session logs frontmatter से distinguish नहीं हो सकते थे। 2026-04-30 को fresh codex (`019ddce8-...`) और gemini (`f8b1aeb3-...`) sessions के साथ end-to-end verified
+- **5 hardening fixes (§33-36, §38)** in `hooks/session-logger-core.mjs` + `hooks/adapters/_common.mjs`:
+  - **§33 INDEX-LOCK-TOCTOU-RACE** — 2-stage defense: PID alive check + post-acquire content re-verify with jitter retry
+  - **§34 BUILD-CONTEXT-REALPATH-FALLBACK** — `realpath` failure अब throw करने के बजाय literal path comparison पर fallback
+  - **§35 EXIT-REASON-MASK-COVERAGE** — `sessionEnd.reason` अब `applyMasks()` + `yamlSafeValue()` से होकर frontmatter में जाता है
+  - **§36 TRANSCRIPT-PATH-VAULT-BOUNDARY** — नया `assertTranscriptInRoot(agent, path)` allowlist `~/.{claude,gemini,codex}/{projects,chats,sessions}/`
+  - **§38 COMMON-MJS-GLOBAL-LISTENER-ACCUMULATION** — `safeMain` listener registration अब module-scope flag से gated
+- **Install path hot fix (§44)** — `marketplace.json` `name` को `kioku-marketplace` → `megaphone-tokyo` rename, 10 README + `docs/install-guide-plugin.md` Claude Code v2.1.89 syntax (`claude plugin marketplace add ...`) पर update
+- **Codex per-turn commit doc (§37)** — `docs/install-guide-multi-agent.{md,ja.md}` Codex section में per-turn commits notes जोड़ा गया
+- **2 नई code-style rules (§39 LEARN#13 / §40 LEARN#14)** — regex literal control-char escape mandatory + ESM entry gate pattern
+- **Workflow codification (parent-only)** — LEARN#10 reverse drift codify किया गया: `git log -10 origin/main --oneline` अब delegation handoff से पहले mandatory precheck है
+- **Verifier script graduated** — `scripts/verify-multi-agent-e2e.sh` Step 6 agent field check informational से fail signal (`exit 1`) में graduate
+- Tests: **Node 155/155 hook suites + 389 non-hook + Bash all green**, `npm audit` clean
+- [Release v0.7.1](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.7.1)
+
 ### 2026-04-28 — v0.7.0: Multi-agent complete — Hook port for Gemini / Codex + automatic session log parity + Visualizer α
 
 v0.7.0 v0.6.0 के narrative-implementation gap को बंद करता है। जहां v0.6.0 ने KIOKU को **discoverable** बनाया (skill symlinks), v0.7.0 इसे **actively work** बनाता है — automatic session logging, hot-cache pipeline, और per-agent install scripts.

--- a/README.ja.md
+++ b/README.ja.md
@@ -484,6 +484,25 @@ KIOKU は Claude Code の**全セッション入出力にアクセスする Hook
 
 ## 更新履歴
 
+### 2026-04-30 — v0.7.1: ポリッシュ — `agent:` frontmatter + 5 件のハードニング + workflow ルール codify
+
+v0.7.1 は v0.7.0 で完成したマルチエージェント narrative の磨き上げ。session log の frontmatter にエージェント識別子を追加、5 件の地味なハードニング (lock TOCTOU / realpath fallback / exit-reason masking / transcript-path boundary / listener accumulation)、運用ルールへの双方向 drift codify を入れた。
+
+- **`agent:` frontmatter フィールド (§41)** — `buildFrontmatter` が `type: session-log` の直後に `agent: <claude|gemini|codex>` を emit。v0.7.0 までは Gemini / Codex の session log が frontmatter だけでは識別不能だった (`session_id` namespace は独立だが)。v0.7.1 でマルチエージェント vault の indexing / filtering が grep 1 回で完結。2026-04-30 に fresh codex (`019ddce8-...`) と gemini (`f8b1aeb3-...`) session で end-to-end 検証済
+- **5 件のハードニング (§33-36, §38)**: `hooks/session-logger-core.mjs` + `hooks/adapters/_common.mjs`:
+  - **§33 INDEX-LOCK-TOCTOU-RACE** — lock 取得を 2 段防御に強化: (a) stale-mtime な lock を steal する前に PID alive check (`process.kill(pid, 0)`)、(b) 取得後に content re-verify + jitter retry で race-stolen を検出
+  - **§34 BUILD-CONTEXT-REALPATH-FALLBACK** — `realpath` 失敗 (EROFS / ENOENT / EACCES on dangling symlink) で throw せず literal path 比較に fallback。`KIOKU_DEBUG=1` で stderr に warn、production は silent
+  - **§35 EXIT-REASON-MASK-COVERAGE** — `sessionEnd.reason` を frontmatter 書き込み前に `applyMasks()` + `yamlSafeValue()` 経由に変更。将来 vendor schema drift で reason が free-form 化した場合の defense-in-depth
+  - **§36 TRANSCRIPT-PATH-VAULT-BOUNDARY** — 新 helper `assertTranscriptInRoot(agent, path)` が `~/.{claude,gemini,codex}/{projects,chats,sessions}/` を allowlist 化、vault 外パスと symlink escape を realpath 経由で reject。3 adapter 全部が `transcript_path` を core に渡す前に wire
+  - **§38 COMMON-MJS-GLOBAL-LISTENER-ACCUMULATION** — `safeMain` の listener 登録を module-scope flag で gate、複数 adapter を import する test harness で `MaxListenersExceededWarning` が発火していた risk を解消
+- **インストールパスの hot fix (§44、v0.7.0 → v0.7.1 期間に適用済)** — `marketplace.json` の `name` を `kioku-marketplace` → `megaphone-tokyo` に rename、ドキュメント通りの `claude plugin install kioku@megaphone-tokyo` で動くように。10 言語 README + `docs/install-guide-plugin.md` も Claude Code v2.1.89 syntax (`claude plugin marketplace add ...`) に統一 (旧 `claude marketplace add ...` から移行)
+- **Codex per-turn commit のドキュメント追加 (§37)** — `docs/install-guide-multi-agent.{md,ja.md}` の Codex section に「Hook port を併用する場合のみ該当する per-turn commit 注意」を追記。SessionEnd 不在 → Stop event での git-sync emulation → 1 session で数十 commit 発生し得る理由と disable 手順
+- **2 つの新コードスタイルルール (§39 LEARN#13 / §40 LEARN#14)** — `.claude/rules/code-style.md` に追加: regex literal の制御文字 escape 必須化 (U+2028/U+2029/U+200B/U+FEFF は `\uXXXX` 必須) と ESM entry gate パターン (`isEntry()` で adapter module の test import 時 stdin hang を回避)
+- **ワークフロー codify (parent-only)** — LEARN#10 の逆方向 drift を codify: PM mental-model drift は **両方向** に起き得る (phantom file paths も task already merged も)。delegation handoff 作成前の `git log -10 origin/main --oneline` check を mandatory 化、既存の `origin/main..main` empty check (LEARN#12 Rule 2) と pair で双方向 guard。2026-04-30 に duplicate-delegation を実時間で catch
+- **検証ヘルパースクリプトの昇格** — `scripts/verify-multi-agent-e2e.sh` の Step 6 agent field check を informational → fail signal (`exit 1`) に昇格、§41 ship 後の正式 check として
+- テスト: **Node 155/155 hook suites + 389 non-hook + Bash install-hooks 全 green**、`npm audit` clean
+- [Release v0.7.1](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.7.1) — `kioku-wiki-0.7.1.mcpb` attached
+
 ### 2026-04-28 — v0.7.0: マルチエージェント完全対応 — Gemini / Codex Hook port + 自動 session log parity + Visualizer α
 
 v0.7.0 は v0.6.0 で開けた "narrative-実装 gap" を完全に閉じる release。v0.6.0 で **discoverable** だった (skill symlink) KIOKU が、v0.7.0 では **actively work** する状態に。Gemini / Codex でも **自動 session log + masking pipeline + per-agent install script** が同等動作。Visualizer α の最初の user 可視 MCP tool も同時投入。

--- a/README.ko.md
+++ b/README.ko.md
@@ -326,6 +326,25 @@ KIOKU은 **모든 Claude Code 세션 입출력**에 접근하는 Hook 시스템�
 
 ## 변경 이력
 
+### 2026-04-30 — v0.7.1: Polish — `agent:` frontmatter 필드 + 5건의 hardening + workflow 코드화
+
+v0.7.1은 v0.7.0에서 정착한 multi-agent narrative를 다듬는 release. 모든 session log가 frontmatter에 agent identity를 갖게 되었고, 다섯 개의 조용한 hardening (lock TOCTOU, realpath fallback, exit-reason masking, transcript-path boundary, listener accumulation), workflow rules에 양방향 drift codification이 추가됨.
+
+- **`agent:` frontmatter 필드 (§41)** — `buildFrontmatter`가 `type: session-log` 직후에 `agent: <claude|gemini|codex>` emit. 이전에는 Gemini와 Codex의 session log가 frontmatter만으로는 구별 불가능했음. 2026-04-30에 fresh codex (`019ddce8-...`)와 gemini (`f8b1aeb3-...`) session으로 end-to-end 검증
+- **5건의 hardening (§33-36, §38)** in `hooks/session-logger-core.mjs` + `hooks/adapters/_common.mjs`:
+  - **§33 INDEX-LOCK-TOCTOU-RACE** — 2단계 방어: PID alive check + post-acquire content re-verify with jitter retry
+  - **§34 BUILD-CONTEXT-REALPATH-FALLBACK** — `realpath` 실패 시 throw 대신 literal path 비교로 fallback
+  - **§35 EXIT-REASON-MASK-COVERAGE** — `sessionEnd.reason`이 frontmatter 쓰기 전에 `applyMasks()` + `yamlSafeValue()` 통과
+  - **§36 TRANSCRIPT-PATH-VAULT-BOUNDARY** — 새 helper `assertTranscriptInRoot(agent, path)` 가 `~/.{claude,gemini,codex}/{projects,chats,sessions}/`를 allowlist
+  - **§38 COMMON-MJS-GLOBAL-LISTENER-ACCUMULATION** — `safeMain` listener registration이 module-scope flag로 gated
+- **Install path hot fix (§44)** — `marketplace.json` `name`을 `kioku-marketplace` → `megaphone-tokyo`로 rename, 10개 README + `docs/install-guide-plugin.md` Claude Code v2.1.89 syntax (`claude plugin marketplace add ...`)로 통일
+- **Codex per-turn commit doc (§37)** — `docs/install-guide-multi-agent.{md,ja.md}` Codex section에 per-turn commit 주의 추가
+- **2개의 새 code-style rules (§39 LEARN#13 / §40 LEARN#14)** — regex literal control-char escape 필수화 + ESM entry gate pattern
+- **Workflow codification (parent-only)** — LEARN#10 reverse drift 코드화: `git log -10 origin/main --oneline`이 delegation handoff 작성 전 mandatory precheck로
+- **Verifier script 격상** — `scripts/verify-multi-agent-e2e.sh` Step 6 agent field check가 informational에서 fail signal (`exit 1`)로 격상
+- Tests: **Node 155/155 hook suites + 389 non-hook + Bash 모두 green**, `npm audit` clean
+- [Release v0.7.1](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.7.1)
+
 ### 2026-04-28 — v0.7.0: Multi-agent 완성 — Gemini / Codex Hook port + 자동 session log parity + Visualizer α
 
 v0.7.0는 v0.6.0에서 열린 narrative-implementation gap을 닫는 release. v0.6.0이 KIOKU를 **discoverable** (skill symlinks) 하게 만들었다면, v0.7.0은 **actively work** — automatic session logging, hot-cache pipeline, per-agent install scripts.

--- a/README.md
+++ b/README.md
@@ -465,6 +465,25 @@ If you find a security issue, please report it via [SECURITY.md](SECURITY.md) �
 
 ## Changelog
 
+### 2026-04-30 — v0.7.1: Polish — `agent:` frontmatter + 5 hardening + workflow codification
+
+v0.7.1 polishes the multi-agent narrative landed in v0.7.0: every session log now carries its agent identity in the frontmatter, five quiet hardening fixes (lock TOCTOU, realpath fallback, exit-reason masking, transcript-path boundary, listener accumulation), and the workflow rules gain bidirectional-drift codification.
+
+- **`agent:` frontmatter field (§41)** — `buildFrontmatter` now emits `agent: <claude|gemini|codex>` immediately after `type: session-log`. Previously, Gemini and Codex session logs were indistinguishable by frontmatter alone (only `session_id` namespace was independent). With v0.7.1, indexing and filtering across multi-agent vaults work with a single grep. Verified end-to-end on 2026-04-30 against fresh codex (`019ddce8-...`) and gemini (`f8b1aeb3-...`) sessions
+- **5 hardening fixes (§33-36, §38)** in `hooks/session-logger-core.mjs` + `hooks/adapters/_common.mjs`:
+  - **§33 INDEX-LOCK-TOCTOU-RACE** — lock acquisition now uses 2-stage defense: (a) PID alive check (`process.kill(pid, 0)`) before stealing a stale-mtime lock, (b) post-acquire content re-verify with jitter retry to detect race-stolen locks
+  - **§34 BUILD-CONTEXT-REALPATH-FALLBACK** — `realpath` failure (EROFS / ENOENT / EACCES on dangling symlink) now falls back to literal path comparison instead of throwing. `KIOKU_DEBUG=1` warns to stderr; production stays silent
+  - **§35 EXIT-REASON-MASK-COVERAGE** — `sessionEnd.reason` now flows through `applyMasks()` + `yamlSafeValue()` before being written to frontmatter. Defense-in-depth against future vendor schema drift where reason might become free-form
+  - **§36 TRANSCRIPT-PATH-VAULT-BOUNDARY** — new `assertTranscriptInRoot(agent, path)` allowlists `~/.{claude,gemini,codex}/{projects,chats,sessions}/`, rejects vault-external paths and symlink escapes via realpath. All 3 adapters wire it before passing `transcript_path` to core
+  - **§38 COMMON-MJS-GLOBAL-LISTENER-ACCUMULATION** — `safeMain` listener registration is now gated by a module-scope flag, eliminating `MaxListenersExceededWarning` in test harnesses that import multiple adapters
+- **Install path hot fix (§44, applied during the v0.7.0 → v0.7.1 window)** — `marketplace.json` `name` renamed `kioku-marketplace` → `megaphone-tokyo` so the docs syntax `claude plugin install kioku@megaphone-tokyo` works as documented. All 10 README + `docs/install-guide-plugin.md` updated to Claude Code v2.1.89 marketplace syntax (`claude plugin marketplace add ...` instead of legacy `claude marketplace add ...`)
+- **Codex per-turn commit doc (§37)** — `docs/install-guide-multi-agent.{md,ja.md}` Codex section gains a "Note on per-turn commits" call-out (Hook port users only): SessionEnd absent → Stop event git-sync emulation → bounded commit count per session, with disable instructions
+- **Two new code-style rules (§39 LEARN#13 / §40 LEARN#14)** — `.claude/rules/code-style.md`: regex literal control-char escape mandate (U+2028/U+2029/U+200B/U+FEFF must use `\uXXXX`) and ESM entry gate pattern (`isEntry()` for adapter modules to avoid stdin-hang on test imports)
+- **Workflow codification (parent-only)** — LEARN#10 reverse drift codified: PM mental-model drift can run *either* direction (phantom file paths *or* tasks already merged). `git log -10 origin/main --oneline` is now a mandatory PM precheck before creating delegation handoffs, paired with the existing `origin/main..main` empty check (LEARN#12 Rule 2). Caught duplicate-delegation in real-time on 2026-04-30
+- **Verifier script graduation** — `scripts/verify-multi-agent-e2e.sh` Step 6 agent-field check graduates from informational to a fail signal (`exit 1`) now that §41 ships
+- Tests: **Node 155/155 hook suites + 389 non-hook + Bash install-hooks all green**, `npm audit` clean
+- [Release v0.7.1](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.7.1) — `kioku-wiki-0.7.1.mcpb` attached
+
 ### 2026-04-28 — v0.7.0: Multi-agent complete — Hook port for Gemini / Codex + automatic session log parity + Visualizer α
 
 v0.7.0 closes the narrative-implementation gap that v0.6.0 opened: where v0.6.0 made KIOKU **discoverable** across non-Claude agents (skill symlinks), v0.7.0 makes KIOKU **actively work** across them — automatic session logging, hot-cache pipeline, and per-agent install scripts. Visualizer α also ships its first user-visible MCP tool.

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -326,6 +326,25 @@ Se voce encontrar um problema de seguranca, por favor reporte via [SECURITY.md](
 
 ## Histórico de mudanças
 
+### 2026-04-30 — v0.7.1: Polimento — campo `agent:` no frontmatter + 5 endurecimentos + codificacao de workflow
+
+v0.7.1 polica a narrativa multi-agente que aterrissou em v0.7.0: cada session log agora carrega sua identidade de agente no frontmatter, cinco endurecimentos discretos (lock TOCTOU, realpath fallback, exit-reason masking, transcript-path boundary, listener accumulation), e as regras de workflow ganham codificacao de drift bidirecional.
+
+- **Campo `agent:` no frontmatter (§41)** — `buildFrontmatter` agora emite `agent: <claude|gemini|codex>` imediatamente apos `type: session-log`. Verificado end-to-end em 2026-04-30 com sessoes fresh codex (`019ddce8-...`) e gemini (`f8b1aeb3-...`)
+- **5 endurecimentos (§33-36, §38)** em `hooks/session-logger-core.mjs` + `hooks/adapters/_common.mjs`:
+  - **§33 INDEX-LOCK-TOCTOU-RACE** — defesa em 2 etapas: PID alive check + content re-verify post-acquire com jitter retry
+  - **§34 BUILD-CONTEXT-REALPATH-FALLBACK** — falha de `realpath` agora faz fallback para comparacao literal em vez de throw
+  - **§35 EXIT-REASON-MASK-COVERAGE** — `sessionEnd.reason` agora passa por `applyMasks()` + `yamlSafeValue()` antes do frontmatter
+  - **§36 TRANSCRIPT-PATH-VAULT-BOUNDARY** — novo `assertTranscriptInRoot(agent, path)` com allowlist `~/.{claude,gemini,codex}/{projects,chats,sessions}/`
+  - **§38 COMMON-MJS-GLOBAL-LISTENER-ACCUMULATION** — registro de listener de `safeMain` agora gated por flag de module-scope
+- **Hot fix install path (§44)** — `marketplace.json` `name` renomeado `kioku-marketplace` → `megaphone-tokyo`. 10 README + `docs/install-guide-plugin.md` atualizados para sintaxe Claude Code v2.1.89 (`claude plugin marketplace add ...`)
+- **Doc Codex per-turn commit (§37)** — `docs/install-guide-multi-agent.{md,ja.md}` Codex section ganha nota sobre per-turn commits
+- **2 novas regras de code-style (§39 LEARN#13 / §40 LEARN#14)** — regex literal control-char escape mandatory + ESM entry gate pattern
+- **Codificacao de workflow (parent-only)** — LEARN#10 reverse drift codificado: `git log -10 origin/main --oneline` agora e precheck mandatorio antes de delegation handoff
+- **Verificador script graduado** — `scripts/verify-multi-agent-e2e.sh` Step 6 agent field check de informational para fail signal (`exit 1`)
+- Tests: **Node 155/155 hook suites + 389 non-hook + Bash todos green**, `npm audit` clean
+- [Release v0.7.1](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.7.1)
+
 ### 2026-04-28 — v0.7.0: Multi-agente completo — Hook port para Gemini / Codex + paridade de session log automatico + Visualizer α
 
 v0.7.0 fecha o "narrative-implementation gap" aberto em v0.6.0. Onde v0.6.0 tornou KIOKU **discoverable** (skill symlinks), v0.7.0 o torna **actively work** — automatic session logging, hot-cache pipeline, e per-agent install scripts.

--- a/README.ru.md
+++ b/README.ru.md
@@ -331,6 +331,25 @@ KIOKU спроектирован для **совместного использ�
 
 ## История изменений
 
+### 2026-04-30 — v0.7.1: Полировка — поле `agent:` в frontmatter + 5 hardening + кодификация workflow
+
+v0.7.1 полирует multi-agent narrative, появившийся в v0.7.0: каждый session log теперь несёт свою agent identity в frontmatter, пять тихих hardening fixes (lock TOCTOU, realpath fallback, exit-reason masking, transcript-path boundary, listener accumulation), правила workflow получают двунаправленную drift-codification.
+
+- **Поле `agent:` в frontmatter (§41)** — `buildFrontmatter` теперь emit `agent: <claude|gemini|codex>` сразу после `type: session-log`. Раньше session logs Gemini и Codex были неотличимы только по frontmatter. Проверено end-to-end 2026-04-30 на fresh codex (`019ddce8-...`) и gemini (`f8b1aeb3-...`) сессиях
+- **5 hardening fixes (§33-36, §38)** в `hooks/session-logger-core.mjs` + `hooks/adapters/_common.mjs`:
+  - **§33 INDEX-LOCK-TOCTOU-RACE** — двухступенчатая защита: PID alive check + post-acquire content re-verify с jitter retry
+  - **§34 BUILD-CONTEXT-REALPATH-FALLBACK** — сбой `realpath` теперь делает fallback на literal path comparison вместо throw
+  - **§35 EXIT-REASON-MASK-COVERAGE** — `sessionEnd.reason` теперь проходит через `applyMasks()` + `yamlSafeValue()` перед записью в frontmatter
+  - **§36 TRANSCRIPT-PATH-VAULT-BOUNDARY** — новый `assertTranscriptInRoot(agent, path)` с allowlist `~/.{claude,gemini,codex}/{projects,chats,sessions}/`
+  - **§38 COMMON-MJS-GLOBAL-LISTENER-ACCUMULATION** — регистрация listener `safeMain` теперь gated module-scope flag
+- **Hot fix install path (§44)** — `marketplace.json` `name` переименован `kioku-marketplace` → `megaphone-tokyo`, 10 README + `docs/install-guide-plugin.md` обновлены до синтаксиса Claude Code v2.1.89 (`claude plugin marketplace add ...`)
+- **Codex per-turn commit doc (§37)** — `docs/install-guide-multi-agent.{md,ja.md}` Codex section получает заметку о per-turn commits
+- **2 новых code-style rules (§39 LEARN#13 / §40 LEARN#14)** — обязательный escape control-chars в regex literal + ESM entry gate pattern
+- **Кодификация workflow (parent-only)** — LEARN#10 reverse drift кодифицирован: `git log -10 origin/main --oneline` теперь обязательный precheck перед созданием delegation handoff
+- **Verifier script повышен** — `scripts/verify-multi-agent-e2e.sh` Step 6 agent field check от informational до fail signal (`exit 1`)
+- Tests: **Node 155/155 hook suites + 389 non-hook + Bash all green**, `npm audit` clean
+- [Release v0.7.1](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.7.1)
+
 ### 2026-04-28 — v0.7.0: Multi-agent завершён — Hook port для Gemini / Codex + parity автоматического session log + Visualizer α
 
 v0.7.0 закрывает "narrative-implementation gap", открытый в v0.6.0. Где v0.6.0 сделал KIOKU **discoverable** (skill symlinks), v0.7.0 делает его **actively work** — automatic session logging, hot-cache pipeline, per-agent install scripts.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -331,6 +331,25 @@ KIOKU 是一个可以访问**所有 Claude Code 会话输入输出**的 Hook 系
 
 ## 更新历史
 
+### 2026-04-30 — v0.7.1：打磨 — frontmatter 中 `agent:` 字段 + 5 项 hardening + workflow 编码
+
+v0.7.1 打磨 v0.7.0 落地的 multi-agent narrative：每个 session log 现在在 frontmatter 中携带其 agent 身份，五项低调 hardening (lock TOCTOU、realpath fallback、exit-reason masking、transcript-path boundary、listener accumulation)，workflow 规则获得双向 drift codification。
+
+- **frontmatter 中 `agent:` 字段 (§41)** — `buildFrontmatter` 现在在 `type: session-log` 之后立即 emit `agent: <claude|gemini|codex>`。之前 Gemini 和 Codex 的 session log 仅凭 frontmatter 无法区分。2026-04-30 在 fresh codex (`019ddce8-...`) 和 gemini (`f8b1aeb3-...`) session 上 end-to-end 验证
+- **5 项 hardening (§33-36, §38)** in `hooks/session-logger-core.mjs` + `hooks/adapters/_common.mjs`：
+  - **§33 INDEX-LOCK-TOCTOU-RACE** — 两阶段防御：PID alive check + post-acquire content re-verify with jitter retry
+  - **§34 BUILD-CONTEXT-REALPATH-FALLBACK** — `realpath` 失败现在 fallback 到 literal path 比较，而非 throw
+  - **§35 EXIT-REASON-MASK-COVERAGE** — `sessionEnd.reason` 现在在写入 frontmatter 前流经 `applyMasks()` + `yamlSafeValue()`
+  - **§36 TRANSCRIPT-PATH-VAULT-BOUNDARY** — 新 `assertTranscriptInRoot(agent, path)` 以 `~/.{claude,gemini,codex}/{projects,chats,sessions}/` allowlist
+  - **§38 COMMON-MJS-GLOBAL-LISTENER-ACCUMULATION** — `safeMain` listener 注册现在由 module-scope flag gated
+- **Install path hot fix (§44)** — `marketplace.json` `name` 重命名 `kioku-marketplace` → `megaphone-tokyo`，10 个 README + `docs/install-guide-plugin.md` 更新到 Claude Code v2.1.89 syntax (`claude plugin marketplace add ...`)
+- **Codex per-turn commit doc (§37)** — `docs/install-guide-multi-agent.{md,ja.md}` Codex section 增加 per-turn commits 注意
+- **2 个新 code-style rules (§39 LEARN#13 / §40 LEARN#14)** — regex literal control-char 强制 escape + ESM entry gate pattern
+- **Workflow codification (parent-only)** — LEARN#10 reverse drift 编码：`git log -10 origin/main --oneline` 现在是创建 delegation handoff 前的强制 precheck
+- **Verifier script 升级** — `scripts/verify-multi-agent-e2e.sh` Step 6 agent field check 从 informational 升级为 fail signal (`exit 1`)
+- Tests：**Node 155/155 hook suites + 389 non-hook + Bash 全部 green**，`npm audit` clean
+- [Release v0.7.1](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.7.1)
+
 ### 2026-04-28 — v0.7.0：多代理完整支持 — Gemini / Codex Hook port + 自动 session log parity + Visualizer α
 
 v0.7.0 关闭了 v0.6.0 中打开的 narrative-implementation gap。v0.6.0 让 KIOKU **discoverable** (skill symlinks)，v0.7.0 让它 **actively work** — automatic session logging、hot-cache pipeline、per-agent install scripts。

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -331,6 +331,25 @@ KIOKU 是一個存取**所有 Claude Code 工作階段 I/O** 的 Hook 系統。
 
 ## 更新歷史
 
+### 2026-04-30 — v0.7.1：打磨 — frontmatter 中 `agent:` 欄位 + 5 項 hardening + workflow 編碼
+
+v0.7.1 打磨 v0.7.0 落地的 multi-agent narrative：每個 session log 現在在 frontmatter 中攜帶其 agent 身份，五項低調 hardening (lock TOCTOU、realpath fallback、exit-reason masking、transcript-path boundary、listener accumulation)，workflow 規則獲得雙向 drift codification。
+
+- **frontmatter 中 `agent:` 欄位 (§41)** — `buildFrontmatter` 現在在 `type: session-log` 之後立即 emit `agent: <claude|gemini|codex>`。之前 Gemini 和 Codex 的 session log 僅憑 frontmatter 無法區分。2026-04-30 在 fresh codex (`019ddce8-...`) 和 gemini (`f8b1aeb3-...`) session 上 end-to-end 驗證
+- **5 項 hardening (§33-36, §38)** in `hooks/session-logger-core.mjs` + `hooks/adapters/_common.mjs`：
+  - **§33 INDEX-LOCK-TOCTOU-RACE** — 兩階段防禦：PID alive check + post-acquire content re-verify with jitter retry
+  - **§34 BUILD-CONTEXT-REALPATH-FALLBACK** — `realpath` 失敗現在 fallback 到 literal path 比較，而非 throw
+  - **§35 EXIT-REASON-MASK-COVERAGE** — `sessionEnd.reason` 現在在寫入 frontmatter 前流經 `applyMasks()` + `yamlSafeValue()`
+  - **§36 TRANSCRIPT-PATH-VAULT-BOUNDARY** — 新 `assertTranscriptInRoot(agent, path)` 以 `~/.{claude,gemini,codex}/{projects,chats,sessions}/` allowlist
+  - **§38 COMMON-MJS-GLOBAL-LISTENER-ACCUMULATION** — `safeMain` listener 註冊現在由 module-scope flag gated
+- **Install path hot fix (§44)** — `marketplace.json` `name` 重命名 `kioku-marketplace` → `megaphone-tokyo`，10 個 README + `docs/install-guide-plugin.md` 更新到 Claude Code v2.1.89 syntax (`claude plugin marketplace add ...`)
+- **Codex per-turn commit doc (§37)** — `docs/install-guide-multi-agent.{md,ja.md}` Codex section 新增 per-turn commits 注意
+- **2 個新 code-style rules (§39 LEARN#13 / §40 LEARN#14)** — regex literal control-char 強制 escape + ESM entry gate pattern
+- **Workflow codification (parent-only)** — LEARN#10 reverse drift 編碼：`git log -10 origin/main --oneline` 現在是建立 delegation handoff 前的強制 precheck
+- **Verifier script 升級** — `scripts/verify-multi-agent-e2e.sh` Step 6 agent field check 從 informational 升級為 fail signal (`exit 1`)
+- Tests：**Node 155/155 hook suites + 389 non-hook + Bash 全部 green**，`npm audit` clean
+- [Release v0.7.1](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.7.1)
+
 ### 2026-04-28 — v0.7.0：多代理完整支援 — Gemini / Codex Hook port + 自動 session log parity + Visualizer α
 
 v0.7.0 關閉了 v0.6.0 中開啟的 narrative-implementation gap。v0.6.0 讓 KIOKU **discoverable** (skill symlinks)，v0.7.0 讓它 **actively work** — automatic session logging、hot-cache pipeline、per-agent install scripts。


### PR DESCRIPTION
v0.7.1 release cascade Step 5: 10 言語 README に v0.7.1 Changelog entry を追加。LEARN#11 sync boundary trap 回避のため kioku 側で直接 push する mandatory pattern (parent → kioku の sync-to-app では README は除外される)。i18n parity 10/10 ✅。