### PR TITLE
v0.7.2 release: Sprint 1 完走 — doctor MVP + drift test + URL test 安定化

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "KIOKU: Hardened LLM Wiki for Claude Code / Claude Desktop by megaphone-tokyo",
-    "version": "0.7.1"
+    "version": "0.7.2"
   },
   "plugins": [
     {
@@ -17,7 +17,7 @@
         "ref": "main"
       },
       "description": "Hardened LLM Wiki for Claude Code + Claude Desktop. Automatic conversation → Obsidian Vault knowledge base. Hot cache + PostCompact hook + secret masking + Git sync.",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "author": {
         "name": "megaphone-tokyo",
         "url": "https://github.com/megaphone-tokyo"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kioku",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "KIOKU — Hardened LLM Wiki for Claude Code + Claude Desktop. Automatic conversation capture to Obsidian Vault, Karpathy LLM Wiki pattern, hot cache + PostCompact hook, secret masking, cross-machine Git sync. Research/legal/enterprise-grade memory for Claude.",
   "author": {
     "name": "megaphone-tokyo",

--- a/mcp/manifest.json
+++ b/mcp/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "kioku-wiki",
   "display_name": "KIOKU Wiki",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Read, search, and write your KIOKU Obsidian Wiki from Claude Desktop or Claude Code.",
   "long_description": "KIOKU is a personal knowledge base ('second brain') built on top of an Obsidian Vault. This MCP server exposes ten tools (kioku_search, kioku_read, kioku_list, kioku_write_note, kioku_write_wiki, kioku_delete, kioku_ingest_pdf, kioku_ingest_url, kioku_ingest_document, kioku_generate_viz) so that Claude Desktop and Claude Code can browse and update the Wiki without leaving the chat. All operations are local stdio — nothing leaves your machine. See https://github.com/megaphone-tokyo/kioku for the full project.",
   "author": {

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kioku-mcp",
-  "version": "0.5.0",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kioku-mcp",
-      "version": "0.5.0",
+      "version": "0.7.2",
       "dependencies": {
         "@modelcontextprotocol/sdk": "~1.29.0",
         "@mozilla/readability": "^0.6.0",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kioku-mcp",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "private": true,
   "type": "module",
   "description": "KIOKU local MCP server (Wiki read/list/search/write_note/write_wiki/delete) for Claude Desktop and Claude Code.",

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -1,0 +1,652 @@
+#!/usr/bin/env bash
+#
+# doctor.sh — KIOKU の状態を一括診断する read-only スクリプト
+#
+# codex roadmap (plan/codex/260430_kioku-product-improvement-roadmap.md §P0) に
+# 基づき、Vault/Runtime/CLI/Hook config/MCP config/Metadata parity/Dependencies
+# を網羅的にチェックして「何が動いていて、何が壊れているか」を即座に表示する。
+#
+# 使い方:
+#   bash scripts/doctor.sh           # human-readable な出力 (default)
+#   bash scripts/doctor.sh --json    # 機械 readable な JSON 出力
+#
+# Exit code:
+#   0 = 全 ok
+#   1 = 1 件以上の fail
+#   2 = warn のみ (fail 無し)
+#
+# 採用方針:
+#   - **Read-only only**: 何も変更しない。fix は Next actions として表示するだけ
+#   - **macOS / Linux 両対応**: 純粋に shell + jq のみで完結し OS 依存な stat -f / -c は使わない
+#   - **冪等**: 何度実行しても状態に応じて再現性のある出力
+#   - **temp HOME / temp Vault で完結する test**: 実 HOME / 実 Vault に touch しない
+
+set -euo pipefail
+
+# -----------------------------------------------------------------------------
+# Path resolution (REPO_ROOT は version metadata / mcp/ 検査に使う)
+# -----------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CB_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"  # tools/claude-brain/
+
+# -----------------------------------------------------------------------------
+# Args
+# -----------------------------------------------------------------------------
+JSON_MODE=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --json) JSON_MODE=1; shift ;;
+    -h|--help)
+      cat <<'USAGE'
+KIOKU Doctor — 状態の一括診断 (read-only)
+
+Usage:
+  bash scripts/doctor.sh           Human-readable output (default)
+  bash scripts/doctor.sh --json    Machine-readable JSON output
+
+Exit codes:
+  0  all ok
+  1  one or more failed checks
+  2  warnings only (no failures)
+USAGE
+      exit 0
+      ;;
+    *)
+      echo "doctor: unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+# -----------------------------------------------------------------------------
+# Result accumulator
+#
+# bash 3.2 (macOS default) で動かすため、associative array は使わず parallel
+# indexed array で持つ。`add_check id level msg [next_action]` で 1 件追加。
+# -----------------------------------------------------------------------------
+RESULT_IDS=()
+RESULT_LEVELS=()
+RESULT_MSGS=()
+RESULT_NEXTS=()
+
+OK_COUNT=0
+WARN_COUNT=0
+FAIL_COUNT=0
+
+add_check() {
+  local id="$1"
+  local level="$2"
+  local msg="$3"
+  local next="${4:-}"
+
+  case "${level}" in
+    ok)   OK_COUNT=$((OK_COUNT + 1)) ;;
+    warn) WARN_COUNT=$((WARN_COUNT + 1)) ;;
+    fail) FAIL_COUNT=$((FAIL_COUNT + 1)) ;;
+    *) echo "doctor: invalid level: ${level}" >&2; exit 2 ;;
+  esac
+
+  RESULT_IDS+=("${id}")
+  RESULT_LEVELS+=("${level}")
+  RESULT_MSGS+=("${msg}")
+  RESULT_NEXTS+=("${next}")
+}
+
+# -----------------------------------------------------------------------------
+# JSON helpers
+#
+# user の config (~/.claude/settings.json 等) の inspect は jq に依存。jq が
+# 無ければ該当 check は warn にする。
+# -----------------------------------------------------------------------------
+HAS_JQ=0
+if command -v jq >/dev/null 2>&1; then
+  HAS_JQ=1
+fi
+
+# json_string_contains FILE MARKER
+#   FILE が JSON で、その serialize 結果 (キー + 値 + 構造) に MARKER
+#   (substring) が含まれれば 0、無ければ 1。jq が無ければ 2。
+#   `[.. | strings]` は値のみ traverse するため key (例: "kioku-wiki") を
+#   見落とす。`tostring` で JSON 全体を 1 string として扱う方が安全
+#   (keys+values 両方をカバー、JSON delimiter " : { が間に挟まるため
+#   arbitrary substring 衝突の risk は実用上無視できる)。
+json_string_contains() {
+  local file="$1"
+  local marker="$2"
+  [[ -f "${file}" ]] || return 1
+  [[ "${HAS_JQ}" -eq 1 ]] || return 2
+  jq -e --arg m "${marker}" 'tostring | contains($m)' "${file}" >/dev/null 2>&1
+}
+
+# -----------------------------------------------------------------------------
+# Section: Environment
+# -----------------------------------------------------------------------------
+check_environment() {
+  # OBSIDIAN_VAULT が設定済か
+  if [[ -n "${OBSIDIAN_VAULT:-}" ]]; then
+    add_check "env-obsidian-vault" "ok" \
+      "OBSIDIAN_VAULT is set: ${OBSIDIAN_VAULT}"
+  else
+    add_check "env-obsidian-vault" "fail" \
+      "OBSIDIAN_VAULT is not set" \
+      "export OBSIDIAN_VAULT=\"\$HOME/claude-brain/main-claude-brain\" in ~/.zshrc or ~/.bashrc"
+    return 0
+  fi
+
+  # Vault directory が存在するか
+  if [[ -d "${OBSIDIAN_VAULT}" ]]; then
+    add_check "env-vault-dir" "ok" \
+      "Vault directory exists: ${OBSIDIAN_VAULT}"
+  else
+    add_check "env-vault-dir" "fail" \
+      "Vault directory does not exist: ${OBSIDIAN_VAULT}" \
+      "bash scripts/setup-vault.sh"
+    return 0
+  fi
+
+  # Vault が Git repo 配下か
+  if git -C "${OBSIDIAN_VAULT}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    add_check "env-vault-git" "ok" \
+      "Vault is inside a Git working tree"
+  else
+    add_check "env-vault-git" "warn" \
+      "Vault is not a Git repo (cross-machine sync via auto-commit/push will be skipped)" \
+      "cd \"${OBSIDIAN_VAULT}\" && git init"
+  fi
+
+  # 4 dir (wiki/ session-logs/ raw-sources/ templates/) の存在
+  local missing=()
+  local dir
+  for dir in wiki session-logs raw-sources templates; do
+    if [[ ! -d "${OBSIDIAN_VAULT}/${dir}" ]]; then
+      missing+=("${dir}")
+    fi
+  done
+  if [[ ${#missing[@]} -eq 0 ]]; then
+    add_check "env-vault-subdirs" "ok" \
+      "Vault has wiki/ session-logs/ raw-sources/ templates/"
+  else
+    add_check "env-vault-subdirs" "fail" \
+      "Vault missing required subdirs: ${missing[*]}" \
+      "bash scripts/setup-vault.sh"
+  fi
+
+  # .gitignore に session-logs/ があるか
+  local gi="${OBSIDIAN_VAULT}/.gitignore"
+  if [[ -f "${gi}" ]] && grep -qE '^session-logs/?$' "${gi}"; then
+    add_check "env-gitignore-session-logs" "ok" \
+      ".gitignore excludes session-logs/"
+  else
+    add_check "env-gitignore-session-logs" "fail" \
+      ".gitignore is missing 'session-logs/' (sensitive logs may be pushed to GitHub)" \
+      "echo 'session-logs/' >> \"${OBSIDIAN_VAULT}/.gitignore\""
+  fi
+
+  # .gitignore に .cache/ があるか (auto-ingest manifest 用)
+  if [[ -f "${gi}" ]] && grep -qE '^\.cache/?$' "${gi}"; then
+    add_check "env-gitignore-cache" "ok" \
+      ".gitignore excludes .cache/"
+  else
+    add_check "env-gitignore-cache" "warn" \
+      ".gitignore is missing '.cache/' (auto-ingest manifest noise may be committed)" \
+      "echo '.cache/' >> \"${OBSIDIAN_VAULT}/.gitignore\""
+  fi
+}
+
+# -----------------------------------------------------------------------------
+# Section: Runtime
+# -----------------------------------------------------------------------------
+check_runtime() {
+  # Node version >= 18
+  if command -v node >/dev/null 2>&1; then
+    local node_version major
+    node_version="$(node --version 2>/dev/null || echo "v0.0.0")"
+    # v18.17.0 -> 18
+    major="${node_version#v}"
+    major="${major%%.*}"
+    # 数値以外が入っていたら 0 にして fail に倒す
+    if [[ ! "${major}" =~ ^[0-9]+$ ]]; then
+      major=0
+    fi
+    if [[ "${major}" -ge 18 ]]; then
+      add_check "runtime-node" "ok" \
+        "Node ${node_version} (>= 18 required)"
+    else
+      add_check "runtime-node" "fail" \
+        "Node ${node_version} is too old (>= 18 required)" \
+        "Install Node 18+ via nvm / asdf / brew"
+    fi
+  else
+    add_check "runtime-node" "fail" \
+      "Node is not installed (required for hooks and MCP server)" \
+      "Install Node 18+ via nvm / asdf / brew"
+  fi
+
+  # jq
+  if [[ "${HAS_JQ}" -eq 1 ]]; then
+    add_check "runtime-jq" "ok" \
+      "jq is installed"
+  else
+    add_check "runtime-jq" "fail" \
+      "jq is not installed (required for install-hooks*.sh --apply and config inspection)" \
+      "brew install jq  # or: apt-get install jq"
+  fi
+
+  # poppler (pdfinfo / pdftotext)
+  local poppler_missing=()
+  command -v pdfinfo  >/dev/null 2>&1 || poppler_missing+=("pdfinfo")
+  command -v pdftotext >/dev/null 2>&1 || poppler_missing+=("pdftotext")
+  if [[ ${#poppler_missing[@]} -eq 0 ]]; then
+    add_check "runtime-poppler" "ok" \
+      "poppler tools installed (pdfinfo, pdftotext)"
+  else
+    add_check "runtime-poppler" "warn" \
+      "poppler tools missing: ${poppler_missing[*]} (PDF ingest will be unavailable)" \
+      "brew install poppler  # or: apt-get install poppler-utils"
+  fi
+
+  # qmd (optional but improves recall)
+  if command -v qmd >/dev/null 2>&1; then
+    add_check "runtime-qmd" "ok" \
+      "qmd is installed (BM25 + vector search backend)"
+  else
+    add_check "runtime-qmd" "warn" \
+      "qmd is not installed (Wiki search falls back to grep; recall is rough)" \
+      "See https://github.com/megaphone-tokyo/qmd for installation"
+  fi
+}
+
+# -----------------------------------------------------------------------------
+# Section: CLI agents
+# -----------------------------------------------------------------------------
+check_cli_agents() {
+  # claude (required for the primary use case)
+  if command -v claude >/dev/null 2>&1; then
+    add_check "cli-claude" "ok" \
+      "claude CLI is installed"
+  else
+    add_check "cli-claude" "fail" \
+      "claude CLI is not installed (Claude Code is the primary KIOKU client)" \
+      "Install Claude Code: https://claude.com/product/claude-code"
+  fi
+
+  # codex (optional)
+  if command -v codex >/dev/null 2>&1; then
+    add_check "cli-codex" "ok" \
+      "codex CLI is installed"
+  else
+    add_check "cli-codex" "warn" \
+      "codex CLI is not installed (optional; install if you want Codex hook integration)" \
+      "Install Codex CLI if you want multi-agent support"
+  fi
+
+  # gemini (optional)
+  if command -v gemini >/dev/null 2>&1; then
+    add_check "cli-gemini" "ok" \
+      "gemini CLI is installed"
+  else
+    add_check "cli-gemini" "warn" \
+      "gemini CLI is not installed (optional; install if you want Gemini hook integration)" \
+      "Install Gemini CLI if you want multi-agent support"
+  fi
+}
+
+# -----------------------------------------------------------------------------
+# Section: Hook configs
+#
+# - Claude:  ~/.claude/settings.json   marker: "session-logger.mjs"
+# - Codex:   ~/.codex/hooks.json       marker: "adapters/codex.mjs"
+# - Gemini:  ~/.gemini/settings.json   marker: "claude-brain-"  (hook name prefix)
+#
+# 3 agent ともに「対応 CLI が install されている時のみ relevant」とみなす:
+# CLI 不在なら "skip" 扱いにせず、"warn (CLI absent)" として 1 行残す
+# (絶対 path を使う install-hooks-* と同じ pattern: CLI が無ければ Hook config
+# は不要だが、user に状況を見せるため info line は出す)。
+# -----------------------------------------------------------------------------
+check_hook_configs() {
+  local home="${HOME}"
+
+  # Claude hook
+  local claude_settings="${home}/.claude/settings.json"
+  if ! command -v claude >/dev/null 2>&1; then
+    add_check "hook-claude" "warn" \
+      "claude CLI absent — skipping ~/.claude/settings.json hook check"
+  elif [[ ! -f "${claude_settings}" ]]; then
+    add_check "hook-claude" "fail" \
+      "${claude_settings} does not exist" \
+      "bash scripts/install-hooks.sh --apply"
+  elif [[ "${HAS_JQ}" -ne 1 ]]; then
+    add_check "hook-claude" "warn" \
+      "jq not available; cannot inspect ${claude_settings}" \
+      "brew install jq"
+  elif json_string_contains "${claude_settings}" "session-logger.mjs"; then
+    add_check "hook-claude" "ok" \
+      "~/.claude/settings.json registers KIOKU session-logger hook"
+  else
+    add_check "hook-claude" "fail" \
+      "~/.claude/settings.json does not register KIOKU session-logger hook" \
+      "bash scripts/install-hooks.sh --apply"
+  fi
+
+  # Codex hook
+  local codex_hooks="${home}/.codex/hooks.json"
+  if ! command -v codex >/dev/null 2>&1; then
+    add_check "hook-codex" "warn" \
+      "codex CLI absent — skipping ~/.codex/hooks.json hook check"
+  elif [[ ! -f "${codex_hooks}" ]]; then
+    add_check "hook-codex" "fail" \
+      "${codex_hooks} does not exist" \
+      "bash scripts/install-hooks-codex.sh --apply"
+  elif [[ "${HAS_JQ}" -ne 1 ]]; then
+    add_check "hook-codex" "warn" \
+      "jq not available; cannot inspect ${codex_hooks}" \
+      "brew install jq"
+  elif json_string_contains "${codex_hooks}" "adapters/codex.mjs"; then
+    add_check "hook-codex" "ok" \
+      "~/.codex/hooks.json registers KIOKU codex adapter hook"
+  else
+    add_check "hook-codex" "fail" \
+      "~/.codex/hooks.json does not register KIOKU codex adapter" \
+      "bash scripts/install-hooks-codex.sh --apply"
+  fi
+
+  # Gemini hook
+  local gemini_settings="${home}/.gemini/settings.json"
+  if ! command -v gemini >/dev/null 2>&1; then
+    add_check "hook-gemini" "warn" \
+      "gemini CLI absent — skipping ~/.gemini/settings.json hook check"
+  elif [[ ! -f "${gemini_settings}" ]]; then
+    add_check "hook-gemini" "fail" \
+      "${gemini_settings} does not exist" \
+      "bash scripts/install-hooks-gemini.sh --apply"
+  elif [[ "${HAS_JQ}" -ne 1 ]]; then
+    add_check "hook-gemini" "warn" \
+      "jq not available; cannot inspect ${gemini_settings}" \
+      "brew install jq"
+  elif json_string_contains "${gemini_settings}" "claude-brain-"; then
+    add_check "hook-gemini" "ok" \
+      "~/.gemini/settings.json registers KIOKU gemini hooks"
+  else
+    add_check "hook-gemini" "fail" \
+      "~/.gemini/settings.json does not register KIOKU gemini hooks" \
+      "bash scripts/install-hooks-gemini.sh --apply"
+  fi
+}
+
+# -----------------------------------------------------------------------------
+# Section: MCP configs
+#
+# - Claude Desktop: ~/Library/Application Support/Claude/claude_desktop_config.json
+#   (Linux なら ~/.config/Claude/... 等、絶対 path を使う install-mcp-client.sh と同じ default)
+# - Codex:  ~/.codex/config.toml に [mcp_servers.kioku] block (TOML)
+# - Gemini: ~/.gemini/settings.json の .mcpServers.kioku
+# -----------------------------------------------------------------------------
+check_mcp_configs() {
+  local home="${HOME}"
+  local uname_s
+  uname_s="$(uname -s 2>/dev/null || echo unknown)"
+
+  # Claude Desktop config (macOS / Linux で path が違う、Linux 側は heuristic)
+  local claude_desktop_config
+  if [[ "${uname_s}" == "Darwin" ]]; then
+    claude_desktop_config="${home}/Library/Application Support/Claude/claude_desktop_config.json"
+  else
+    claude_desktop_config="${home}/.config/Claude/claude_desktop_config.json"
+  fi
+  # CLAUDE_DESKTOP_CONFIG env で override 可 (install-mcp-client.sh と同 pattern)
+  if [[ -n "${CLAUDE_DESKTOP_CONFIG:-}" ]]; then
+    claude_desktop_config="${CLAUDE_DESKTOP_CONFIG}"
+  fi
+
+  if [[ ! -f "${claude_desktop_config}" ]]; then
+    add_check "mcp-claude-desktop" "warn" \
+      "Claude Desktop config not found at ${claude_desktop_config} (Claude Desktop may not be installed)" \
+      "bash scripts/install-mcp-client.sh --apply  # if Claude Desktop is in use"
+  elif [[ "${HAS_JQ}" -ne 1 ]]; then
+    add_check "mcp-claude-desktop" "warn" \
+      "jq not available; cannot inspect ${claude_desktop_config}"
+  elif json_string_contains "${claude_desktop_config}" "kioku"; then
+    add_check "mcp-claude-desktop" "ok" \
+      "Claude Desktop config registers KIOKU MCP server"
+  else
+    add_check "mcp-claude-desktop" "fail" \
+      "Claude Desktop config does not register KIOKU MCP server" \
+      "bash scripts/install-mcp-client.sh --apply"
+  fi
+
+  # Codex MCP (TOML, jq 不要)
+  local codex_config="${home}/.codex/config.toml"
+  if ! command -v codex >/dev/null 2>&1; then
+    add_check "mcp-codex" "warn" \
+      "codex CLI absent — skipping ~/.codex/config.toml MCP check"
+  elif [[ ! -f "${codex_config}" ]]; then
+    add_check "mcp-codex" "warn" \
+      "${codex_config} does not exist (Codex MCP not configured)"
+  elif grep -qE '^\[mcp_servers\.(kioku|"kioku|kioku-wiki|"kioku-wiki)' "${codex_config}"; then
+    add_check "mcp-codex" "ok" \
+      "Codex config.toml registers KIOKU MCP server"
+  else
+    add_check "mcp-codex" "warn" \
+      "Codex config.toml does not register KIOKU MCP server" \
+      "Add [mcp_servers.kioku] block to ~/.codex/config.toml"
+  fi
+
+  # Gemini MCP
+  local gemini_settings="${home}/.gemini/settings.json"
+  if ! command -v gemini >/dev/null 2>&1; then
+    add_check "mcp-gemini" "warn" \
+      "gemini CLI absent — skipping ~/.gemini/settings.json MCP check"
+  elif [[ ! -f "${gemini_settings}" ]]; then
+    add_check "mcp-gemini" "warn" \
+      "${gemini_settings} does not exist (Gemini MCP not configured)"
+  elif [[ "${HAS_JQ}" -ne 1 ]]; then
+    add_check "mcp-gemini" "warn" \
+      "jq not available; cannot inspect ${gemini_settings}"
+  elif jq -e '.mcpServers // {} | has("kioku") or has("kioku-wiki")' \
+        "${gemini_settings}" >/dev/null 2>&1; then
+    add_check "mcp-gemini" "ok" \
+      "Gemini settings registers KIOKU MCP server"
+  else
+    add_check "mcp-gemini" "warn" \
+      "Gemini settings does not register KIOKU MCP server"
+  fi
+}
+
+# -----------------------------------------------------------------------------
+# Section: Metadata parity
+#
+# 4 file の version field が一致しているか:
+#   mcp/package.json                        .version
+#   mcp/manifest.json                       .version
+#   .claude-plugin/plugin.json              .version
+#   .claude-plugin/marketplace.json         .metadata.version (and .plugins[0].version)
+# -----------------------------------------------------------------------------
+check_metadata_parity() {
+  if [[ "${HAS_JQ}" -ne 1 ]]; then
+    add_check "metadata-version" "warn" \
+      "jq not available; cannot verify metadata version parity" \
+      "brew install jq"
+    return 0
+  fi
+
+  local files=(
+    "${CB_ROOT}/mcp/package.json"
+    "${CB_ROOT}/mcp/manifest.json"
+    "${CB_ROOT}/.claude-plugin/plugin.json"
+    "${CB_ROOT}/.claude-plugin/marketplace.json"
+  )
+
+  local missing=()
+  local f
+  for f in "${files[@]}"; do
+    [[ -f "${f}" ]] || missing+=("${f#${CB_ROOT}/}")
+  done
+  if [[ ${#missing[@]} -gt 0 ]]; then
+    add_check "metadata-files" "fail" \
+      "Metadata files missing: ${missing[*]}"
+    return 0
+  fi
+
+  local v_pkg v_man v_plugin v_market_meta v_market_plugin
+  v_pkg="$(jq -r '.version // ""' "${CB_ROOT}/mcp/package.json" 2>/dev/null || echo "")"
+  v_man="$(jq -r '.version // ""' "${CB_ROOT}/mcp/manifest.json" 2>/dev/null || echo "")"
+  v_plugin="$(jq -r '.version // ""' "${CB_ROOT}/.claude-plugin/plugin.json" 2>/dev/null || echo "")"
+  v_market_meta="$(jq -r '.metadata.version // ""' "${CB_ROOT}/.claude-plugin/marketplace.json" 2>/dev/null || echo "")"
+  v_market_plugin="$(jq -r '.plugins[0].version // ""' "${CB_ROOT}/.claude-plugin/marketplace.json" 2>/dev/null || echo "")"
+
+  local empty=()
+  [[ -n "${v_pkg}"           ]] || empty+=("mcp/package.json")
+  [[ -n "${v_man}"           ]] || empty+=("mcp/manifest.json")
+  [[ -n "${v_plugin}"        ]] || empty+=(".claude-plugin/plugin.json")
+  [[ -n "${v_market_meta}"   ]] || empty+=(".claude-plugin/marketplace.json:.metadata.version")
+  [[ -n "${v_market_plugin}" ]] || empty+=(".claude-plugin/marketplace.json:.plugins[0].version")
+  if [[ ${#empty[@]} -gt 0 ]]; then
+    add_check "metadata-version" "fail" \
+      "Cannot read version from: ${empty[*]}"
+    return 0
+  fi
+
+  if [[ "${v_pkg}" == "${v_man}" \
+     && "${v_pkg}" == "${v_plugin}" \
+     && "${v_pkg}" == "${v_market_meta}" \
+     && "${v_pkg}" == "${v_market_plugin}" ]]; then
+    add_check "metadata-version" "ok" \
+      "All 4 metadata files report version ${v_pkg}"
+  else
+    add_check "metadata-version" "fail" \
+      "Version drift: pkg=${v_pkg} manifest=${v_man} plugin=${v_plugin} marketplace.metadata=${v_market_meta} marketplace.plugins[0]=${v_market_plugin}" \
+      "Bump all 5 fields together (release prep checklist)"
+  fi
+}
+
+# -----------------------------------------------------------------------------
+# Section: Dependencies
+# -----------------------------------------------------------------------------
+check_dependencies() {
+  # mcp/node_modules
+  if [[ -d "${CB_ROOT}/mcp/node_modules" ]]; then
+    add_check "deps-mcp-node-modules" "ok" \
+      "mcp/node_modules/ is present"
+  else
+    add_check "deps-mcp-node-modules" "warn" \
+      "mcp/node_modules/ is missing (MCP server will fail to start)" \
+      "bash scripts/setup-mcp.sh"
+  fi
+
+  # scan-secrets.sh の existence (実行は重いので doctor では起動せず info だけ)
+  if [[ -f "${CB_ROOT}/scripts/scan-secrets.sh" ]]; then
+    add_check "deps-scan-secrets" "ok" \
+      "scan-secrets.sh is present (run separately to audit Vault)"
+  else
+    add_check "deps-scan-secrets" "fail" \
+      "scan-secrets.sh is missing from scripts/" \
+      "Re-clone or re-install KIOKU"
+  fi
+}
+
+# -----------------------------------------------------------------------------
+# Output: text or JSON
+# -----------------------------------------------------------------------------
+print_text() {
+  local total=$((OK_COUNT + WARN_COUNT + FAIL_COUNT))
+  echo "KIOKU Doctor"
+  echo ""
+
+  local i=0
+  while [[ $i -lt $total ]]; do
+    local level="${RESULT_LEVELS[$i]}"
+    local msg="${RESULT_MSGS[$i]}"
+    case "${level}" in
+      ok)   printf '[ok]   %s\n' "${msg}" ;;
+      warn) printf '[warn] %s\n' "${msg}" ;;
+      fail) printf '[fail] %s\n' "${msg}" ;;
+    esac
+    i=$((i + 1))
+  done
+
+  echo ""
+  printf 'Summary: %d ok / %d warn / %d fail\n' \
+    "${OK_COUNT}" "${WARN_COUNT}" "${FAIL_COUNT}"
+
+  # Next actions (warn/fail で next_action が空でないものを列挙、重複は除く)
+  local actions_file
+  actions_file="$(mktemp)"
+  i=0
+  while [[ $i -lt $total ]]; do
+    local lvl="${RESULT_LEVELS[$i]}"
+    local nxt="${RESULT_NEXTS[$i]}"
+    if [[ "${lvl}" != "ok" && -n "${nxt}" ]]; then
+      printf '%s\n' "${nxt}" >> "${actions_file}"
+    fi
+    i=$((i + 1))
+  done
+  if [[ -s "${actions_file}" ]]; then
+    echo ""
+    echo "Next actions:"
+    # 重複除去 (出現順を保持)
+    awk '!seen[$0]++' "${actions_file}" | while IFS= read -r line; do
+      printf '  - %s\n' "${line}"
+    done
+  fi
+  rm -f "${actions_file}"
+}
+
+print_json() {
+  if [[ "${HAS_JQ}" -ne 1 ]]; then
+    echo "doctor: --json requires jq" >&2
+    return 2
+  fi
+
+  local total=$((OK_COUNT + WARN_COUNT + FAIL_COUNT))
+  local buf
+  buf="$(mktemp)"
+  local i=0
+  while [[ $i -lt $total ]]; do
+    local id="${RESULT_IDS[$i]}"
+    local level="${RESULT_LEVELS[$i]}"
+    local msg="${RESULT_MSGS[$i]}"
+    local nxt="${RESULT_NEXTS[$i]}"
+    jq -nc \
+      --arg id "${id}" \
+      --arg level "${level}" \
+      --arg message "${msg}" \
+      --arg next_action "${nxt}" \
+      '{id: $id, level: $level, message: $message}
+       + (if $next_action == "" then {} else {next_action: $next_action} end)' \
+      >> "${buf}"
+    i=$((i + 1))
+  done
+
+  jq -s \
+    --argjson ok "${OK_COUNT}" \
+    --argjson warn "${WARN_COUNT}" \
+    --argjson fail "${FAIL_COUNT}" \
+    '{summary: {ok: $ok, warn: $warn, fail: $fail}, checks: .}' \
+    "${buf}"
+  rm -f "${buf}"
+}
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+check_environment
+check_runtime
+check_cli_agents
+check_hook_configs
+check_mcp_configs
+check_metadata_parity
+check_dependencies
+
+if [[ "${JSON_MODE}" -eq 1 ]]; then
+  print_json
+else
+  print_text
+fi
+
+# Exit code: 1 if any fail, 2 if warn but no fail, else 0
+if [[ "${FAIL_COUNT}" -gt 0 ]]; then
+  exit 1
+elif [[ "${WARN_COUNT}" -gt 0 ]]; then
+  exit 2
+fi
+exit 0

--- a/tests/doctor.test.sh
+++ b/tests/doctor.test.sh
@@ -1,0 +1,787 @@
+#!/usr/bin/env bash
+#
+# doctor.test.sh — scripts/doctor.sh のスモークテスト (BLUE-DOCTOR-*)
+#
+# 実行: bash tools/claude-brain/tests/doctor.test.sh
+#
+# 方針:
+#   - 実 HOME / 実 Vault / 実 ~/.claude / ~/.codex / ~/.gemini を絶対に touch しない
+#   - 全 case を mktemp -d 配下の temp HOME / temp Vault / temp PATH で完結
+#   - PATH stub で `claude` `codex` `gemini` `node` `qmd` `pdfinfo` `pdftotext` を
+#     擬似的に存在 / 不在 / 古い version に切り替える
+#   - 実 jq に依存 (jq が無い環境では一部 case を skip して info 出力)
+#
+# Test ID: BLUE-DOCTOR-* (LEARN#8a per-file scope、本 file 内 unique)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+DOCTOR="${REPO_ROOT}/tools/claude-brain/scripts/doctor.sh"
+
+if [[ ! -f "${DOCTOR}" ]]; then
+  echo "FATAL: doctor.sh not found at ${DOCTOR}" >&2
+  exit 1
+fi
+
+# 実 jq への依存 (本 test 自体が jq を使う)
+if ! command -v jq >/dev/null 2>&1; then
+  echo "WARN: jq is not installed; doctor JSON-mode tests will be skipped" >&2
+fi
+
+TMPROOT="$(mktemp -d)"
+trap 'rm -rf "${TMPROOT}"' EXIT
+
+PASS=0
+FAIL=0
+
+pass() {
+  PASS=$((PASS + 1))
+  echo "  ok  $1"
+}
+
+fail() {
+  FAIL=$((FAIL + 1))
+  echo "  NG  $1" >&2
+}
+
+assert_eq() {
+  local expected="$1"
+  local actual="$2"
+  local msg="$3"
+  if [[ "${expected}" == "${actual}" ]]; then
+    pass "${msg}"
+  else
+    fail "${msg} (expected=${expected}, actual=${actual})"
+  fi
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local msg="$3"
+  if printf '%s' "${haystack}" | grep -q -F -- "${needle}"; then
+    pass "${msg}"
+  else
+    fail "${msg} (substring not found: ${needle})"
+  fi
+}
+
+assert_not_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local msg="$3"
+  if printf '%s' "${haystack}" | grep -q -F -- "${needle}"; then
+    fail "${msg} (unexpected substring found: ${needle})"
+  else
+    pass "${msg}"
+  fi
+}
+
+# -----------------------------------------------------------------------------
+# Test scaffolding
+#
+# new_case <name>:
+#   - $TMPROOT/cases/<name>/{home,vault,bin} を作る
+#   - bin/ に最低限の stub (claude/codex/gemini/qmd/pdfinfo/pdftotext/node) を配置
+#   - run_doctor で env を組んで bash doctor.sh を呼ぶ
+#
+# stub 戦略:
+#   - default (full_stub_path): 全 CLI を stub (= 実 PATH と同じ「全部 install 済」状態)
+#   - minimal_stub_path: 必要最小限のみ (jq は実 PATH のものを使う)
+# -----------------------------------------------------------------------------
+
+new_case() {
+  local name="$1"
+  local case_dir="${TMPROOT}/cases/${name}"
+  mkdir -p "${case_dir}/home" "${case_dir}/vault" "${case_dir}/bin"
+  echo "${case_dir}"
+}
+
+# write a small stub command into <bin>/<name> with optional output
+write_stub() {
+  local bin_dir="$1"
+  local name="$2"
+  local output="${3:-}"
+  cat >"${bin_dir}/${name}" <<EOF
+#!/usr/bin/env bash
+# stub for ${name}
+$( [[ -n "${output}" ]] && echo "echo '${output}'" )
+exit 0
+EOF
+  chmod +x "${bin_dir}/${name}"
+}
+
+# Locate real binary path for jq / git / grep / awk so we can preserve them in
+# the test PATH while stubbing CLI tools.
+real_path_for() {
+  local name="$1"
+  command -v "${name}" 2>/dev/null || true
+}
+
+# Build a minimal PATH that contains:
+#   - the case-specific bin/ (CLI stubs)
+#   - dirs of jq, git, grep, awk, mktemp, sed, uname, dirname, mkdir, rm, cat,
+#     printf, chmod (and other coreutils used by doctor.sh)
+# We just include $TMPROOT/bin then fall back to a curated allowlist of dirs
+# from the real PATH (avoids leaking $HOME tooling).
+build_path() {
+  local case_bin="$1"
+  local extras=""
+  local p
+  # Include common system paths so the doctor.sh's internal tooling works.
+  for p in /usr/bin /bin /usr/sbin /sbin /opt/homebrew/bin /usr/local/bin; do
+    [[ -d "${p}" ]] && extras="${extras}:${p}"
+  done
+  printf '%s%s' "${case_bin}" "${extras}"
+}
+
+# Run doctor with custom env. Returns exit code via $? and stdout via stdout.
+# Args: <case_dir> [extra env entries]
+run_doctor() {
+  local case_dir="$1"; shift
+  local home="${case_dir}/home"
+  local vault="${case_dir}/vault"
+  local case_bin="${case_dir}/bin"
+  local path
+  path="$(build_path "${case_bin}")"
+
+  # Use env -i to scrub inherited env (avoid host's OBSIDIAN_VAULT etc.)
+  env -i \
+    HOME="${home}" \
+    PATH="${path}" \
+    TMPDIR="${TMPDIR:-/tmp}" \
+    "$@" \
+    bash "${DOCTOR}"
+}
+
+# -----------------------------------------------------------------------------
+# Stub builders for common scenarios
+#
+# stub_full_clis <bin>: stubs claude / codex / gemini / qmd / pdfinfo / pdftotext
+# stub_node_18 <bin>: stubs node returning v18.20.0
+# stub_node_17 <bin>: stubs node returning v17.99.99
+# -----------------------------------------------------------------------------
+stub_full_clis() {
+  local bin="$1"
+  write_stub "${bin}" "claude"
+  write_stub "${bin}" "codex"
+  write_stub "${bin}" "gemini"
+  write_stub "${bin}" "qmd"
+  write_stub "${bin}" "pdfinfo"
+  write_stub "${bin}" "pdftotext"
+}
+
+stub_node_18() {
+  local bin="$1"
+  cat >"${bin}/node" <<'EOF'
+#!/usr/bin/env bash
+case "${1:-}" in
+  --version|-v) echo "v18.20.0" ;;
+  *) exit 0 ;;
+esac
+EOF
+  chmod +x "${bin}/node"
+}
+
+stub_node_17() {
+  local bin="$1"
+  cat >"${bin}/node" <<'EOF'
+#!/usr/bin/env bash
+case "${1:-}" in
+  --version|-v) echo "v17.99.99" ;;
+  *) exit 0 ;;
+esac
+EOF
+  chmod +x "${bin}/node"
+}
+
+# Vault setup helpers
+init_full_vault() {
+  local vault="$1"
+  mkdir -p "${vault}/wiki" "${vault}/session-logs" "${vault}/raw-sources" "${vault}/templates"
+  cat >"${vault}/.gitignore" <<'EOF'
+session-logs/
+.cache/
+.obsidian/
+EOF
+  # Make it look like a git repo via `git init`
+  (cd "${vault}" && git init --quiet 2>/dev/null) || true
+}
+
+# -----------------------------------------------------------------------------
+# BLUE-DOCTOR-ENV-1: OBSIDIAN_VAULT unset → fail
+# -----------------------------------------------------------------------------
+test_env_unset() {
+  echo "BLUE-DOCTOR-ENV-1: OBSIDIAN_VAULT unset → fail"
+  local d
+  d="$(new_case "env-unset")"
+  stub_full_clis "${d}/bin"
+  stub_node_18 "${d}/bin"
+
+  local out
+  set +e
+  out="$(run_doctor "${d}" 2>&1)"
+  local rc=$?
+  set -e
+
+  assert_contains "${out}" "[fail] OBSIDIAN_VAULT is not set" "ENV-1: fail line for unset OBSIDIAN_VAULT"
+  assert_eq "1" "${rc}" "ENV-1: exit code 1 (any fail)"
+}
+
+# -----------------------------------------------------------------------------
+# BLUE-DOCTOR-ENV-2: OBSIDIAN_VAULT set but Vault dir missing → fail
+# -----------------------------------------------------------------------------
+test_env_vault_dir_missing() {
+  echo "BLUE-DOCTOR-ENV-2: OBSIDIAN_VAULT set + Vault dir missing → fail"
+  local d
+  d="$(new_case "env-vault-missing")"
+  stub_full_clis "${d}/bin"
+  stub_node_18 "${d}/bin"
+
+  local missing="${d}/does-not-exist"
+  local out
+  set +e
+  out="$(run_doctor "${d}" OBSIDIAN_VAULT="${missing}" 2>&1)"
+  local rc=$?
+  set -e
+
+  assert_contains "${out}" "[fail] Vault directory does not exist" "ENV-2: fail line for missing Vault dir"
+  assert_contains "${out}" "setup-vault.sh" "ENV-2: suggests setup-vault.sh"
+  assert_eq "1" "${rc}" "ENV-2: exit code 1"
+}
+
+# -----------------------------------------------------------------------------
+# BLUE-DOCTOR-VAULT-1: full Vault → ok subdirs
+# -----------------------------------------------------------------------------
+test_vault_full_ok() {
+  echo "BLUE-DOCTOR-VAULT-1: full Vault subdirs → ok"
+  local d
+  d="$(new_case "vault-full")"
+  stub_full_clis "${d}/bin"
+  stub_node_18 "${d}/bin"
+  init_full_vault "${d}/vault"
+
+  local out
+  set +e
+  out="$(run_doctor "${d}" OBSIDIAN_VAULT="${d}/vault" 2>&1)"
+  set -e
+
+  assert_contains "${out}" "[ok]   Vault has wiki/ session-logs/ raw-sources/ templates/" \
+    "VAULT-1: all 4 subdirs detected"
+}
+
+# -----------------------------------------------------------------------------
+# BLUE-DOCTOR-VAULT-2: only wiki/ → fail with missing list
+# -----------------------------------------------------------------------------
+test_vault_partial_fail() {
+  echo "BLUE-DOCTOR-VAULT-2: only wiki/ → fail listing missing dirs"
+  local d
+  d="$(new_case "vault-partial")"
+  stub_full_clis "${d}/bin"
+  stub_node_18 "${d}/bin"
+  mkdir -p "${d}/vault/wiki"
+
+  local out
+  set +e
+  out="$(run_doctor "${d}" OBSIDIAN_VAULT="${d}/vault" 2>&1)"
+  local rc=$?
+  set -e
+
+  assert_contains "${out}" "[fail] Vault missing required subdirs:" "VAULT-2: fail line"
+  assert_contains "${out}" "session-logs" "VAULT-2: lists session-logs"
+  assert_contains "${out}" "raw-sources" "VAULT-2: lists raw-sources"
+  assert_contains "${out}" "templates" "VAULT-2: lists templates"
+  assert_eq "1" "${rc}" "VAULT-2: exit code 1"
+}
+
+# -----------------------------------------------------------------------------
+# BLUE-DOCTOR-GITIGNORE-1: .gitignore has session-logs/ + .cache/ → ok
+# -----------------------------------------------------------------------------
+test_gitignore_complete() {
+  echo "BLUE-DOCTOR-GITIGNORE-1: .gitignore complete → ok"
+  local d
+  d="$(new_case "gitignore-complete")"
+  stub_full_clis "${d}/bin"
+  stub_node_18 "${d}/bin"
+  init_full_vault "${d}/vault"
+
+  local out
+  set +e
+  out="$(run_doctor "${d}" OBSIDIAN_VAULT="${d}/vault" 2>&1)"
+  set -e
+
+  assert_contains "${out}" "[ok]   .gitignore excludes session-logs/" "GITIGNORE-1: session-logs entry detected"
+  assert_contains "${out}" "[ok]   .gitignore excludes .cache/" "GITIGNORE-1: .cache entry detected"
+}
+
+# -----------------------------------------------------------------------------
+# BLUE-DOCTOR-GITIGNORE-2: missing session-logs/ → fail (security)
+# -----------------------------------------------------------------------------
+test_gitignore_missing_session_logs() {
+  echo "BLUE-DOCTOR-GITIGNORE-2: missing session-logs/ → fail"
+  local d
+  d="$(new_case "gitignore-missing-sl")"
+  stub_full_clis "${d}/bin"
+  stub_node_18 "${d}/bin"
+  init_full_vault "${d}/vault"
+  # Replace gitignore with one that has only .cache/
+  cat >"${d}/vault/.gitignore" <<'EOF'
+.cache/
+EOF
+
+  local out
+  set +e
+  out="$(run_doctor "${d}" OBSIDIAN_VAULT="${d}/vault" 2>&1)"
+  local rc=$?
+  set -e
+
+  assert_contains "${out}" "[fail] .gitignore is missing 'session-logs/'" "GITIGNORE-2: fail line"
+  assert_eq "1" "${rc}" "GITIGNORE-2: exit code 1 (security)"
+}
+
+# -----------------------------------------------------------------------------
+# BLUE-DOCTOR-NODE-1: Node 18+ stub → ok
+# -----------------------------------------------------------------------------
+test_node_18_ok() {
+  echo "BLUE-DOCTOR-NODE-1: Node 18 → ok"
+  local d
+  d="$(new_case "node-18")"
+  stub_full_clis "${d}/bin"
+  stub_node_18 "${d}/bin"
+  init_full_vault "${d}/vault"
+
+  local out
+  set +e
+  out="$(run_doctor "${d}" OBSIDIAN_VAULT="${d}/vault" 2>&1)"
+  set -e
+
+  assert_contains "${out}" "[ok]   Node v18.20.0 (>= 18 required)" "NODE-1: Node 18 ok"
+}
+
+# -----------------------------------------------------------------------------
+# BLUE-DOCTOR-NODE-2: Node 17 stub → fail
+# -----------------------------------------------------------------------------
+test_node_17_fail() {
+  echo "BLUE-DOCTOR-NODE-2: Node 17 → fail"
+  local d
+  d="$(new_case "node-17")"
+  stub_full_clis "${d}/bin"
+  stub_node_17 "${d}/bin"
+  init_full_vault "${d}/vault"
+
+  local out
+  set +e
+  out="$(run_doctor "${d}" OBSIDIAN_VAULT="${d}/vault" 2>&1)"
+  local rc=$?
+  set -e
+
+  assert_contains "${out}" "[fail] Node v17.99.99 is too old" "NODE-2: fail for Node 17"
+  assert_eq "1" "${rc}" "NODE-2: exit code 1"
+}
+
+# -----------------------------------------------------------------------------
+# BLUE-DOCTOR-CLI-CLAUDE-1: claude in PATH → ok
+# -----------------------------------------------------------------------------
+test_cli_claude_present() {
+  echo "BLUE-DOCTOR-CLI-CLAUDE-1: claude in PATH → ok"
+  local d
+  d="$(new_case "cli-claude-present")"
+  stub_full_clis "${d}/bin"
+  stub_node_18 "${d}/bin"
+  init_full_vault "${d}/vault"
+
+  local out
+  set +e
+  out="$(run_doctor "${d}" OBSIDIAN_VAULT="${d}/vault" 2>&1)"
+  set -e
+
+  assert_contains "${out}" "[ok]   claude CLI is installed" "CLI-CLAUDE-1: claude detected"
+}
+
+# -----------------------------------------------------------------------------
+# BLUE-DOCTOR-CLI-CLAUDE-2: claude not in PATH → fail
+# -----------------------------------------------------------------------------
+test_cli_claude_missing() {
+  echo "BLUE-DOCTOR-CLI-CLAUDE-2: claude not in PATH → fail"
+  local d
+  d="$(new_case "cli-claude-missing")"
+  # Stub everything except claude
+  write_stub "${d}/bin" "codex"
+  write_stub "${d}/bin" "gemini"
+  write_stub "${d}/bin" "qmd"
+  write_stub "${d}/bin" "pdfinfo"
+  write_stub "${d}/bin" "pdftotext"
+  stub_node_18 "${d}/bin"
+  init_full_vault "${d}/vault"
+
+  local out
+  set +e
+  out="$(run_doctor "${d}" OBSIDIAN_VAULT="${d}/vault" 2>&1)"
+  local rc=$?
+  set -e
+
+  assert_contains "${out}" "[fail] claude CLI is not installed" "CLI-CLAUDE-2: fail line"
+  assert_eq "1" "${rc}" "CLI-CLAUDE-2: exit code 1"
+}
+
+# -----------------------------------------------------------------------------
+# BLUE-DOCTOR-HOOK-CLAUDE-1: settings.json with KIOKU hook → ok
+# -----------------------------------------------------------------------------
+test_hook_claude_present() {
+  echo "BLUE-DOCTOR-HOOK-CLAUDE-1: ~/.claude/settings.json with session-logger.mjs → ok"
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "  skip  jq not available"
+    return 0
+  fi
+  local d
+  d="$(new_case "hook-claude-present")"
+  stub_full_clis "${d}/bin"
+  stub_node_18 "${d}/bin"
+  init_full_vault "${d}/vault"
+
+  mkdir -p "${d}/home/.claude"
+  cat >"${d}/home/.claude/settings.json" <<'EOF'
+{
+  "hooks": {
+    "Stop": [
+      { "hooks": [ { "type": "command", "command": "node /tmp/session-logger.mjs" } ] }
+    ]
+  }
+}
+EOF
+
+  local out
+  set +e
+  out="$(run_doctor "${d}" OBSIDIAN_VAULT="${d}/vault" 2>&1)"
+  set -e
+
+  assert_contains "${out}" "[ok]   ~/.claude/settings.json registers KIOKU session-logger hook" \
+    "HOOK-CLAUDE-1: KIOKU hook detected"
+}
+
+# -----------------------------------------------------------------------------
+# BLUE-DOCTOR-HOOK-CLAUDE-2: settings.json without KIOKU hook → fail
+# -----------------------------------------------------------------------------
+test_hook_claude_missing_kioku() {
+  echo "BLUE-DOCTOR-HOOK-CLAUDE-2: ~/.claude/settings.json missing KIOKU hook → fail"
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "  skip  jq not available"
+    return 0
+  fi
+  local d
+  d="$(new_case "hook-claude-missing")"
+  stub_full_clis "${d}/bin"
+  stub_node_18 "${d}/bin"
+  init_full_vault "${d}/vault"
+
+  mkdir -p "${d}/home/.claude"
+  # settings.json exists but only has unrelated hook
+  cat >"${d}/home/.claude/settings.json" <<'EOF'
+{
+  "hooks": {
+    "Stop": [
+      { "hooks": [ { "type": "command", "command": "echo unrelated" } ] }
+    ]
+  }
+}
+EOF
+
+  local out
+  set +e
+  out="$(run_doctor "${d}" OBSIDIAN_VAULT="${d}/vault" 2>&1)"
+  local rc=$?
+  set -e
+
+  assert_contains "${out}" "[fail] ~/.claude/settings.json does not register KIOKU session-logger hook" \
+    "HOOK-CLAUDE-2: fail line"
+  assert_contains "${out}" "install-hooks.sh --apply" "HOOK-CLAUDE-2: suggests install-hooks.sh"
+  assert_eq "1" "${rc}" "HOOK-CLAUDE-2: exit code 1"
+}
+
+# -----------------------------------------------------------------------------
+# BLUE-DOCTOR-HOOK-CODEX-1: ~/.codex/hooks.json with adapters/codex.mjs → ok
+# -----------------------------------------------------------------------------
+test_hook_codex_present() {
+  echo "BLUE-DOCTOR-HOOK-CODEX-1: ~/.codex/hooks.json with adapters/codex.mjs → ok"
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "  skip  jq not available"
+    return 0
+  fi
+  local d
+  d="$(new_case "hook-codex-present")"
+  stub_full_clis "${d}/bin"
+  stub_node_18 "${d}/bin"
+  init_full_vault "${d}/vault"
+
+  mkdir -p "${d}/home/.codex"
+  cat >"${d}/home/.codex/hooks.json" <<'EOF'
+{
+  "hooks": {
+    "Stop": [
+      { "hooks": [ { "type": "command", "command": "node /tmp/hooks/adapters/codex.mjs" } ] }
+    ]
+  }
+}
+EOF
+
+  local out
+  set +e
+  out="$(run_doctor "${d}" OBSIDIAN_VAULT="${d}/vault" 2>&1)"
+  set -e
+
+  assert_contains "${out}" "[ok]   ~/.codex/hooks.json registers KIOKU codex adapter hook" \
+    "HOOK-CODEX-1: KIOKU codex adapter detected"
+}
+
+# -----------------------------------------------------------------------------
+# BLUE-DOCTOR-HOOK-GEMINI-1: ~/.gemini/settings.json with claude-brain-* names → ok
+# -----------------------------------------------------------------------------
+test_hook_gemini_present() {
+  echo "BLUE-DOCTOR-HOOK-GEMINI-1: ~/.gemini/settings.json with claude-brain-* → ok"
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "  skip  jq not available"
+    return 0
+  fi
+  local d
+  d="$(new_case "hook-gemini-present")"
+  stub_full_clis "${d}/bin"
+  stub_node_18 "${d}/bin"
+  init_full_vault "${d}/vault"
+
+  mkdir -p "${d}/home/.gemini"
+  cat >"${d}/home/.gemini/settings.json" <<'EOF'
+{
+  "hooks": {
+    "AfterAgent": [
+      {
+        "matcher": "*",
+        "hooks": [
+          { "name": "claude-brain-assistant-stop", "type": "command", "command": "node /tmp/x.mjs" }
+        ]
+      }
+    ]
+  }
+}
+EOF
+
+  local out
+  set +e
+  out="$(run_doctor "${d}" OBSIDIAN_VAULT="${d}/vault" 2>&1)"
+  set -e
+
+  assert_contains "${out}" "[ok]   ~/.gemini/settings.json registers KIOKU gemini hooks" \
+    "HOOK-GEMINI-1: KIOKU gemini hooks detected"
+}
+
+# -----------------------------------------------------------------------------
+# BLUE-DOCTOR-VERSION-1: All 4 metadata files share same version → ok
+#
+# 本 test は実 repo の metadata を読むため、parity が崩れていれば fail と出る
+# (これは実は望ましい — repo 側の release prep を doctor が pin する)
+# -----------------------------------------------------------------------------
+test_version_parity_real_repo() {
+  echo "BLUE-DOCTOR-VERSION-1: real repo metadata version parity → ok (or fail if drift)"
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "  skip  jq not available"
+    return 0
+  fi
+  local d
+  d="$(new_case "version-real")"
+  stub_full_clis "${d}/bin"
+  stub_node_18 "${d}/bin"
+  init_full_vault "${d}/vault"
+
+  local out
+  set +e
+  out="$(run_doctor "${d}" OBSIDIAN_VAULT="${d}/vault" 2>&1)"
+  set -e
+
+  # In the current repo all 4 files share the same version. If a future PR
+  # introduces drift, this assertion will fail (which is the intent).
+  assert_contains "${out}" "[ok]   All 4 metadata files report version" \
+    "VERSION-1: real repo metadata parity ok"
+}
+
+# -----------------------------------------------------------------------------
+# BLUE-DOCTOR-EXIT-CODE-1: All-ok scenario → exit 0
+# -----------------------------------------------------------------------------
+test_exit_code_all_ok() {
+  echo "BLUE-DOCTOR-EXIT-CODE-1: full healthy state → exit 0"
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "  skip  jq not available"
+    return 0
+  fi
+  local d
+  d="$(new_case "exit-all-ok")"
+  stub_full_clis "${d}/bin"
+  stub_node_18 "${d}/bin"
+  init_full_vault "${d}/vault"
+
+  # Configure all hook configs and MCP configs so no fail/warn arises (other
+  # than info-level checks that always pass).
+  mkdir -p "${d}/home/.claude" "${d}/home/.codex" "${d}/home/.gemini" \
+           "${d}/home/Library/Application Support/Claude"
+  cat >"${d}/home/.claude/settings.json" <<'EOF'
+{ "hooks": { "Stop": [ { "hooks": [ { "type": "command", "command": "node /x/session-logger.mjs" } ] } ] } }
+EOF
+  cat >"${d}/home/.codex/hooks.json" <<'EOF'
+{ "hooks": { "Stop": [ { "hooks": [ { "type": "command", "command": "node /x/hooks/adapters/codex.mjs" } ] } ] } }
+EOF
+  cat >"${d}/home/.codex/config.toml" <<'EOF'
+[mcp_servers.kioku]
+command = "node"
+args = ["/x/server.mjs"]
+EOF
+  cat >"${d}/home/.gemini/settings.json" <<'EOF'
+{
+  "hooks": { "AfterAgent": [ { "hooks": [ { "name": "claude-brain-assistant-stop", "type": "command", "command": "node /x.mjs" } ] } ] },
+  "mcpServers": { "kioku": { "command": "node", "args": ["/x/server.mjs"] } }
+}
+EOF
+  cat >"${d}/home/Library/Application Support/Claude/claude_desktop_config.json" <<'EOF'
+{ "mcpServers": { "kioku-wiki": { "command": "node", "args": ["/x/server.mjs"] } } }
+EOF
+
+  local out
+  set +e
+  out="$(run_doctor "${d}" OBSIDIAN_VAULT="${d}/vault" \
+    CLAUDE_DESKTOP_CONFIG="${d}/home/Library/Application Support/Claude/claude_desktop_config.json" \
+    2>&1)"
+  local rc=$?
+  set -e
+
+  assert_eq "0" "${rc}" "EXIT-CODE-1: rc=0 in fully healthy state"
+  assert_not_contains "${out}" "[fail]" "EXIT-CODE-1: no [fail] lines"
+  assert_not_contains "${out}" "[warn]" "EXIT-CODE-1: no [warn] lines"
+}
+
+# -----------------------------------------------------------------------------
+# BLUE-DOCTOR-EXIT-CODE-2: 1 fail → exit 1
+# -----------------------------------------------------------------------------
+test_exit_code_fail() {
+  echo "BLUE-DOCTOR-EXIT-CODE-2: 1 fail → exit 1"
+  local d
+  d="$(new_case "exit-fail")"
+  stub_full_clis "${d}/bin"
+  stub_node_18 "${d}/bin"
+  # No Vault setup → forces fail on env-vault-dir
+  local out
+  set +e
+  out="$(run_doctor "${d}" OBSIDIAN_VAULT="${d}/no-such-vault" 2>&1)"
+  local rc=$?
+  set -e
+  assert_eq "1" "${rc}" "EXIT-CODE-2: rc=1 when fail present"
+}
+
+# -----------------------------------------------------------------------------
+# BLUE-DOCTOR-EXIT-CODE-3: warn only (no fail) → exit 2
+#
+# To produce only warns: full healthy Vault but no qmd / Claude Desktop config
+# → at least one warn (warn = qmd missing or Claude Desktop config missing) +
+# CLI agent warns (codex/gemini absent if only claude is stubbed).
+# -----------------------------------------------------------------------------
+test_exit_code_warn_only() {
+  echo "BLUE-DOCTOR-EXIT-CODE-3: warn only (no fail) → exit 2"
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "  skip  jq not available"
+    return 0
+  fi
+  local d
+  d="$(new_case "exit-warn-only")"
+  # Stub claude only (codex / gemini absent → warn)
+  # Stub poppler so no warn from there.
+  write_stub "${d}/bin" "claude"
+  write_stub "${d}/bin" "pdfinfo"
+  write_stub "${d}/bin" "pdftotext"
+  # qmd intentionally missing → warn
+  stub_node_18 "${d}/bin"
+  init_full_vault "${d}/vault"
+
+  # Claude hook ok, but Claude Desktop config absent → warn (not fail)
+  mkdir -p "${d}/home/.claude"
+  cat >"${d}/home/.claude/settings.json" <<'EOF'
+{ "hooks": { "Stop": [ { "hooks": [ { "type": "command", "command": "node /x/session-logger.mjs" } ] } ] } }
+EOF
+
+  local out
+  set +e
+  out="$(run_doctor "${d}" OBSIDIAN_VAULT="${d}/vault" 2>&1)"
+  local rc=$?
+  set -e
+
+  assert_not_contains "${out}" "[fail]" "EXIT-CODE-3: no fail lines"
+  assert_contains "${out}" "[warn]" "EXIT-CODE-3: at least one warn line"
+  assert_eq "2" "${rc}" "EXIT-CODE-3: rc=2 (warn only)"
+}
+
+# -----------------------------------------------------------------------------
+# BLUE-DOCTOR-JSON-1: --json output is parseable + has summary + checks
+# -----------------------------------------------------------------------------
+test_json_output() {
+  echo "BLUE-DOCTOR-JSON-1: --json mode emits valid JSON"
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "  skip  jq not available"
+    return 0
+  fi
+  local d
+  d="$(new_case "json-mode")"
+  stub_full_clis "${d}/bin"
+  stub_node_18 "${d}/bin"
+  init_full_vault "${d}/vault"
+
+  # run_doctor does not pass extra CLI args to doctor.sh (its trailing $@ is
+  # treated as additional env assignments by env -i). For --json we invoke
+  # bash directly with the same scrubbed-env pattern.
+  local out
+  set +e
+  out="$(env -i \
+        HOME="${d}/home" \
+        PATH="$(build_path "${d}/bin")" \
+        TMPDIR="${TMPDIR:-/tmp}" \
+        OBSIDIAN_VAULT="${d}/vault" \
+        bash "${DOCTOR}" --json 2>&1)"
+  set -e
+
+  # Validate JSON parse + structure
+  if printf '%s' "${out}" | jq -e '.summary.ok and .summary.warn and .summary.fail and (.checks|length > 0)' >/dev/null 2>&1; then
+    pass "JSON-1: --json emits {summary, checks[]}"
+  else
+    # ok==0 が falsy になり得るので別判定 (any field exists) — ok=0 case 用
+    if printf '%s' "${out}" | jq -e '(.summary | has("ok") and has("warn") and has("fail")) and (.checks|length > 0)' >/dev/null 2>&1; then
+      pass "JSON-1: --json emits {summary, checks[]}"
+    else
+      fail "JSON-1: --json output is not valid (got: $(printf '%s' "${out}" | head -c 200))"
+    fi
+  fi
+}
+
+# -----------------------------------------------------------------------------
+# Run all
+# -----------------------------------------------------------------------------
+test_env_unset
+test_env_vault_dir_missing
+test_vault_full_ok
+test_vault_partial_fail
+test_gitignore_complete
+test_gitignore_missing_session_logs
+test_node_18_ok
+test_node_17_fail
+test_cli_claude_present
+test_cli_claude_missing
+test_hook_claude_present
+test_hook_claude_missing_kioku
+test_hook_codex_present
+test_hook_gemini_present
+test_version_parity_real_repo
+test_exit_code_all_ok
+test_exit_code_fail
+test_exit_code_warn_only
+test_json_output
+
+echo ""
+echo "doctor.test.sh: ${PASS} passed, ${FAIL} failed"
+if [[ ${FAIL} -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/tests/extract-url.test.sh
+++ b/tests/extract-url.test.sh
@@ -4,6 +4,14 @@
 # 実行: bash tools/claude-brain/tests/extract-url.test.sh
 set -euo pipefail
 
+# v0.7.2 PR C: URL test 安定化。`KIOKU_SKIP_NETWORKISH_TESTS=1` で skip 可能。
+# 本テストは extract-url.sh を spawn し DNS lookup (example.invalid 解決) を伴うため
+# network-ish 扱いとし、quick suite では skip する。
+if [[ "${KIOKU_SKIP_NETWORKISH_TESTS:-0}" == "1" ]]; then
+  echo "SKIP: extract-url.test.sh (KIOKU_SKIP_NETWORKISH_TESTS=1)"
+  exit 0
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 EXTRACT="${REPO_ROOT}/tools/claude-brain/scripts/extract-url.sh"
@@ -11,6 +19,19 @@ EXTRACT="${REPO_ROOT}/tools/claude-brain/scripts/extract-url.sh"
 unset OBSIDIAN_VAULT || true
 TMPROOT="$(mktemp -d)"
 trap 'rm -rf "${TMPROOT}"' EXIT
+
+# Hard timeout (30s per spawn) — extract-url.sh が DNS resolution / fetch で hang した
+# 場合に test runner 全体を止めない。`timeout` は coreutils (Linux) / `gtimeout` (macOS
+# brew) / なし (素 macOS) のいずれか。fallback で素 spawn。
+timeout_run() {
+  if command -v timeout >/dev/null 2>&1; then
+    timeout 30 "$@"
+  elif command -v gtimeout >/dev/null 2>&1; then
+    gtimeout 30 "$@"
+  else
+    "$@"
+  fi
+}
 
 PASS=0; FAIL=0
 pass() { PASS=$((PASS+1)); echo "  ok  $1"; }
@@ -26,22 +47,29 @@ assert_contains() {
 
 # EU1: --help → exit 0 + "Usage"
 echo "test EU1: --help exits 0"
-set +e; out1="$(bash "${EXTRACT}" --help 2>&1)"; rc=$?; set -e
+set +e; out1="$(timeout_run bash "${EXTRACT}" --help 2>&1)"; rc=$?; set -e
 assert_eq "0" "${rc}" "EU1 --help exit 0"
 assert_contains "${out1}" "Usage" "EU1 usage shown"
 
 # EU2: missing --url and --urls-file → exit 2
 echo "test EU2: missing --url exits 2"
-set +e; out2="$(bash "${EXTRACT}" --vault "${TMPROOT}/v" 2>&1)"; rc=$?; set -e
+set +e; out2="$(timeout_run bash "${EXTRACT}" --vault "${TMPROOT}/v" 2>&1)"; rc=$?; set -e
 assert_eq "2" "${rc}" "EU2 exit 2"
 assert_contains "${out2}" "--url required" "EU2 error message"
 
 # EU3: node missing → exit 1
 # `env -i PATH=/usr/bin:/bin` to strip volta/brew installations of node.
 # macOS default: /usr/bin/node does not exist, so node is unavailable.
+# 注: timeout_run() (shell function) は `env -i` で消えるため、ここでは
+# 直接 `timeout` (or `gtimeout`) binary を前置する。binary が無ければ素 spawn。
 echo "test EU3: node missing exits 1"
+TIMEOUT_BIN=""
+if command -v timeout >/dev/null 2>&1; then TIMEOUT_BIN="timeout 30"
+elif command -v gtimeout >/dev/null 2>&1; then TIMEOUT_BIN="gtimeout 30"
+fi
 set +e
-out3="$(env -i HOME=/tmp PATH=/usr/bin:/bin bash "${EXTRACT}" \
+# shellcheck disable=SC2086
+out3="$(${TIMEOUT_BIN} env -i HOME=/tmp PATH=/usr/bin:/bin bash "${EXTRACT}" \
   --url http://example.com --vault "${TMPROOT}/v" 2>&1)"
 rc=$?
 set -e
@@ -57,7 +85,7 @@ fi
 echo "test EU4: bad URL in urls.txt is tolerated"
 mkdir -p "${TMPROOT}/v"
 echo "not-a-url" > "${TMPROOT}/urls.txt"
-set +e; out4="$(bash "${EXTRACT}" --urls-file "${TMPROOT}/urls.txt" --vault "${TMPROOT}/v" --subdir articles 2>&1)"; rc=$?; set -e
+set +e; out4="$(timeout_run bash "${EXTRACT}" --urls-file "${TMPROOT}/urls.txt" --vault "${TMPROOT}/v" --subdir articles 2>&1)"; rc=$?; set -e
 assert_eq "0" "${rc}" "EU4 exit 0 (bad URL → warning only)"
 assert_contains "${out4}" "skip non-URL" "EU4 warned on non-URL"
 
@@ -68,7 +96,7 @@ cat > "${TMPROOT}/urls-multi.txt" <<EOF
 http://example.invalid/a
 http://example.invalid/b ; tags=x
 EOF
-set +e; out5="$(bash "${EXTRACT}" --urls-file "${TMPROOT}/urls-multi.txt" --vault "${TMPROOT}/v" --subdir articles 2>&1)"; rc=$?; set -e
+set +e; out5="$(timeout_run bash "${EXTRACT}" --urls-file "${TMPROOT}/urls-multi.txt" --vault "${TMPROOT}/v" --subdir articles 2>&1)"; rc=$?; set -e
 assert_eq "0" "${rc}" "EU5 exit 0 (loop completes even if individual URLs fail)"
 assert_contains "${out5}" "example.invalid/a" "EU5 first URL logged"
 assert_contains "${out5}" "example.invalid/b" "EU5 second URL logged"
@@ -79,19 +107,19 @@ cat > "${TMPROOT}/urls-comments.txt" <<EOF
 # all comments
 # nothing to do
 EOF
-set +e; out6="$(bash "${EXTRACT}" --urls-file "${TMPROOT}/urls-comments.txt" --vault "${TMPROOT}/v" --subdir articles 2>&1)"; rc=$?; set -e
+set +e; out6="$(timeout_run bash "${EXTRACT}" --urls-file "${TMPROOT}/urls-comments.txt" --vault "${TMPROOT}/v" --subdir articles 2>&1)"; rc=$?; set -e
 assert_eq "0" "${rc}" "EU6 exit 0 with no URLs"
 
 # EU7: unknown DSL key produces warning but does not abort
 echo "test EU7: unknown DSL key"
 echo "http://example.invalid/c ; weirdkey=foo" > "${TMPROOT}/urls-weird.txt"
-set +e; out7="$(bash "${EXTRACT}" --urls-file "${TMPROOT}/urls-weird.txt" --vault "${TMPROOT}/v" --subdir articles 2>&1)"; rc=$?; set -e
+set +e; out7="$(timeout_run bash "${EXTRACT}" --urls-file "${TMPROOT}/urls-weird.txt" --vault "${TMPROOT}/v" --subdir articles 2>&1)"; rc=$?; set -e
 assert_eq "0" "${rc}" "EU7 exit 0 despite unknown DSL"
 assert_contains "${out7}" "unknown DSL key: weirdkey" "EU7 warned on weirdkey"
 
 # EU8: unknown flag → exit 2
 echo "test EU8: unknown flag"
-set +e; out8="$(bash "${EXTRACT}" --url http://example.com --bogus yes --vault "${TMPROOT}/v" 2>&1)"; rc=$?; set -e
+set +e; out8="$(timeout_run bash "${EXTRACT}" --url http://example.com --bogus yes --vault "${TMPROOT}/v" 2>&1)"; rc=$?; set -e
 assert_eq "2" "${rc}" "EU8 unknown flag exit 2"
 assert_contains "${out8}" "unknown flag" "EU8 error mentions flag"
 

--- a/tests/mcp/tools-ingest-url.test.mjs
+++ b/tests/mcp/tools-ingest-url.test.mjs
@@ -47,6 +47,11 @@ const MCP_DIR = join(__dirname, '..', '..', 'mcp');
 
 const { handleIngestUrl } = await import(join(MCP_DIR, 'tools', 'ingest-url.mjs'));
 
+// v0.7.2 PR C: URL test 安定化。fixture server / network-ish 統合テストは
+// `KIOKU_SKIP_NETWORKISH_TESTS=1` で skip 可能、各 test に 30s hard timeout。
+const SKIP_NETWORK = process.env.KIOKU_SKIP_NETWORKISH_TESTS === '1';
+const NETWORK_TEST = { skip: SKIP_NETWORK ? 'KIOKU_SKIP_NETWORKISH_TESTS=1' : false, timeout: 30_000 };
+
 // poppler が無ければ PDF dispatch サブスイートを skip (handleIngestPdf が extract-pdf.sh
 // を spawn するので pdfinfo / pdftotext が必要)。
 const popplerCheck = spawnSync(
@@ -62,6 +67,7 @@ let stubBin;
 let stubLog;
 
 before(async () => {
+  if (SKIP_NETWORK) return;
   process.env.KIOKU_URL_ALLOW_LOOPBACK = '1';
   server = await startFixtureServer();
   workspace = await mkdtemp(join(tmpdir(), 'kioku-iu-'));
@@ -93,6 +99,7 @@ before(async () => {
 });
 
 after(async () => {
+  if (SKIP_NETWORK) return;
   delete process.env.KIOKU_URL_ALLOW_LOOPBACK;
   if (server) await server.close();
   if (workspace) await rm(workspace, { recursive: true, force: true });
@@ -109,7 +116,7 @@ async function makeVault(name) {
 }
 
 describe('kioku_ingest_url', () => {
-  test('MCP31 normal URL → fetched_and_summarized_pending', async () => {
+  test('MCP31 normal URL → fetched_and_summarized_pending', NETWORK_TEST, async () => {
     const v = await makeVault('mcp31');
     const r = await handleIngestUrl(
       v,
@@ -123,7 +130,7 @@ describe('kioku_ingest_url', () => {
     assert.ok(r.path.startsWith('raw-sources/articles/fetched/'));
   });
 
-  test('MCP32 SSRF: localhost rejected when KIOKU_URL_ALLOW_LOOPBACK=0', async () => {
+  test('MCP32 SSRF: localhost rejected when KIOKU_URL_ALLOW_LOOPBACK=0', NETWORK_TEST, async () => {
     process.env.KIOKU_URL_ALLOW_LOOPBACK = '0';
     try {
       const v = await makeVault('mcp32');
@@ -136,7 +143,7 @@ describe('kioku_ingest_url', () => {
     }
   });
 
-  test('MCP32b HIGH-1: loopback flag still rejects file:// scheme', async () => {
+  test('MCP32b HIGH-1: loopback flag still rejects file:// scheme', NETWORK_TEST, async () => {
     // KIOKU_URL_ALLOW_LOOPBACK=1 が production に leak しても、scheme allowlist
     // (http/https only) は強制される。SSRF IP-range だけが skip される設計。
     const v = await makeVault('mcp32b');
@@ -146,7 +153,7 @@ describe('kioku_ingest_url', () => {
     );
   });
 
-  test('MCP32c HIGH-1: loopback flag still rejects URL credentials', async () => {
+  test('MCP32c HIGH-1: loopback flag still rejects URL credentials', NETWORK_TEST, async () => {
     // user:pass@host も同様に loopback bypass 時にも reject される必要がある
     // (生クレデンシャルが log / error / network 経路に乗らないように)。
     const v = await makeVault('mcp32c');
@@ -160,7 +167,7 @@ describe('kioku_ingest_url', () => {
     );
   });
 
-  test('MCP33 idempotent second call → skipped', async () => {
+  test('MCP33 idempotent second call → skipped', NETWORK_TEST, async () => {
     const v = await makeVault('mcp33');
     await handleIngestUrl(
       v,
@@ -175,7 +182,7 @@ describe('kioku_ingest_url', () => {
     assert.match(r2.status, /skipped/, `expected skipped status, got: ${r2.status}`);
   });
 
-  test('MCP34 robots Disallow → invalid_request', async () => {
+  test('MCP34 robots Disallow → invalid_request', NETWORK_TEST, async () => {
     const v = await makeVault('mcp34');
     await assert.rejects(
       () => handleIngestUrl(
@@ -187,7 +194,7 @@ describe('kioku_ingest_url', () => {
     );
   });
 
-  test('MCP35 lockfile held externally → still pending after 200ms', async () => {
+  test('MCP35 lockfile held externally → still pending after 200ms', NETWORK_TEST, async () => {
     // HIGH-3 fix: assert.equal が失敗しても lockfile / setTimeout / dangling promise が
     // 残らないよう try/finally + clearTimeout で確実に cleanup する。
     // 旧実装は assert 失敗時に lockfile が残留して後続テストの workspace が破損する
@@ -214,7 +221,7 @@ describe('kioku_ingest_url', () => {
     }
   });
 
-  test('MCP36 child env allowlist (no GH_TOKEN leak, KIOKU_NO_LOG / MCP_CHILD propagated)', async () => {
+  test('MCP36 child env allowlist (no GH_TOKEN leak, KIOKU_NO_LOG / MCP_CHILD propagated)', NETWORK_TEST, async () => {
     await writeFile(stubLog, '');
     const prevGh = process.env.GH_TOKEN;
     process.env.GH_TOKEN = 'ghp_SHOULD_NOT_LEAK';
@@ -236,7 +243,7 @@ describe('kioku_ingest_url', () => {
     assert.match(log, /KIOKU_MCP_CHILD=1/, 'KIOKU_MCP_CHILD=1 propagated');
   });
 
-  test('MCP37 default subdir = articles', async () => {
+  test('MCP37 default subdir = articles', NETWORK_TEST, async () => {
     const v = await makeVault('mcp37');
     const r = await handleIngestUrl(
       v,
@@ -246,7 +253,7 @@ describe('kioku_ingest_url', () => {
     assert.match(r.path, /raw-sources\/articles\/fetched\//);
   });
 
-  test('MCP38 title arg overrides frontmatter title', async () => {
+  test('MCP38 title arg overrides frontmatter title', NETWORK_TEST, async () => {
     const v = await makeVault('mcp38');
     const r = await handleIngestUrl(
       v,
@@ -257,7 +264,7 @@ describe('kioku_ingest_url', () => {
     assert.match(content, /title: "Custom Title"/);
   });
 
-  test('MCP39 tags propagate to frontmatter and tag values are masked', async () => {
+  test('MCP39 tags propagate to frontmatter and tag values are masked', NETWORK_TEST, async () => {
     // MED-4 fix (code-quality 2026-04-19): tag 値も applyMasks を通る。
     // 旧実装では url-extract.mjs#buildFrontmatterObject が tags を素通ししていたため、
     // frontmatter に GitHub PAT 等の secret 文字列が漏洩 → vault の git push で
@@ -287,7 +294,7 @@ describe('kioku_ingest_url', () => {
     assert.match(content, /"ghp_\*\*\*"/, 'mask placeholder applied to tag');
   });
 
-  test('MCP39b og_image / published_time meta secrets are masked (red M-1)', async () => {
+  test('MCP39b og_image / published_time meta secrets are masked (red M-1)', NETWORK_TEST, async () => {
     // red M-1 fix (2026-04-20): <meta property="og:image"> と
     // <meta property="article:published_time"> の raw 文字列が attacker-controlled。
     // 旧実装では url-extract.mjs#buildFrontmatterObject で setRaw だったため
@@ -321,7 +328,7 @@ describe('kioku_ingest_url', () => {
     assert.doesNotMatch(content, /^published_time: /m, 'published_time field absent from frontmatter');
   });
 
-  test('MCP40 refresh_days arg overrides global default', async () => {
+  test('MCP40 refresh_days arg overrides global default', NETWORK_TEST, async () => {
     const v = await makeVault('mcp40');
     const r = await handleIngestUrl(
       v,
@@ -333,7 +340,7 @@ describe('kioku_ingest_url', () => {
   });
 
   describe('PDF dispatch (§4.7)', { skip: !HAS_POPPLER ? 'poppler not installed' : false }, () => {
-    test('MCP41 HTML content-type → no PDF dispatch', async () => {
+    test('MCP41 HTML content-type → no PDF dispatch', NETWORK_TEST, async () => {
       const v = await makeVault('mcp41');
       const r = await handleIngestUrl(
         v,
@@ -343,7 +350,7 @@ describe('kioku_ingest_url', () => {
       assert.notEqual(r.status, 'dispatched_to_pdf', `unexpected dispatch: ${r.status}`);
     });
 
-    test('MCP42 application/pdf → dispatch to handleIngestPdf', async () => {
+    test('MCP42 application/pdf → dispatch to handleIngestPdf', NETWORK_TEST, async () => {
       const v = await makeVault('mcp42');
       const r = await handleIngestUrl(
         v,
@@ -361,7 +368,7 @@ describe('kioku_ingest_url', () => {
         'short PDF should be summarized synchronously');
     });
 
-    test('MCP42b v0.3.5: long PDF (42p = 3 chunks) → dispatched_to_pdf_queued', async () => {
+    test('MCP42b v0.3.5: long PDF (42p = 3 chunks) → dispatched_to_pdf_queued', NETWORK_TEST, async () => {
       // handleIngestPdf が `queued_for_summary` を返す分岐が URL 経路でも
       // `dispatched_to_pdf_queued` に正しく伝搬すること。
       const v = await makeVault('mcp42b');
@@ -384,7 +391,7 @@ describe('kioku_ingest_url', () => {
       assert.equal(typeof r.pdf_result.detached_pid, 'number', 'detached_pid surfaced');
     });
 
-    test('MCP43 octet-stream + URL .pdf → dispatch', async () => {
+    test('MCP43 octet-stream + URL .pdf → dispatch', NETWORK_TEST, async () => {
       const v = await makeVault('mcp43');
       // /pdf-file/<name>.pdf にすると pathname 末尾が `.pdf` になり、
       // octet-stream Content-Type でも PDF として dispatch される。
@@ -398,7 +405,7 @@ describe('kioku_ingest_url', () => {
       assert.equal(r.status, 'dispatched_to_pdf');
     });
 
-    test('MCP44 PDF body > 50MB → invalid_request', async () => {
+    test('MCP44 PDF body > 50MB → invalid_request', NETWORK_TEST, async () => {
       const v = await makeVault('mcp44');
       await assert.rejects(
         () => handleIngestUrl(
@@ -410,7 +417,7 @@ describe('kioku_ingest_url', () => {
       );
     });
 
-    test('MCP45 PDF dispatch releases outer lock before handleIngestPdf acquires its own (v0.4.0 Tier A#3 M-a2)', async () => {
+    test('MCP45 PDF dispatch releases outer lock before handleIngestPdf acquires its own (v0.4.0 Tier A#3 M-a2)', NETWORK_TEST, async () => {
       // 2026-04-21 M-a2 fix: 旧実装は outer withLock を保持したまま handleIngestPdf に
       // skipLock=true で dispatch → 大容量 PDF (poppler 同期 extract) で outer lock を
       // 最大 4.5 分保持する問題があった。新実装は dispatchToPdf を withLock の外へ
@@ -439,7 +446,7 @@ describe('kioku_ingest_url', () => {
       assert.equal(lockExists, false, 'lockfile must be unlinked after dispatch');
     });
 
-    test('MCP45c GAP-1 fix: orphan PDF is cleaned up when handleIngestPdf fails (v0.4.0 Tier A#3 post-review)', async () => {
+    test('MCP45c GAP-1 fix: orphan PDF is cleaned up when handleIngestPdf fails (v0.4.0 Tier A#3 post-review)', NETWORK_TEST, async () => {
       // 2026-04-21 /security-review (red + blue parallel) の GAP-1 共通指摘:
       //   refactor 後は outer withLock release 後に PDF が raw-sources/ に
       //   visible になるため、handleIngestPdf が失敗 (encrypted / invalid PDF /
@@ -481,7 +488,7 @@ describe('kioku_ingest_url', () => {
       );
     });
 
-    test('MCP45b PDF dispatch: outer lock is released during handleIngestPdf Phase 1 (v0.4.0 Tier A#3 M-a2)', async () => {
+    test('MCP45b PDF dispatch: outer lock is released during handleIngestPdf Phase 1 (v0.4.0 Tier A#3 M-a2)', NETWORK_TEST, async () => {
       // 2026-04-21 M-a2 refactor の invariant test: late-PDF dispatch 中、
       // outer withLock は既に解放されているので「別の操作が lockfile を取得できる」
       // はずである。旧実装 (skipLock=true で outer 保持) だと、以下の concurrent write
@@ -515,7 +522,7 @@ describe('kioku_ingest_url', () => {
         `concurrent dispatch must complete quickly (actual: ${duration}ms)`);
     });
 
-    test('MCP46 CRIT-1: late-PDF discovery re-fetches with binary mode', async () => {
+    test('MCP46 CRIT-1: late-PDF discovery re-fetches with binary mode', NETWORK_TEST, async () => {
       // late-PDF discovery 経路:
       //   1 回目 fetch (ingest-url 側 binary:true) → text/html を受領
       //   → extractAndSaveUrl に委譲 (refresh skip 等のため非バイナリ再 fetch)
@@ -561,7 +568,7 @@ describe('kioku_ingest_url', () => {
     });
   });
 
-  test('MCP47 HIGH-2: fetch error message does not leak credentials in URL', async () => {
+  test('MCP47 HIGH-2: fetch error message does not leak credentials in URL', NETWORK_TEST, async () => {
     // KIOKU_URL_ALLOW_LOOPBACK=1 (テスト) でも、url credentials は HIGH-1 fix で
     // invalid_params にされる。ここで確認したいのは、production 経路 (loopback flag
     // 無し) で fetchUrl が credentials を含む URL を引いた場合、上位に投げる
@@ -596,7 +603,7 @@ describe('kioku_ingest_url', () => {
     }
   });
 
-  test('MCP48 MED-1: subdir with whitespace rejected (no silent mangling)', async () => {
+  test('MCP48 MED-1: subdir with whitespace rejected (no silent mangling)', NETWORK_TEST, async () => {
     // 旧実装: subdir.replace(/[^\p{L}\p{N}_-]/gu, '') で "my notes" → "mynotes" と
     // 黙って書き換わる UX trap。修正後は invalid_params で reject する。
     const v = await makeVault('mcp48');

--- a/tests/metadata-drift.test.mjs
+++ b/tests/metadata-drift.test.mjs
@@ -1,0 +1,411 @@
+// tests/metadata-drift.test.mjs — v0.7.2 PR B metadata drift detection
+//
+// Targets: KIOKU の metadata / docs drift を機械的に検出し future regression を pin する。
+//          codex roadmap §P0 drift 自動検出テスト
+//          (plan/codex/260430_kioku-product-improvement-roadmap.md L202-245) の codification。
+//
+// Test prefixes (BLUE-DRIFT-* namespace, per LEARN#8a no collision verified):
+//   - BLUE-DRIFT-TOOL-1     : MCP server.mjs registerTool ↔ manifest.json tools[].name 一致
+//   - BLUE-DRIFT-TOOL-2     : app/README.md (EN) tool 言及 ⊆ manifest set (no phantom)
+//   - BLUE-DRIFT-TOOL-3     : context/14-mcp-server.md tool 言及 ⊆ manifest set (no phantom)
+//   - BLUE-DRIFT-VERSION-1  : 4 metadata file (mcp/package.json, mcp/manifest.json,
+//                             .claude-plugin/plugin.json, .claude-plugin/marketplace.json
+//                             metadata.version) all parity
+//   - BLUE-DRIFT-VERSION-2  : marketplace.json metadata.version ↔ plugins[0].version 一致 (5th place)
+//   - BLUE-DRIFT-VERSION-3  : version 文字列が semver 形式 (X.Y.Z) であること (sanity gate)
+//   - BLUE-DRIFT-INSTALL-1  : docs/install-guide-plugin.md fenced bash code block で
+//                             current syntax を使用 (legacy 不在)
+//   - BLUE-DRIFT-INSTALL-2  : docs/install-guide-plugin.md install identifier kioku@<owner>
+//                             の <owner> が marketplace.json.name と一致
+//   - BLUE-DRIFT-INSTALL-3  : marketplace add 引数 owner/repo slug が <owner>/kioku 形式で整合
+//
+// 設計方針:
+//   - Node 18+ stdlib のみ (外部依存なし)
+//   - JSON は parse して比較、Markdown は regex で抽出
+//   - error message は「expected: X / found: Y / fix: Z」形式 (handoff §Acceptance criteria)
+//   - drift 修正は本 test ではなく人間が手動で行う (read-only detection)
+//   - MVP scope: EN README + docs/install-guide-plugin.md のみ。10 言語 README は後続 PR で拡張可
+//
+// LEARN#13 注意: regex literal に U+2028 / U+2029 / U+200B / U+FEFF を直接書かない。
+// 本 file は ASCII のみで constructed regex を使い、literal 制御文字を含めない。
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
+
+// path resolution
+
+const moduleFilePath = fileURLToPath(import.meta.url);
+const moduleDir = dirname(moduleFilePath);
+const CB_ROOT = resolve(moduleDir, '..'); // tools/claude-brain/
+
+const PATHS = {
+  serverMjs: join(CB_ROOT, 'mcp', 'server.mjs'),
+  manifest: join(CB_ROOT, 'mcp', 'manifest.json'),
+  packageJson: join(CB_ROOT, 'mcp', 'package.json'),
+  pluginJson: join(CB_ROOT, '.claude-plugin', 'plugin.json'),
+  marketplaceJson: join(CB_ROOT, '.claude-plugin', 'marketplace.json'),
+  contextMcp: join(CB_ROOT, 'context', '14-mcp-server.md'),
+  installGuide: join(CB_ROOT, 'docs', 'install-guide-plugin.md'),
+  appReadme: join(CB_ROOT, 'app', 'README.md'),
+};
+
+// helpers (no external dependency)
+
+async function readJson(path) {
+  const text = await readFile(path, 'utf8');
+  return JSON.parse(text);
+}
+
+async function readText(path) {
+  return await readFile(path, 'utf8');
+}
+
+// server.mjs から `register(<TOOL_DEF_NAME>, ...)` で登録された tool def 識別子を抽出
+async function extractRegisteredToolDefIds() {
+  const text = await readText(PATHS.serverMjs);
+  const re = /register\(\s*([A-Z][A-Z0-9_]*_TOOL_DEF)\s*,/g;
+  const ids = [];
+  let m;
+  while ((m = re.exec(text)) !== null) {
+    ids.push(m[1]);
+  }
+  return ids;
+}
+
+// server.mjs の import 文から `*_TOOL_DEF` -> import source path mapping
+async function extractToolDefImports() {
+  const text = await readText(PATHS.serverMjs);
+  const re = /import\s*\{([^}]+)\}\s*from\s*['"]([^'"]+)['"]/g;
+  const mapping = new Map();
+  let m;
+  while ((m = re.exec(text)) !== null) {
+    const names = m[1]
+      .split(',')
+      .map((s) => s.trim())
+      .filter((s) => /_TOOL_DEF$/.test(s));
+    for (const name of names) {
+      mapping.set(name, m[2]);
+    }
+  }
+  return mapping;
+}
+
+// 1 file を read して `<id>` の `name: '...'` field を抽出。
+// 再 export (`export { id } from './path'`) を最大 N 段まで辿る。
+async function resolveIdInFile(id, filePath, fileCache, depth = 0) {
+  if (depth > 5) {
+    throw new Error(
+      `[drift-test] re-export chain が深すぎます (id=${id}, file=${filePath})`,
+    );
+  }
+  let text = fileCache.get(filePath);
+  if (text === undefined) {
+    text = await readText(filePath);
+    fileCache.set(filePath, text);
+  }
+
+  // case 1: 直接 export (`export const ID = { ... name: 'kioku_xxx' ... }`)
+  // 識別子が `=` の左辺にあるかを見て decl の場合は近傍の name field を抽出
+  const declRe = new RegExp(`export\\s+const\\s+${id}\\s*=`);
+  if (declRe.test(text)) {
+    const idIdx = text.search(declRe);
+    const tail = text.slice(idIdx);
+    const nameMatch = /name\s*:\s*['"]([^'"]+)['"]/.exec(tail);
+    if (!nameMatch) {
+      throw new Error(
+        `[drift-test] tool def ${id} (${filePath}) で 'name:' field が抽出できません。`,
+      );
+    }
+    return nameMatch[1];
+  }
+
+  // case 2: 再 export (`export { id, ... } from '<path>'`)
+  const reExportRe = /export\s*\{([^}]+)\}\s*from\s*['"]([^'"]+)['"]/g;
+  let m;
+  while ((m = reExportRe.exec(text)) !== null) {
+    const names = m[1]
+      .split(',')
+      .map((s) => s.trim().split(/\s+as\s+/)[0])
+      .filter((s) => s.length > 0);
+    if (names.includes(id)) {
+      const nextPath = resolve(dirname(filePath), m[2]);
+      return await resolveIdInFile(id, nextPath, fileCache, depth + 1);
+    }
+  }
+
+  throw new Error(
+    `[drift-test] tool def ${id} を file ${filePath} (またはその re-export 先) で解決できません。`,
+  );
+}
+
+// 各 tool def file を read し identName -> toolName mapping を返す
+async function resolveToolNamesFromDefs() {
+  const ids = await extractRegisteredToolDefIds();
+  const importMap = await extractToolDefImports();
+  const idToToolName = new Map();
+  const fileCache = new Map();
+  for (const id of ids) {
+    const importPath = importMap.get(id);
+    if (!importPath) {
+      throw new Error(
+        `[drift-test] register(${id}, ...) の import が server.mjs で見つかりません。` +
+          `server.mjs の import 文と register 呼び出しを確認してください。`,
+      );
+    }
+    const filePath = resolve(dirname(PATHS.serverMjs), importPath);
+    const toolName = await resolveIdInFile(id, filePath, fileCache);
+    idToToolName.set(id, toolName);
+  }
+  return idToToolName;
+}
+
+// markdown 全文から `kioku_xxx` 識別子を抽出 (重複排除)
+function extractKiokuToolMentions(markdown) {
+  const re = /kioku_[a-z][a-z0-9_]*/g;
+  const set = new Set();
+  let m;
+  while ((m = re.exec(markdown)) !== null) {
+    set.add(m[0]);
+  }
+  return set;
+}
+
+// markdown から fenced bash/sh/shell code block の本文のみを抽出
+function extractFencedBashBlocks(markdown) {
+  const re = /```(?:bash|sh|shell)\s*\n([\s\S]*?)\n```/g;
+  const blocks = [];
+  let m;
+  while ((m = re.exec(markdown)) !== null) {
+    blocks.push(m[1]);
+  }
+  return blocks;
+}
+
+// Category 1: MCP tool registry drift
+
+describe('BLUE-DRIFT-TOOL: MCP tool registry drift', () => {
+  test('BLUE-DRIFT-TOOL-1: server.mjs registerTool set === manifest.json tools[].name set', async () => {
+    const idToName = await resolveToolNamesFromDefs();
+    const serverNames = new Set(idToName.values());
+
+    const manifest = await readJson(PATHS.manifest);
+    const manifestNames = new Set(manifest.tools.map((t) => t.name));
+
+    const missingInManifest = [...serverNames].filter((n) => !manifestNames.has(n)).sort();
+    const missingInServer = [...manifestNames].filter((n) => !serverNames.has(n)).sort();
+
+    assert.deepEqual(
+      { missingInManifest, missingInServer },
+      { missingInManifest: [], missingInServer: [] },
+      `MCP tool registry drift detected.\n` +
+        `  expected: server.mjs registerTool set === manifest.json tools[].name set\n` +
+        `  found: server has ${serverNames.size} tools, manifest has ${manifestNames.size} tools\n` +
+        `  manifest missing (add to manifest.json tools[]): ${missingInManifest.join(', ') || '(none)'}\n` +
+        `  server missing (remove from manifest or add register): ${missingInServer.join(', ') || '(none)'}`,
+    );
+  });
+
+  test('BLUE-DRIFT-TOOL-2: app/README.md (EN) tool mentions are subset of manifest set', async () => {
+    const manifest = await readJson(PATHS.manifest);
+    const manifestNames = new Set(manifest.tools.map((t) => t.name));
+
+    const readmeText = await readText(PATHS.appReadme);
+    const readmeMentions = extractKiokuToolMentions(readmeText);
+
+    const phantom = [...readmeMentions].filter((n) => !manifestNames.has(n)).sort();
+
+    assert.deepEqual(
+      phantom,
+      [],
+      `app/README.md tool mention drift detected.\n` +
+        `  expected: app/README.md で言及される kioku_* tool は全て manifest.json tools[].name に存在\n` +
+        `  found phantom (README に記載あり、manifest に無し): ${phantom.join(', ')}\n` +
+        `  fix: app/README.md から該当 tool 言及を削除する、または manifest.json に追加する`,
+    );
+  });
+
+  test('BLUE-DRIFT-TOOL-3: context/14-mcp-server.md tool mentions are subset of manifest set', async () => {
+    const manifest = await readJson(PATHS.manifest);
+    const manifestNames = new Set(manifest.tools.map((t) => t.name));
+
+    const contextText = await readText(PATHS.contextMcp);
+    const contextMentions = extractKiokuToolMentions(contextText);
+
+    const phantom = [...contextMentions].filter((n) => !manifestNames.has(n)).sort();
+
+    assert.deepEqual(
+      phantom,
+      [],
+      `context/14-mcp-server.md tool mention drift detected.\n` +
+        `  expected: context/14 で言及される kioku_* tool は全て manifest.json tools[].name に存在\n` +
+        `  found phantom: ${phantom.join(', ')}\n` +
+        `  fix: context/14-mcp-server.md から該当 tool 言及を削除する、または manifest に追加する`,
+    );
+  });
+});
+
+// Category 2: 5-place version parity
+
+describe('BLUE-DRIFT-VERSION: 5-place version parity', () => {
+  test('BLUE-DRIFT-VERSION-1: 4 metadata files の version が一致', async () => {
+    const pkg = await readJson(PATHS.packageJson);
+    const man = await readJson(PATHS.manifest);
+    const plugin = await readJson(PATHS.pluginJson);
+    const market = await readJson(PATHS.marketplaceJson);
+
+    const versions = {
+      'mcp/package.json': pkg.version,
+      'mcp/manifest.json': man.version,
+      '.claude-plugin/plugin.json': plugin.version,
+      '.claude-plugin/marketplace.json metadata.version': market.metadata?.version,
+    };
+
+    const distinct = new Set(Object.values(versions));
+    assert.equal(
+      distinct.size,
+      1,
+      `4 metadata version mismatch detected.\n` +
+        `  expected: 全 4 file の version が同一\n` +
+        `  found: ${JSON.stringify(versions, null, 2)}\n` +
+        `  fix: release cascade Step 1 で 4 file 全て同じ version に bump する`,
+    );
+  });
+
+  test('BLUE-DRIFT-VERSION-2: marketplace.json metadata.version === plugins[0].version (5th place)', async () => {
+    const market = await readJson(PATHS.marketplaceJson);
+    const metaVer = market.metadata?.version;
+    const pluginVer = market.plugins?.[0]?.version;
+
+    assert.equal(
+      metaVer,
+      pluginVer,
+      `marketplace.json internal version mismatch.\n` +
+        `  expected: metadata.version === plugins[0].version (5 places parity)\n` +
+        `  found: metadata.version=${metaVer}, plugins[0].version=${pluginVer}\n` +
+        `  fix: .claude-plugin/marketplace.json の 2 occurrence を同じ version に揃える`,
+    );
+  });
+
+  test('BLUE-DRIFT-VERSION-3: version 文字列が semver 形式', async () => {
+    const pkg = await readJson(PATHS.packageJson);
+    const semverRe = /^\d+\.\d+\.\d+(?:-[A-Za-z0-9.-]+)?$/;
+    assert.ok(
+      semverRe.test(pkg.version),
+      `version semver violation.\n` +
+        `  expected: ^\\d+\\.\\d+\\.\\d+(-prerelease)?$ (例: 0.7.1, 0.7.2-rc1)\n` +
+        `  found: mcp/package.json version=${pkg.version}\n` +
+        `  fix: semver compliant な version 文字列に修正する`,
+    );
+  });
+});
+
+// Category 3: install command syntax drift
+
+describe('BLUE-DRIFT-INSTALL: install command syntax drift', () => {
+  test('BLUE-DRIFT-INSTALL-1: docs/install-guide-plugin.md fenced bash で current syntax を使用', async () => {
+    const text = await readText(PATHS.installGuide);
+    const blocks = extractFencedBashBlocks(text);
+    const joined = blocks.join('\n');
+
+    // legacy syntax: `claude marketplace add` (no `plugin` between)
+    // word boundary を使い `claude plugin marketplace add` には match しないようにする
+    const legacyRe = /(^|[^a-zA-Z])claude\s+marketplace\s+add\b/m;
+    const hasLegacy = legacyRe.test(joined);
+    const currentRe = /claude\s+plugin\s+marketplace\s+add\b/;
+    const hasCurrent = currentRe.test(joined);
+
+    assert.equal(
+      hasLegacy,
+      false,
+      `legacy install syntax found in docs/install-guide-plugin.md fenced bash block.\n` +
+        `  expected: 'claude plugin marketplace add ...' (Claude Code v2.1.89+ syntax)\n` +
+        `  found: legacy 'claude marketplace add ...' present (§44 incident 再発)\n` +
+        `  fix: docs/install-guide-plugin.md の bash code block で 'claude marketplace add' を 'claude plugin marketplace add' に書き換える`,
+    );
+    assert.equal(
+      hasCurrent,
+      true,
+      `current install syntax missing in docs/install-guide-plugin.md.\n` +
+        `  expected: 少なくとも 1 つの bash code block に 'claude plugin marketplace add ...' が存在\n` +
+        `  found: 'claude plugin marketplace add' を含む bash block が無い\n` +
+        `  fix: docs/install-guide-plugin.md の install snippet で current syntax を使う`,
+    );
+  });
+
+  test('BLUE-DRIFT-INSTALL-2: docs install identifier kioku@<owner> が marketplace.json.name と一致', async () => {
+    const market = await readJson(PATHS.marketplaceJson);
+    const expectedOwner = market.name;
+
+    const text = await readText(PATHS.installGuide);
+    const installRe = /claude\s+plugin\s+install\s+kioku@([a-zA-Z0-9._-]+)/g;
+    const owners = new Set();
+    let m;
+    while ((m = installRe.exec(text)) !== null) {
+      owners.add(m[1]);
+    }
+
+    assert.notEqual(
+      owners.size,
+      0,
+      `docs/install-guide-plugin.md に 'claude plugin install kioku@<owner>' snippet が見つからない.\n` +
+        `  expected: kioku@<owner> identifier の install snippet が少なくとも 1 つ\n` +
+        `  fix: docs/install-guide-plugin.md に install snippet を追加する`,
+    );
+
+    const ownersArr = [...owners].sort();
+    const mismatched = ownersArr.filter((o) => o !== expectedOwner);
+
+    assert.deepEqual(
+      mismatched,
+      [],
+      `install identifier owner drift detected.\n` +
+        `  expected: kioku@${expectedOwner} (= marketplace.json.name)\n` +
+        `  found: ${ownersArr.join(', ')}\n` +
+        `  fix: docs/install-guide-plugin.md の identifier を kioku@${expectedOwner} に揃える、` +
+        `または .claude-plugin/marketplace.json の name field を更新する (§44 incident 参照)`,
+    );
+  });
+
+  test('BLUE-DRIFT-INSTALL-3: docs marketplace add 引数の owner/repo slug が整合', async () => {
+    const text = await readText(PATHS.installGuide);
+    const addRe = /claude\s+plugin\s+marketplace\s+add\s+([a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+)/g;
+    const slugs = new Set();
+    let m;
+    while ((m = addRe.exec(text)) !== null) {
+      slugs.add(m[1]);
+    }
+
+    assert.notEqual(
+      slugs.size,
+      0,
+      `docs/install-guide-plugin.md に 'claude plugin marketplace add <owner/repo>' snippet が見つからない.\n` +
+        `  expected: owner/repo slug を含む marketplace add snippet\n` +
+        `  fix: docs/install-guide-plugin.md に marketplace add snippet を追加する`,
+    );
+
+    const slugsArr = [...slugs].sort();
+    const repoMismatch = slugsArr.filter((s) => !s.endsWith('/kioku'));
+
+    assert.deepEqual(
+      repoMismatch,
+      [],
+      `marketplace add slug repo name drift.\n` +
+        `  expected: 全 slug が '<owner>/kioku' 形式\n` +
+        `  found: ${slugsArr.join(', ')}\n` +
+        `  fix: docs/install-guide-plugin.md の marketplace add slug を '<owner>/kioku' に揃える`,
+    );
+
+    const owners = new Set(slugsArr.map((s) => s.split('/')[0]));
+    assert.equal(
+      owners.size,
+      1,
+      `marketplace add slug owner inconsistency.\n` +
+        `  expected: 全 marketplace add snippet が同じ owner を指す\n` +
+        `  found owners: ${[...owners].sort().join(', ')}\n` +
+        `  fix: docs/install-guide-plugin.md の owner 部分を統一する`,
+    );
+  });
+});

--- a/tests/post-release-sync.test.sh
+++ b/tests/post-release-sync.test.sh
@@ -284,21 +284,30 @@ fi
 # -----------------------------------------------------------------------------
 # PRS-S13: dry-run 動的テスト — default / --force-sync で output が変わる
 # -----------------------------------------------------------------------------
-echo "test PRS-S13: --dry-run output differs by --force-sync"
-
-default_dry="$(bash "${TARGET}" --dry-run 2>&1 || true)"
-force_dry="$(bash "${TARGET}" --dry-run --force-sync 2>&1 || true)"
-
-if printf '%s' "${default_dry}" | grep -qF 'fatal error if diverged'; then
-  pass "PRS-S13 default --dry-run mentions fatal on diverge"
+# Skip in linked worktree (.git is a file pointing to parent repo's worktree
+# metadata, not a directory). post-release-sync.sh の git status 系出力が
+# worktree の metadata path を含み、static string match を破壊するため。
+# 本 test は parent main checkout でのみ走らせる (LEARN-CANDIDATE: test
+# should not depend on git state outside its scope、§45 と同種 candidate)。
+if [[ -f "${REPO_ROOT}/.git" ]]; then
+  echo "skip PRS-S13: linked worktree (parent main checkout でのみ実行可)"
 else
-  fail "PRS-S13 default --dry-run missing diverge warning"
-fi
+  echo "test PRS-S13: --dry-run output differs by --force-sync"
 
-if printf '%s' "${force_dry}" | grep -qF '(--force-sync) git reset --hard'; then
-  pass "PRS-S13 --force-sync --dry-run announces reset --hard"
-else
-  fail "PRS-S13 --force-sync --dry-run missing reset announcement"
+  default_dry="$(bash "${TARGET}" --dry-run 2>&1 || true)"
+  force_dry="$(bash "${TARGET}" --dry-run --force-sync 2>&1 || true)"
+
+  if printf '%s' "${default_dry}" | grep -qF 'fatal error if diverged'; then
+    pass "PRS-S13 default --dry-run mentions fatal on diverge"
+  else
+    fail "PRS-S13 default --dry-run missing diverge warning"
+  fi
+
+  if printf '%s' "${force_dry}" | grep -qF '(--force-sync) git reset --hard'; then
+    pass "PRS-S13 --force-sync --dry-run announces reset --hard"
+  else
+    fail "PRS-S13 --force-sync --dry-run missing reset announcement"
+  fi
 fi
 
 # -----------------------------------------------------------------------------

--- a/tests/robots-check.test.mjs
+++ b/tests/robots-check.test.mjs
@@ -3,18 +3,25 @@ import assert from 'node:assert/strict';
 import { checkRobots, RobotsError } from '../mcp/lib/robots-check.mjs';
 import { startFixtureServer } from './helpers/fixture-server.mjs';
 
+// v0.7.2 PR C: URL test 安定化。fixture server / network-ish 統合テストは
+// `KIOKU_SKIP_NETWORKISH_TESTS=1` で skip 可能、各 test に 30s hard timeout。
+const SKIP_NETWORK = process.env.KIOKU_SKIP_NETWORKISH_TESTS === '1';
+const NETWORK_TEST = { skip: SKIP_NETWORK ? 'KIOKU_SKIP_NETWORKISH_TESTS=1' : false, timeout: 30_000 };
+
 describe('robots-check', () => {
   let server;
   before(async () => {
+    if (SKIP_NETWORK) return;
     process.env.KIOKU_URL_ALLOW_LOOPBACK = '1';
     server = await startFixtureServer();
   });
   after(() => {
+    if (SKIP_NETWORK) return;
     delete process.env.KIOKU_URL_ALLOW_LOOPBACK;
     return server.close();
   });
 
-  test('UX15 Disallow / blocks fetch', async () => {
+  test('UX15 Disallow / blocks fetch', NETWORK_TEST, async () => {
     await assert.rejects(
       () => checkRobots(`${server.url}/article-normal.html?_variant=disallow`,
                          { robotsUrlOverride: `${server.url}/robots.txt?variant=disallow` }),
@@ -22,19 +29,19 @@ describe('robots-check', () => {
     );
   });
 
-  test('UX16 Disallow /admin allows /article', async () => {
+  test('UX16 Disallow /admin allows /article', NETWORK_TEST, async () => {
     await checkRobots(`${server.url}/article-normal.html`,
                        { robotsUrlOverride: `${server.url}/robots.txt?variant=mixed` });
     // No throw = pass
   });
 
-  test('UX17 robots 404 → allow (no throw)', async () => {
+  test('UX17 robots 404 → allow (no throw)', NETWORK_TEST, async () => {
     // Override to missing URL — fixture server returns 404 for unknown robots variant
     await checkRobots(`${server.url}/article-normal.html`,
                        { robotsUrlOverride: `${server.url}/robots.txt?variant=does-not-exist` });
   });
 
-  test('UX18 IGNORE_ROBOTS=1 bypasses', async () => {
+  test('UX18 IGNORE_ROBOTS=1 bypasses', NETWORK_TEST, async () => {
     process.env.KIOKU_URL_IGNORE_ROBOTS = '1';
     try {
       await checkRobots(`${server.url}/article-normal.html`,

--- a/tests/run-full-suite.sh
+++ b/tests/run-full-suite.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# run-full-suite.sh — release 前用の全 test suite (URL/network 系含む)
+#
+# v0.7.2 PR C で導入。codex roadmap §「P0: URL 系テストの安定化」の Acceptance criteria #3
+# 「full suite の対象が README / context に明記される」を満たす runbook。
+#
+# 含むもの:
+#   - Node test 全部 (tests/hooks/, tests/mcp/, tests/*.test.mjs)
+#     → URL 系統合 test (url-fetch / url-extract / url-image / robots-check) と
+#       MCP integration (mcp/tools-ingest-url) も含む
+#   - Bash test 全部 (tests/*.test.sh)
+#     → setup-vault / install-hooks / install-hooks-gemini / install-hooks-codex /
+#        auto-ingest / auto-lint / scan-secrets / doctor / build-mcpb / sync-to-app /
+#        post-release-sync / extract-url / extract-pdf / extract-epub / extract-docx 等
+#
+# 環境前提:
+#   - tools/claude-brain/mcp/node_modules/ が install 済 (`cd mcp && npm install`)
+#   - 任意で poppler (pdfinfo/pdftotext) — PDF dispatch test の skip 判定に使われる
+#
+# 実行: bash tools/claude-brain/tests/run-full-suite.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TESTS_DIR="${SCRIPT_DIR}"
+
+start=${SECONDS}
+echo "[run-full-suite] 全 test suite を実行 (KIOKU_SKIP_NETWORKISH_TESTS は unset、URL test も走る)"
+
+# 失敗カテゴリを収集して最後に報告 (途中失敗で stop せず全カテゴリを走らせる)。
+# `set -e` 環境下で `||` を使い node 失敗を非 fatal 化する。
+FAIL_LOG=""
+
+# Node test 全カテゴリ (top-level + hooks/ + mcp/)
+echo "[run-full-suite] Node test (top-level + hooks/ + mcp/)"
+if ! node --test \
+  "${TESTS_DIR}/"*.test.mjs \
+  "${TESTS_DIR}/hooks/"*.test.mjs \
+  "${TESTS_DIR}/mcp/"*.test.mjs; then
+  FAIL_LOG="${FAIL_LOG}\n  - Node test (top-level + hooks/ + mcp/)"
+fi
+
+# Bash test を 1 本ずつ run。失敗を収集しつつ全部回す。
+BASH_TESTS=(
+  setup-vault.test.sh
+  install-hooks.test.sh
+  install-hooks-gemini.test.sh
+  install-hooks-codex.test.sh
+  install-launchagents.test.sh
+  install-mcp-client.test.sh
+  install-skills.test.sh
+  setup-mcp.test.sh
+  setup-multi-agent.test.sh
+  setup-qmd.test.sh
+  auto-ingest.test.sh
+  auto-lint.test.sh
+  scan-secrets.test.sh
+  doctor.test.sh
+  build-mcpb.test.sh
+  sync-to-app.test.sh
+  post-release-sync.test.sh
+  extract-url.test.sh
+  extract-pdf.test.sh
+  extract-epub.test.sh
+  extract-docx.test.sh
+  competitor-watch.test.sh
+  cron-guard-parity.test.sh
+  mcp-server-registration.test.sh
+  hooks/no-network-import.test.sh
+)
+
+for t in "${BASH_TESTS[@]}"; do
+  full="${TESTS_DIR}/${t}"
+  if [[ ! -f "${full}" ]]; then
+    echo "[run-full-suite] SKIP missing: ${t}"
+    continue
+  fi
+  echo "[run-full-suite] bash ${t}"
+  if ! bash "${full}"; then
+    FAIL_LOG="${FAIL_LOG}\n  - bash ${t}"
+  fi
+done
+
+elapsed=$((SECONDS - start))
+if [[ -z "${FAIL_LOG}" ]]; then
+  echo "[run-full-suite] OK (${elapsed}s)"
+else
+  printf "[run-full-suite] FAIL (%ss). 失敗カテゴリ:%b\n" "${elapsed}" "${FAIL_LOG}" >&2
+  exit 1
+fi

--- a/tests/run-quick-suite.sh
+++ b/tests/run-quick-suite.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# run-quick-suite.sh — 日常開発用の軽量 test suite (60 秒以内に完走する目標)
+#
+# v0.7.2 PR C で導入。codex roadmap §「P0: URL 系テストの安定化」の Acceptance criteria #1
+# 「quick suite が 60 秒以内に終わる」を満たす。
+#
+# 含むもの (KIOKU_SKIP_NETWORKISH_TESTS=1 を強制し、URL/network test を skip):
+#   - Hook の Node test (tests/hooks/*.test.mjs)
+#   - MCP の Node test (tests/mcp/*.test.mjs) ※ tools-ingest-url.test.mjs は env で skip
+#
+# 含まないもの (full suite 側、tests/run-full-suite.sh で実行):
+#   - URL 系統合 test (url-fetch / url-extract / url-image / robots-check / extract-url.test.sh 等)
+#   - Bash test 群 (auto-ingest / install-hooks / setup-vault / doctor / build-mcpb / sync-to-app 等)
+#
+# 実行: bash tools/claude-brain/tests/run-quick-suite.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TESTS_DIR="${SCRIPT_DIR}"
+
+start=${SECONDS}
+echo "[run-quick-suite] hooks + mcp の Node test を KIOKU_SKIP_NETWORKISH_TESTS=1 で実行 (target <60s)"
+
+# `node --test` は失敗すると non-zero exit → set -e で stop。pipeline は使わない (output を
+# そのまま contributor が見れるように)。glob expand は bash がする。
+KIOKU_SKIP_NETWORKISH_TESTS=1 node --test \
+  "${TESTS_DIR}/hooks/"*.test.mjs \
+  "${TESTS_DIR}/mcp/"*.test.mjs
+
+elapsed=$((SECONDS - start))
+echo "[run-quick-suite] OK (${elapsed}s)"
+if [[ "${elapsed}" -ge 60 ]]; then
+  echo "[run-quick-suite] WARN: ${elapsed}s exceeded 60s budget" >&2
+fi

--- a/tests/url-extract-cli.test.mjs
+++ b/tests/url-extract-cli.test.mjs
@@ -15,6 +15,11 @@ import { startFixtureServer } from './helpers/fixture-server.mjs';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const CLI = join(__dirname, '..', 'mcp', 'lib', 'url-extract-cli.mjs');
 
+// v0.7.2 PR C: URL test 安定化。fixture server / network-ish 統合テストは
+// `KIOKU_SKIP_NETWORKISH_TESTS=1` で skip 可能、各 test に 30s hard timeout。
+const SKIP_NETWORK = process.env.KIOKU_SKIP_NETWORKISH_TESTS === '1';
+const NETWORK_TEST = { skip: SKIP_NETWORK ? 'KIOKU_SKIP_NETWORKISH_TESTS=1' : false, timeout: 30_000 };
+
 function runCli(args, env = {}) {
   return new Promise((resolve) => {
     const child = spawn('node', [CLI, ...args], {
@@ -31,6 +36,7 @@ function runCli(args, env = {}) {
 describe('url-extract-cli', () => {
   let server, workspace, vault;
   before(async () => {
+    if (SKIP_NETWORK) return;
     server = await startFixtureServer();
     workspace = await mkdtemp(join(tmpdir(), 'kioku-uec-'));
     vault = join(workspace, 'vault');
@@ -38,11 +44,12 @@ describe('url-extract-cli', () => {
     await mkdir(join(vault, '.cache', 'html'), { recursive: true });
   });
   after(async () => {
+    if (SKIP_NETWORK) return;
     await server.close();
     await rm(workspace, { recursive: true, force: true });
   });
 
-  test('CLI normal URL → exit 0 + JSON on stdout', async () => {
+  test('CLI normal URL → exit 0 + JSON on stdout', NETWORK_TEST, async () => {
     const r = await runCli(
       [
         '--url', `${server.url}/article-normal.html`,
@@ -59,19 +66,19 @@ describe('url-extract-cli', () => {
     assert.match(json.path, /raw-sources\/articles\/fetched\//);
   });
 
-  test('CLI missing --url → exit 2 + stderr', async () => {
+  test('CLI missing --url → exit 2 + stderr', NETWORK_TEST, async () => {
     const r = await runCli(['--vault', vault]);
     assert.equal(r.code, 2);
     assert.match(r.stderr, /--url required/i);
   });
 
-  test('CLI missing --vault → exit 2 + stderr', async () => {
+  test('CLI missing --vault → exit 2 + stderr', NETWORK_TEST, async () => {
     const r = await runCli(['--url', 'https://example.com/']);
     assert.equal(r.code, 2);
     assert.match(r.stderr, /--vault required/i);
   });
 
-  test('CLI robots Disallow → exit 3', async () => {
+  test('CLI robots Disallow → exit 3', NETWORK_TEST, async () => {
     const r = await runCli(
       [
         '--url', `${server.url}/article-normal.html`,
@@ -85,7 +92,7 @@ describe('url-extract-cli', () => {
     assert.match(r.stderr, /robots_disallow/);
   });
 
-  test('CLI fetch failure (non-http scheme in validated mode) → exit 4', async () => {
+  test('CLI fetch failure (non-http scheme in validated mode) → exit 4', NETWORK_TEST, async () => {
     const r = await runCli(
       [
         '--url', 'file:///etc/passwd',
@@ -99,7 +106,7 @@ describe('url-extract-cli', () => {
     assert.equal(r.code, 4, `stdout=${r.stdout} stderr=${r.stderr}`);
   });
 
-  test('CLI security-code error message is scrubbed (red M-2)', async () => {
+  test('CLI security-code error message is scrubbed (red M-2)', NETWORK_TEST, async () => {
     // red M-2 fix (2026-04-20): FetchError の raw message に解決済み内部 IP や
     // attacker-controlled hostname がそのまま embed された状態で cron log に
     // leak する経路を塞ぐ。security code (url_scheme / dns_private / ...) では
@@ -120,7 +127,7 @@ describe('url-extract-cli', () => {
     assert.match(r.stderr, /\((url_scheme|url_parse)\)/, 'code is still surfaced for ops visibility');
   });
 
-  test('CLI tags flag parses comma-separated list', async () => {
+  test('CLI tags flag parses comma-separated list', NETWORK_TEST, async () => {
     // 別 subdir で fresh 書込み (orchestrator の idempotency で以前の file が skip を
     // 返してしまうため、テスト単位で isolate する)。
     const r = await runCli(
@@ -141,7 +148,7 @@ describe('url-extract-cli', () => {
     assert.match(content, /tags: \["foo", "bar", "baz"\]/);
   });
 
-  test('CLI --refresh-days=never → passed through', async () => {
+  test('CLI --refresh-days=never → passed through', NETWORK_TEST, async () => {
     const r = await runCli(
       [
         '--url', `${server.url}/article-normal.html`,

--- a/tests/url-extract.test.mjs
+++ b/tests/url-extract.test.mjs
@@ -11,9 +11,15 @@ import { join } from 'node:path';
 import { extractAndSaveUrl } from '../mcp/lib/url-extract.mjs';
 import { startFixtureServer } from './helpers/fixture-server.mjs';
 
+// v0.7.2 PR C: URL test 安定化。fixture server / network-ish 統合テストは
+// `KIOKU_SKIP_NETWORKISH_TESTS=1` で skip 可能、各 test に 30s hard timeout。
+const SKIP_NETWORK = process.env.KIOKU_SKIP_NETWORKISH_TESTS === '1';
+const NETWORK_TEST = { skip: SKIP_NETWORK ? 'KIOKU_SKIP_NETWORKISH_TESTS=1' : false, timeout: 30_000 };
+
 describe('url-extract orchestrator', () => {
   let server, workspace, vault;
   before(async () => {
+    if (SKIP_NETWORK) return;
     process.env.KIOKU_URL_ALLOW_LOOPBACK = '1';
     server = await startFixtureServer();
     workspace = await mkdtemp(join(tmpdir(), 'kioku-ue-'));
@@ -22,12 +28,13 @@ describe('url-extract orchestrator', () => {
     await mkdir(join(vault, '.cache', 'html'), { recursive: true });
   });
   after(async () => {
+    if (SKIP_NETWORK) return;
     delete process.env.KIOKU_URL_ALLOW_LOOPBACK;
     await server.close();
     await rm(workspace, { recursive: true, force: true });
   });
 
-  test('orchestration: normal article → writes markdown + media + frontmatter', async () => {
+  test('orchestration: normal article → writes markdown + media + frontmatter', NETWORK_TEST, async () => {
     const r = await extractAndSaveUrl({
       url: `${server.url}/article-normal.html`,
       vault,
@@ -47,7 +54,7 @@ describe('url-extract orchestrator', () => {
     assert.match(content, /refresh_days: 30/);
   });
 
-  test('UI9 same content re-extract → skipped', async () => {
+  test('UI9 same content re-extract → skipped', NETWORK_TEST, async () => {
     const r1 = await extractAndSaveUrl({
       url: `${server.url}/article-normal.html`,
       vault, subdir: 'articles',
@@ -62,7 +69,7 @@ describe('url-extract orchestrator', () => {
     assert.equal(r2.source_sha256, r1.source_sha256);
   });
 
-  test('UI11 within REFRESH_DAYS → skipped_within_refresh', async () => {
+  test('UI11 within REFRESH_DAYS → skipped_within_refresh', NETWORK_TEST, async () => {
     // First fetch
     await extractAndSaveUrl({
       url: `${server.url}/article-normal.html`,
@@ -80,7 +87,7 @@ describe('url-extract orchestrator', () => {
     assert.ok(r.status === 'skipped_within_refresh' || r.status === 'skipped_same_sha');
   });
 
-  test('UI13 refresh_days=1 with old fetched_at → re-fetch', async () => {
+  test('UI13 refresh_days=1 with old fetched_at → re-fetch', NETWORK_TEST, async () => {
     const r1 = await extractAndSaveUrl({
       url: `${server.url}/article-normal.html`,
       vault, subdir: 'articles',
@@ -103,7 +110,7 @@ describe('url-extract orchestrator', () => {
     assert.ok(['refreshed_fetched_at', 'skipped_same_sha'].includes(r2.status));
   });
 
-  test('UI14 refresh_days=never with existing file → always skipped', async () => {
+  test('UI14 refresh_days=never with existing file → always skipped', NETWORK_TEST, async () => {
     await extractAndSaveUrl({
       url: `${server.url}/article-normal.html`,
       vault, subdir: 'articles',
@@ -120,7 +127,7 @@ describe('url-extract orchestrator', () => {
     assert.ok(['skipped_never', 'skipped_same_sha'].includes(r2.status));
   });
 
-  test('UI17 future fetched_at (clock skew) does not crash and preserves title', async () => {
+  test('UI17 future fetched_at (clock skew) does not crash and preserves title', NETWORK_TEST, async () => {
     // Regression smoke for code-quality HIGH-2 (2026-04-19):
     // 2 Mac NTP 差で fetched_at が未来時刻で保存されるケースをシミュレート。
     // 事前 fix では ageMs < 0 が refreshMs 未満で永続 skip していた。
@@ -153,7 +160,7 @@ describe('url-extract orchestrator', () => {
     assert.match(reread, /title: "Attention Is All You Need — Normal Article"/);
   });
 
-  test('robots Disallow returns skipped_robots', async () => {
+  test('robots Disallow returns skipped_robots', NETWORK_TEST, async () => {
     await assert.rejects(
       () => extractAndSaveUrl({
         url: `${server.url}/article-normal.html`,
@@ -164,7 +171,7 @@ describe('url-extract orchestrator', () => {
     );
   });
 
-  test('raw HTML saved to .cache/html/', async () => {
+  test('raw HTML saved to .cache/html/', NETWORK_TEST, async () => {
     await extractAndSaveUrl({
       url: `${server.url}/article-normal.html`,
       vault, subdir: 'articles',

--- a/tests/url-fetch.test.mjs
+++ b/tests/url-fetch.test.mjs
@@ -3,19 +3,26 @@ import assert from 'node:assert/strict';
 import { fetchUrl, FetchError } from '../mcp/lib/url-fetch.mjs';
 import { startFixtureServer } from './helpers/fixture-server.mjs';
 
+// v0.7.2 PR C: URL test 安定化。fixture server / network-ish 統合テストは
+// `KIOKU_SKIP_NETWORKISH_TESTS=1` で skip 可能、各 test に 30s hard timeout。
+const SKIP_NETWORK = process.env.KIOKU_SKIP_NETWORKISH_TESTS === '1';
+const NETWORK_TEST = { skip: SKIP_NETWORK ? 'KIOKU_SKIP_NETWORKISH_TESTS=1' : false, timeout: 30_000 };
+
 describe('url-fetch (integration with fixture server)', () => {
   let server;
   // テスト用に loopback を一時許可
   before(async () => {
+    if (SKIP_NETWORK) return;
     process.env.KIOKU_URL_ALLOW_LOOPBACK = '1';
     server = await startFixtureServer();
   });
   after(() => {
+    if (SKIP_NETWORK) return;
     delete process.env.KIOKU_URL_ALLOW_LOOPBACK;
     return server.close();
   });
 
-  test('UX8 fetch normal article returns body + content-type', async () => {
+  test('UX8 fetch normal article returns body + content-type', NETWORK_TEST, async () => {
     const r = await fetchUrl(`${server.url}/article-normal.html`);
     assert.match(r.body, /<h1>Attention Is All You Need<\/h1>/);
     assert.match(r.contentType, /text\/html/);
@@ -23,14 +30,14 @@ describe('url-fetch (integration with fixture server)', () => {
     assert.equal(r.truncated, false);
   });
 
-  test('UX9 redirect follow up to 5 hops', async () => {
+  test('UX9 redirect follow up to 5 hops', NETWORK_TEST, async () => {
     const target = encodeURIComponent(`${server.url}/article-normal.html`);
     const r = await fetchUrl(`${server.url}/redirect-to/${target}`);
     assert.equal(r.status, 200);
     assert.ok(r.finalUrl.endsWith('article-normal.html'));
   });
 
-  test('UX9b redirect limit exceeded → FetchError', async () => {
+  test('UX9b redirect limit exceeded → FetchError', NETWORK_TEST, async () => {
     let chained = `${server.url}/article-normal.html`;
     for (let i = 0; i < 6; i++) {
       chained = `${server.url}/redirect-to/${encodeURIComponent(chained)}`;
@@ -38,7 +45,7 @@ describe('url-fetch (integration with fixture server)', () => {
     await assert.rejects(() => fetchUrl(chained), (e) => e.code === 'redirect_limit');
   });
 
-  test('UX10 HTTPS → HTTP downgrade rejected', async () => {
+  test('UX10 HTTPS → HTTP downgrade rejected', NETWORK_TEST, async () => {
     const httpsLike = `${server.url}/redirect-to/${encodeURIComponent('http://insecure.example.com/')}`;
     await assert.rejects(
       () => fetchUrl(httpsLike, { assumeStartScheme: 'https:' }),
@@ -46,41 +53,41 @@ describe('url-fetch (integration with fixture server)', () => {
     );
   });
 
-  test('UX11 401 Unauthorized → FetchError(auth)', async () => {
+  test('UX11 401 Unauthorized → FetchError(auth)', NETWORK_TEST, async () => {
     await assert.rejects(
       () => fetchUrl(`${server.url}/status?code=401`),
       (e) => e.code === 'auth_required',
     );
   });
 
-  test('UX11b 403 Forbidden → FetchError(auth)', async () => {
+  test('UX11b 403 Forbidden → FetchError(auth)', NETWORK_TEST, async () => {
     await assert.rejects(
       () => fetchUrl(`${server.url}/status?code=403`),
       (e) => e.code === 'auth_required',
     );
   });
 
-  test('UX12 404 → FetchError(not_found)', async () => {
+  test('UX12 404 → FetchError(not_found)', NETWORK_TEST, async () => {
     await assert.rejects(
       () => fetchUrl(`${server.url}/status?code=404`),
       (e) => e.code === 'not_found',
     );
   });
 
-  test('UX13 5MB+ body → truncated: true', async () => {
+  test('UX13 5MB+ body → truncated: true', NETWORK_TEST, async () => {
     const r = await fetchUrl(`${server.url}/huge`, { maxBytes: 5_000_000 });
     assert.equal(r.truncated, true);
     assert.ok(r.body.length <= 5_000_000);
   });
 
-  test('UX14 timeout triggers FetchError', async () => {
+  test('UX14 timeout triggers FetchError', NETWORK_TEST, async () => {
     await assert.rejects(
       () => fetchUrl(`${server.url}/slow`, { timeoutMs: 100 }),
       (e) => e.code === 'timeout',
     );
   });
 
-  test('UX15 DNS rebinding (public hostname → private IP) rejected', async () => {
+  test('UX15 DNS rebinding (public hostname → private IP) rejected', NETWORK_TEST, async () => {
     // Simulate a hostname that resolves to 10.0.0.1 (private RFC1918).
     // Use a fake hostname so validateUrl string check passes.
     const fakeLookup = async (host) => ({ address: '10.0.0.1', family: 4 });
@@ -92,7 +99,7 @@ describe('url-fetch (integration with fixture server)', () => {
     );
   });
 
-  test('UX16 DNS resolution failure → dns_failed', async () => {
+  test('UX16 DNS resolution failure → dns_failed', NETWORK_TEST, async () => {
     const failLookup = async (host) => { throw new Error('NXDOMAIN'); };
     await assert.rejects(
       () => fetchUrl('http://nonexistent.example.com/', {

--- a/tests/url-image.test.mjs
+++ b/tests/url-image.test.mjs
@@ -7,21 +7,28 @@ import { join } from 'node:path';
 import { downloadImages, rewriteImageSrc } from '../mcp/lib/url-image.mjs';
 import { startFixtureServer } from './helpers/fixture-server.mjs';
 
+// v0.7.2 PR C: URL test 安定化。fixture server / network-ish 統合テストは
+// `KIOKU_SKIP_NETWORKISH_TESTS=1` で skip 可能、各 test に 30s hard timeout。
+const SKIP_NETWORK = process.env.KIOKU_SKIP_NETWORKISH_TESTS === '1';
+const NETWORK_TEST = { skip: SKIP_NETWORK ? 'KIOKU_SKIP_NETWORKISH_TESTS=1' : false, timeout: 30_000 };
+
 describe('url-image', () => {
   let server, workspace, mediaDir;
   before(async () => {
+    if (SKIP_NETWORK) return;
     process.env.KIOKU_URL_ALLOW_LOOPBACK = '1';
     server = await startFixtureServer();
     workspace = await mkdtemp(join(tmpdir(), 'kioku-img-'));
     mediaDir = join(workspace, 'media');
   });
   after(async () => {
+    if (SKIP_NETWORK) return;
     delete process.env.KIOKU_URL_ALLOW_LOOPBACK;
     await server.close();
     await rm(workspace, { recursive: true, force: true });
   });
 
-  test('UI1 relative URL resolved against base, downloaded', async () => {
+  test('UI1 relative URL resolved against base, downloaded', NETWORK_TEST, async () => {
     const imgs = [{ src: '/sample-image.png', alt: 'sample' }];
     const r = await downloadImages(imgs, { baseUrl: server.url, mediaDir });
     assert.equal(r.images.length, 1);
@@ -30,7 +37,7 @@ describe('url-image', () => {
     assert.equal(entries.length, 1);
   });
 
-  test('UI2 same sha → dedupe (second download → no new file)', async () => {
+  test('UI2 same sha → dedupe (second download → no new file)', NETWORK_TEST, async () => {
     const imgs = [
       { src: '/sample-image.png', alt: 'a' },
       { src: '/sample-image.png', alt: 'b' },
@@ -40,49 +47,49 @@ describe('url-image', () => {
     assert.equal(r.images[0].localPath, r.images[1].localPath, 'dedupe to same file');
   });
 
-  test('UI3 octet-stream MIME → skip + warning', async () => {
+  test('UI3 octet-stream MIME → skip + warning', NETWORK_TEST, async () => {
     const imgs = [{ src: '/redirect-target?ct=application%2Foctet-stream&body=junk', alt: 'x' }];
     const r = await downloadImages(imgs, { baseUrl: server.url, mediaDir });
     assert.equal(r.images.length, 0);
     assert.match(r.warnings.join('\n'), /MIME/);
   });
 
-  test('UI4 size > maxBytes → skip + warning', async () => {
+  test('UI4 size > maxBytes → skip + warning', NETWORK_TEST, async () => {
     const imgs = [{ src: '/huge', alt: 'x' }];
     const r = await downloadImages(imgs, { baseUrl: server.url, mediaDir, maxBytes: 1024 });
     assert.equal(r.images.length, 0);
     assert.match(r.warnings.join('\n'), /size/i);
   });
 
-  test('UI5 tracking pixel (< 200 bytes) → skip', async () => {
+  test('UI5 tracking pixel (< 200 bytes) → skip', NETWORK_TEST, async () => {
     const imgs = [{ src: '/pixel-1x1.png', alt: '' }];
     const r = await downloadImages(imgs, { baseUrl: server.url, mediaDir });
     assert.equal(r.images.length, 0);
     assert.match(r.warnings.join('\n'), /pixel|small/i);
   });
 
-  test('UI6 SVG skipped with warning', async () => {
+  test('UI6 SVG skipped with warning', NETWORK_TEST, async () => {
     const imgs = [{ src: '/redirect-target?ct=image%2Fsvg%2Bxml&body=%3Csvg%3E%3C%2Fsvg%3E', alt: 'svg' }];
     const r = await downloadImages(imgs, { baseUrl: server.url, mediaDir });
     assert.equal(r.images.length, 0);
     assert.match(r.warnings.join('\n'), /svg/i);
   });
 
-  test('UI7 fetch timeout → skip + warning', async () => {
+  test('UI7 fetch timeout → skip + warning', NETWORK_TEST, async () => {
     const imgs = [{ src: '/slow', alt: 'x' }];
     const r = await downloadImages(imgs, { baseUrl: server.url, mediaDir, timeoutMs: 200 });
     assert.equal(r.images.length, 0);
     assert.match(r.warnings.join('\n'), /timeout/i);
   });
 
-  test('UI8 data: URI skipped (not downloaded)', async () => {
+  test('UI8 data: URI skipped (not downloaded)', NETWORK_TEST, async () => {
     const imgs = [{ src: 'data:image/png;base64,iVBORw0KGgo=', alt: 'inline' }];
     const r = await downloadImages(imgs, { baseUrl: server.url, mediaDir });
     assert.equal(r.images.length, 0);
     assert.match(r.warnings.join('\n'), /data:/);
   });
 
-  test('UI9 hostname `..` rejected (path-traversal defense-in-depth)', async () => {
+  test('UI9 hostname `..` rejected (path-traversal defense-in-depth)', NETWORK_TEST, async () => {
     // new URL('http://../x.png').hostname === '..' — without an explicit
     // guard, path.join(mediaDir, '..') would write one directory above
     // mediaDir. fetchUrl rejects this via DNS, but we do not depend on that.
@@ -92,7 +99,7 @@ describe('url-image', () => {
     assert.match(r.warnings.join('\n'), /unsafe hostname/i);
   });
 
-  test('UI10 hostname `.` rejected (would collapse into mediaDir root)', async () => {
+  test('UI10 hostname `.` rejected (would collapse into mediaDir root)', NETWORK_TEST, async () => {
     const imgs = [{ src: 'http://./evil.png', alt: 'evil' }];
     const r = await downloadImages(imgs, { baseUrl: server.url, mediaDir });
     assert.equal(r.images.length, 0);


### PR DESCRIPTION
## Summary

v0.7.2 Sprint 1 完走 release sync from parent (Step 4/8 of LEARN#11 cascade).

## What's bundled

### 🩺 \`kioku doctor\` MVP (PR A、parent #84)
\`scripts/doctor.sh\` 22 check items × 7 category (Environment / Runtime / CLI agents / Hook configs / MCP configs / Metadata parity / Dependencies)、出力 human-readable + \`--json\` 機械可読、read-only mandate、temp HOME/Vault test isolation、macOS/Linux portable (BSD/GNU 分岐回避 design)。

### 🔍 metadata drift test (PR B、parent #89)
\`tests/metadata-drift.test.mjs\` 9 BLUE-DRIFT-* tests × 3 category (TOOL / VERSION / INSTALL)。§44 install path drift incident (4/28) を future regression として pin、LEARN#9 grep-based audit の自動化版。

### ⚡ URL test 安定化 (PR C、parent #90)
\`run-quick-suite.sh\` (60s budget、KIOKU_SKIP_NETWORKISH_TESTS=1 強制) + \`run-full-suite.sh\` (FAIL_LOG 集約、network 含む全 test) 分離。10 既存 URL test file に \`{ timeout, skip }\` パターン統一、fixture server explicit close。

### 🔢 Version bump 5 places (0.7.1 → 0.7.2)
mcp/package.json + mcp/manifest.json + .claude-plugin/plugin.json + .claude-plugin/marketplace.json (×2)

### 🛠 副次発見 2 件 fix
- mcp/package-lock.json 0.5.0 → 0.7.2
- post-release-sync.test.sh PRS-S13 worktree skip guard

## Test result (RYU 5/7 dogfood verified、Mac mini)

| test | 結果 |
|---|---|
| doctor.sh | 19 ok / 2 warn / 1 fail (期待通り) |
| drift test | 9 pass / 0 fail (54ms) |
| run-quick-suite.sh | **300 pass / 24 skipped / 0 fail (9.8s)** |

## Cascade status

- [x] Step 1: parent release PR #92 (5 places + 副次発見 2 件)
- [x] Step 2: parent PR #92 merged
- [x] Step 3: sync-to-app
- [x] Step 4: kioku next → main PR (本 PR)
- [ ] Step 5: kioku 10 言語 README v0.7.2 Changelog (LEARN#11 sync boundary 回避のため別 PR)
- [ ] Step 6: post-release-sync
- [ ] Step 7: .mcpb build + GitHub Release v0.7.2
- [ ] Step 8: marketing handoff

## Note

README Changelog (10 言語) は本 PR に **含まれない** — Step 5 で kioku 側に直接 push する flow (LEARN#11 sync boundary trap 回避 mandatory pattern)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)