### PR TITLE
docs: v0.7.2 Changelog entry を 10 言語 README に展開 (LEARN#11 mandatory)

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -263,6 +263,17 @@ Si encuentras un problema de seguridad, repórtalo a través de [SECURITY.md](SE
 
 ## Cambios
 
+### 2026-05-07 — v0.7.2: Sprint de confiabilidad — `kioku doctor` + metadata drift test + URL test stabilization
+
+v0.7.2 entrega el **Sprint 1** completo del roadmap de confiabilidad post-v0.7.1: tres herramientas de diagnostico que convierten la pregunta "que esta roto?" de intuicion en verificacion mecanica.
+
+- **`kioku doctor` (PR A)** — `bash scripts/doctor.sh` ejecuta 22 read-only checks en 7 categorias (Environment / Runtime / CLI agents / Hook configs / MCP configs / Metadata parity / Dependencies). Default human-readable, `--json` para tooling. Cada `[fail]` / `[warn]` viene con `Next action` concreto. 36 BLUE-DOCTOR-* tests con temp HOME / temp Vault isolation
+- **metadata drift test (PR B)** — `node --test tests/metadata-drift.test.mjs` detecta 3 categorias de drift: MCP tool registry / 5-place version parity / install command syntax. Codifica el incidente §44 install-syntax-drift (4/28) como regression guard. 9 BLUE-DRIFT-* tests
+- **URL test stabilization (PR C)** — Quick suite (60s budget, `KIOKU_SKIP_NETWORKISH_TESTS=1`) + Full suite separadas. 10 URL test files con patron unificado `{ timeout, skip }`. Medido: **quick suite 9.8s en Mac mini**
+- **Side-finding fixes (bundled)** — `mcp/package-lock.json` version 0.5.0 → 0.7.2 / `tests/post-release-sync.test.sh` PRS-S13 worktree skip guard
+- Tests: **Node 475 + Bash 22 suites + 36 doctor + 9 drift + 27 post-release-sync all green**
+- [Release v0.7.2](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.7.2)
+
 ### 2026-04-30 — v0.7.1: Pulido — campo `agent:` en frontmatter + 5 endurecimientos + codificacion de workflow
 
 v0.7.1 pule la narrativa multi-agente que aterrizo en v0.7.0: cada session log ahora lleva su identidad de agente en el frontmatter, cinco endurecimientos discretos (lock TOCTOU, realpath fallback, exit-reason masking, transcript-path boundary, listener accumulation), y las reglas de workflow obtienen codificacion de drift bidireccional.

--- a/README.fr.md
+++ b/README.fr.md
@@ -326,6 +326,17 @@ Si vous trouvez un probleme de securite, veuillez le signaler via [SECURITY.md](
 
 ## Journal des modifications
 
+### 2026-05-07 — v0.7.2 : Sprint de fiabilite — `kioku doctor` + metadata drift test + URL test stabilization
+
+v0.7.2 livre le **Sprint 1** complet de la roadmap de fiabilite post-v0.7.1 : trois outils de diagnostic qui transforment la question "qu'est-ce qui est casse ?" de l'intuition en verification mecanique.
+
+- **`kioku doctor` (PR A)** — `bash scripts/doctor.sh` execute 22 verifications read-only dans 7 categories (Environment / Runtime / CLI agents / Hook configs / MCP configs / Metadata parity / Dependencies). Default human-readable, `--json` pour outils. Chaque `[fail]` / `[warn]` vient avec un `Next action` concret. 36 tests BLUE-DOCTOR-* avec isolation temp HOME / temp Vault
+- **metadata drift test (PR B)** — `node --test tests/metadata-drift.test.mjs` detecte mecaniquement 3 categories de drift : MCP tool registry / 5-place version parity / install command syntax. Codifie l'incident §44 install-syntax-drift (4/28) comme regression guard. 9 tests BLUE-DRIFT-*
+- **URL test stabilization (PR C)** — Quick suite (60s budget, `KIOKU_SKIP_NETWORKISH_TESTS=1`) + Full suite separes. 10 fichiers URL test avec pattern unifie `{ timeout, skip }`. Mesure : **quick suite 9.8s sur Mac mini**
+- **Side-finding fixes (bundled)** — `mcp/package-lock.json` version 0.5.0 → 0.7.2 / `tests/post-release-sync.test.sh` PRS-S13 worktree skip guard
+- Tests : **Node 475 + Bash 22 suites + 36 doctor + 9 drift + 27 post-release-sync tous green**
+- [Release v0.7.2](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.7.2)
+
 ### 2026-04-30 — v0.7.1 : Polissage — champ `agent:` dans frontmatter + 5 durcissements + codification du workflow
 
 v0.7.1 polit la narrative multi-agent atterrie en v0.7.0 : chaque session log porte maintenant son identite d'agent dans le frontmatter, cinq durcissements discrets (lock TOCTOU, realpath fallback, exit-reason masking, transcript-path boundary, listener accumulation), et les regles de workflow gagnent une codification de drift bidirectionnelle.

--- a/README.hi.md
+++ b/README.hi.md
@@ -263,6 +263,17 @@ KIOKU एक Hook सिस्टम है जो **सभी Claude Code स�
 
 ## परिवर्तन इतिहास
 
+### 2026-05-07 — v0.7.2: Reliability Sprint — `kioku doctor` + metadata drift test + URL test stabilization
+
+v0.7.2 post-v0.7.1 reliability roadmap के पूरे **Sprint 1** को ship करता है — तीन diagnostic tools जो KIOKU की "क्या टूट रहा है?" surface को intuition से machine-checkable में बदलते हैं।
+
+- **`kioku doctor` (PR A)** — `bash scripts/doctor.sh` 22 read-only checks × 7 categories (Environment / Runtime / CLI agents / Hook configs / MCP configs / Metadata parity / Dependencies) चलाता है। Default human-readable, `--json` machine consumption के लिए। हर `[fail]` / `[warn]` के साथ concrete `Next action` (जैसे `bash scripts/install-mcp-client.sh --apply`)। 36 BLUE-DOCTOR-* tests temp HOME / temp Vault isolation में
+- **metadata drift test (PR B)** — `node --test tests/metadata-drift.test.mjs` 3 drift categories machine-detect करता है: MCP tool registry / 5-place version parity / install command syntax। §44 install-syntax-drift incident (4/28) को continuous regression guard में codify करता है। 9 BLUE-DRIFT-* tests
+- **URL test stabilization (PR C)** — Quick suite (60s budget, `KIOKU_SKIP_NETWORKISH_TESTS=1`) + Full suite अलग। 10 URL test files में `{ timeout, skip }` unified pattern। मापा: **Mac mini पर quick suite 9.8s**
+- **Side-finding fixes (bundled)** — `mcp/package-lock.json` version 0.5.0 → 0.7.2 / `tests/post-release-sync.test.sh` PRS-S13 worktree skip guard
+- Tests: **Node 475 + Bash 22 suites + 36 doctor + 9 drift + 27 post-release-sync all green**
+- [Release v0.7.2](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.7.2)
+
 ### 2026-04-30 — v0.7.1: Polish — frontmatter में `agent:` field + 5 hardening + workflow codification
 
 v0.7.1 v0.7.0 में ship हुई multi-agent narrative को polish करता है: हर session log अब अपनी agent identity frontmatter में रखता है, पाँच quiet hardening fixes (lock TOCTOU, realpath fallback, exit-reason masking, transcript-path boundary, listener accumulation), और workflow rules में bidirectional drift codification।

--- a/README.ja.md
+++ b/README.ja.md
@@ -484,6 +484,17 @@ KIOKU は Claude Code の**全セッション入出力にアクセスする Hook
 
 ## 更新履歴
 
+### 2026-05-07 — v0.7.2: 信頼性スプリント — `kioku doctor` + metadata drift test + URL test 安定化
+
+v0.7.2 は post-v0.7.1 の信頼性ロードマップ **Sprint 1** を一気に ship。v0.7.0 / v0.7.1 が multi-agent boundary を hardening したのに対し、v0.7.2 は KIOKU の「何が壊れているか」を **直感ベースから機械検査ベース** に転換する 3 つの diagnostic axis。
+
+- **`kioku doctor` (PR A)** — `bash scripts/doctor.sh` で 22 件の read-only チェック × 7 カテゴリ (Environment / Runtime / CLI agents / Hook configs / MCP configs / Metadata parity / Dependencies)。default は人間 readable、`--json` で機械可読。各 `[fail]` / `[warn]` には具体的な `Next action` (例: `bash scripts/install-mcp-client.sh --apply`) を併記。36 件の BLUE-DOCTOR-* test を temp HOME / temp Vault で isolation、macOS / Linux 両対応 (BSD vs GNU `stat` 分岐を design で回避)
+- **metadata drift test (PR B)** — `node --test tests/metadata-drift.test.mjs` が 3 drift カテゴリを機械検出: MCP tool registry (server.mjs ↔ manifest.json ↔ README ↔ context/14) / 5-place version parity (package.json + manifest.json + plugin.json + marketplace.json metadata + plugins[0]) / install command syntax (docs/install-guide-plugin.md の `claude plugin marketplace add` syntax + identifier が `marketplace.json` `name` と一致)。§44 install syntax drift incident (4/28) を継続的な regression guard として codify。9 件の BLUE-DRIFT-* test
+- **URL test 安定化 (PR C)** — 日常 `node --test ...` が URL/fetch test で数分 hang する問題を解消。`tests/run-quick-suite.sh` (60 秒予算、`KIOKU_SKIP_NETWORKISH_TESTS=1` 強制、hooks/ + mcp/ のみ) が新規 default、`tests/run-full-suite.sh` (FAIL_LOG 集約、network 含む) が release 時の gate。10 個の URL test file が `{ timeout, skip }` 統一 pattern、fixture server explicit close。実測: **Mac mini で quick suite 9.8 秒** (target <60 秒)
+- **副次発見 fix (bundled)** — `mcp/package-lock.json` version 0.5.0 → 0.7.2 (long-stale な lock metadata、future drift test の 6th place candidate)。`tests/post-release-sync.test.sh` PRS-S13 に linked worktree skip guard (`[[ -f "${REPO_ROOT}/.git" ]]` で pointer-file `.git` を検出して dynamic dry-run output match を skip)
+- テスト: **Node 475 + Bash 22 suites + 36 doctor + 9 drift + 27 post-release-sync 全 green**、`npm audit` clean
+- [Release v0.7.2](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.7.2) — `kioku-wiki-0.7.2.mcpb` attached
+
 ### 2026-04-30 — v0.7.1: ポリッシュ — `agent:` frontmatter + 5 件のハードニング + workflow ルール codify
 
 v0.7.1 は v0.7.0 で完成したマルチエージェント narrative の磨き上げ。session log の frontmatter にエージェント識別子を追加、5 件の地味なハードニング (lock TOCTOU / realpath fallback / exit-reason masking / transcript-path boundary / listener accumulation)、運用ルールへの双方向 drift codify を入れた。

--- a/README.ko.md
+++ b/README.ko.md
@@ -326,6 +326,17 @@ KIOKU은 **모든 Claude Code 세션 입출력**에 접근하는 Hook 시스템�
 
 ## 변경 이력
 
+### 2026-05-07 — v0.7.2: 신뢰성 스프린트 — `kioku doctor` + metadata drift test + URL test 안정화
+
+v0.7.2는 post-v0.7.1 신뢰성 로드맵의 **Sprint 1** 전체를 한 번에 ship. v0.7.0 / v0.7.1이 multi-agent boundary를 hardening한 것에 비해, v0.7.2는 KIOKU의 "무엇이 망가졌나?" surface를 **직관 기반에서 기계 검사 기반**으로 전환하는 3개의 diagnostic axis.
+
+- **`kioku doctor` (PR A)** — `bash scripts/doctor.sh`로 22개 read-only check × 7 카테고리 (Environment / Runtime / CLI agents / Hook configs / MCP configs / Metadata parity / Dependencies). default는 human-readable, `--json`으로 machine-readable. 각 `[fail]` / `[warn]`에 구체적 `Next action`을 병기. 36개의 BLUE-DOCTOR-* test, temp HOME / temp Vault에서 isolation
+- **metadata drift test (PR B)** — `node --test tests/metadata-drift.test.mjs`가 3개 drift 카테고리를 기계 검출: MCP tool registry / 5-place version parity / install command syntax. §44 install syntax drift incident (4/28)를 지속적인 regression guard로 codify. 9개의 BLUE-DRIFT-* test
+- **URL test 안정화 (PR C)** — Quick suite (60s budget, `KIOKU_SKIP_NETWORKISH_TESTS=1`) + Full suite 분리. 10개의 URL test file에 `{ timeout, skip }` 통일 패턴. 측정: **Mac mini에서 quick suite 9.8s**
+- **Side-finding fixes (bundled)** — `mcp/package-lock.json` version 0.5.0 → 0.7.2 / `tests/post-release-sync.test.sh` PRS-S13 worktree skip guard
+- Tests: **Node 475 + Bash 22 suites + 36 doctor + 9 drift + 27 post-release-sync 모두 green**
+- [Release v0.7.2](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.7.2)
+
 ### 2026-04-30 — v0.7.1: Polish — `agent:` frontmatter 필드 + 5건의 hardening + workflow 코드화
 
 v0.7.1은 v0.7.0에서 정착한 multi-agent narrative를 다듬는 release. 모든 session log가 frontmatter에 agent identity를 갖게 되었고, 다섯 개의 조용한 hardening (lock TOCTOU, realpath fallback, exit-reason masking, transcript-path boundary, listener accumulation), workflow rules에 양방향 drift codification이 추가됨.

--- a/README.md
+++ b/README.md
@@ -465,6 +465,17 @@ If you find a security issue, please report it via [SECURITY.md](SECURITY.md) �
 
 ## Changelog
 
+### 2026-05-07 — v0.7.2: Reliability Sprint — `kioku doctor` + metadata drift test + URL test stabilization
+
+v0.7.2 ships the entire **Sprint 1** of the post-v0.7.1 reliability roadmap. Where v0.7.0 / v0.7.1 hardened the multi-agent boundary, v0.7.2 turns KIOKU's "what's broken?" surface from intuition into machine-checkable across three new diagnostic axes.
+
+- **`kioku doctor` (PR A)** — `bash scripts/doctor.sh` runs 22 read-only checks across 7 categories (Environment / Runtime / CLI agents / Hook configs / MCP configs / Metadata parity / Dependencies). Human-readable by default, `--json` for tooling. Each `[fail]` / `[warn]` is paired with a concrete `Next action` (e.g. `bash scripts/install-mcp-client.sh --apply`). 36 BLUE-DOCTOR-* tests with temp HOME / temp Vault isolation, macOS / Linux portable (avoids BSD vs GNU `stat` divergence by design)
+- **metadata drift test (PR B)** — `node --test tests/metadata-drift.test.mjs` machine-detects 3 drift categories: MCP tool registry (server.mjs ↔ manifest.json ↔ README ↔ context/14) / 5-place version parity (package.json + manifest.json + plugin.json + marketplace.json metadata + plugins[0]) / install command syntax (docs/install-guide-plugin.md `claude plugin marketplace add` syntax + identifier matches `marketplace.json` `name`). Codifies the §44 install-syntax-drift incident (4/28) into a continuous regression guard. 9 BLUE-DRIFT-* tests
+- **URL test stabilization (PR C)** — Daily `node --test ...` no longer hangs minutes on URL/fetch tests. `tests/run-quick-suite.sh` (60s budget, `KIOKU_SKIP_NETWORKISH_TESTS=1` forced, hooks/ + mcp/ only) is the new contributor default; `tests/run-full-suite.sh` (FAIL_LOG aggregation, network included) is the release-time gate. 10 URL test files now share a `{ timeout, skip }` pattern with explicit fixture-server cleanup. Measured: **quick suite 9.8s on Mac mini** (target <60s)
+- **Side-finding fixes (bundled)** — `mcp/package-lock.json` version field bumped 0.5.0 → 0.7.2 (long-stale lock metadata, future drift test 6th place candidate). `tests/post-release-sync.test.sh` PRS-S13 gains a linked-worktree skip guard (`[[ -f "${REPO_ROOT}/.git" ]]` detects pointer-file `.git` and skips dynamic dry-run output match)
+- Tests: **Node 475 + Bash 22 suites + 36 doctor + 9 drift + 27 post-release-sync all green**, `npm audit` clean
+- [Release v0.7.2](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.7.2) — `kioku-wiki-0.7.2.mcpb` attached
+
 ### 2026-04-30 — v0.7.1: Polish — `agent:` frontmatter + 5 hardening + workflow codification
 
 v0.7.1 polishes the multi-agent narrative landed in v0.7.0: every session log now carries its agent identity in the frontmatter, five quiet hardening fixes (lock TOCTOU, realpath fallback, exit-reason masking, transcript-path boundary, listener accumulation), and the workflow rules gain bidirectional-drift codification.

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -326,6 +326,17 @@ Se voce encontrar um problema de seguranca, por favor reporte via [SECURITY.md](
 
 ## Histórico de mudanças
 
+### 2026-05-07 — v0.7.2: Sprint de confiabilidade — `kioku doctor` + metadata drift test + URL test stabilization
+
+v0.7.2 entrega o **Sprint 1** completo do roadmap de confiabilidade post-v0.7.1: tres ferramentas de diagnostico que transformam a pergunta "o que esta quebrado?" de intuicao em verificacao mecanica.
+
+- **`kioku doctor` (PR A)** — `bash scripts/doctor.sh` executa 22 read-only checks em 7 categorias (Environment / Runtime / CLI agents / Hook configs / MCP configs / Metadata parity / Dependencies). Default human-readable, `--json` para tooling. Cada `[fail]` / `[warn]` vem com `Next action` concreto. 36 BLUE-DOCTOR-* tests com isolation temp HOME / temp Vault
+- **metadata drift test (PR B)** — `node --test tests/metadata-drift.test.mjs` detecta 3 categorias de drift: MCP tool registry / 5-place version parity / install command syntax. Codifica o incidente §44 install-syntax-drift (4/28) como regression guard. 9 BLUE-DRIFT-* tests
+- **URL test stabilization (PR C)** — Quick suite (60s budget, `KIOKU_SKIP_NETWORKISH_TESTS=1`) + Full suite separados. 10 arquivos URL test com padrao unificado `{ timeout, skip }`. Medido: **quick suite 9.8s no Mac mini**
+- **Side-finding fixes (bundled)** — `mcp/package-lock.json` version 0.5.0 → 0.7.2 / `tests/post-release-sync.test.sh` PRS-S13 worktree skip guard
+- Tests: **Node 475 + Bash 22 suites + 36 doctor + 9 drift + 27 post-release-sync todos green**
+- [Release v0.7.2](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.7.2)
+
 ### 2026-04-30 — v0.7.1: Polimento — campo `agent:` no frontmatter + 5 endurecimentos + codificacao de workflow
 
 v0.7.1 polica a narrativa multi-agente que aterrissou em v0.7.0: cada session log agora carrega sua identidade de agente no frontmatter, cinco endurecimentos discretos (lock TOCTOU, realpath fallback, exit-reason masking, transcript-path boundary, listener accumulation), e as regras de workflow ganham codificacao de drift bidirecional.

--- a/README.ru.md
+++ b/README.ru.md
@@ -331,6 +331,17 @@ KIOKU спроектирован для **совместного использ�
 
 ## История изменений
 
+### 2026-05-07 — v0.7.2: Спринт надёжности — `kioku doctor` + metadata drift test + URL test stabilization
+
+v0.7.2 поставляет весь **Sprint 1** post-v0.7.1 roadmap надёжности — три diagnostic tool, превращающих KIOKU surface "что сломано?" из интуиции в machine-checkable.
+
+- **`kioku doctor` (PR A)** — `bash scripts/doctor.sh` выполняет 22 read-only проверки в 7 категориях (Environment / Runtime / CLI agents / Hook configs / MCP configs / Metadata parity / Dependencies). Default human-readable, `--json` для tooling. Каждый `[fail]` / `[warn]` сопровождается конкретным `Next action`. 36 BLUE-DOCTOR-* тестов с temp HOME / temp Vault изоляцией
+- **metadata drift test (PR B)** — `node --test tests/metadata-drift.test.mjs` machine-detects 3 категории drift: MCP tool registry / 5-place version parity / install command syntax. Кодифицирует инцидент §44 install-syntax-drift (4/28) как regression guard. 9 BLUE-DRIFT-* тестов
+- **URL test stabilization (PR C)** — Quick suite (60s budget, `KIOKU_SKIP_NETWORKISH_TESTS=1`) + Full suite разделены. 10 URL test files с унифицированным паттерном `{ timeout, skip }`. Измерено: **quick suite 9.8s на Mac mini**
+- **Side-finding fixes (bundled)** — `mcp/package-lock.json` version 0.5.0 → 0.7.2 / `tests/post-release-sync.test.sh` PRS-S13 worktree skip guard
+- Tests: **Node 475 + Bash 22 suites + 36 doctor + 9 drift + 27 post-release-sync all green**
+- [Release v0.7.2](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.7.2)
+
 ### 2026-04-30 — v0.7.1: Полировка — поле `agent:` в frontmatter + 5 hardening + кодификация workflow
 
 v0.7.1 полирует multi-agent narrative, появившийся в v0.7.0: каждый session log теперь несёт свою agent identity в frontmatter, пять тихих hardening fixes (lock TOCTOU, realpath fallback, exit-reason masking, transcript-path boundary, listener accumulation), правила workflow получают двунаправленную drift-codification.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -331,6 +331,17 @@ KIOKU 是一个可以访问**所有 Claude Code 会话输入输出**的 Hook 系
 
 ## 更新历史
 
+### 2026-05-07 — v0.7.2：可靠性冲刺 — `kioku doctor` + metadata drift test + URL test 稳定化
+
+v0.7.2 一次性 ship post-v0.7.1 可靠性 roadmap 的整个 **Sprint 1** —— 三个 diagnostic 工具将 KIOKU 的"什么坏了?"surface 从直觉转变为机器可检查。
+
+- **`kioku doctor` (PR A)** — `bash scripts/doctor.sh` 在 7 个类别 (Environment / Runtime / CLI agents / Hook configs / MCP configs / Metadata parity / Dependencies) 中运行 22 个 read-only check。默认 human-readable，`--json` 用于 tooling。每个 `[fail]` / `[warn]` 都附带具体的 `Next action`。36 个 BLUE-DOCTOR-* test，temp HOME / temp Vault isolation
+- **metadata drift test (PR B)** — `node --test tests/metadata-drift.test.mjs` 机器检测 3 个 drift 类别：MCP tool registry / 5-place version parity / install command syntax。将 §44 install-syntax-drift incident (4/28) codify 为持续的 regression guard。9 个 BLUE-DRIFT-* test
+- **URL test 稳定化 (PR C)** — Quick suite (60s budget, `KIOKU_SKIP_NETWORKISH_TESTS=1`) + Full suite 分离。10 个 URL test 文件采用 `{ timeout, skip }` 统一模式。测量：**Mac mini 上 quick suite 9.8s**
+- **Side-finding fixes (bundled)** — `mcp/package-lock.json` version 0.5.0 → 0.7.2 / `tests/post-release-sync.test.sh` PRS-S13 worktree skip guard
+- Tests: **Node 475 + Bash 22 suites + 36 doctor + 9 drift + 27 post-release-sync 全部 green**
+- [Release v0.7.2](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.7.2)
+
 ### 2026-04-30 — v0.7.1：打磨 — frontmatter 中 `agent:` 字段 + 5 项 hardening + workflow 编码
 
 v0.7.1 打磨 v0.7.0 落地的 multi-agent narrative：每个 session log 现在在 frontmatter 中携带其 agent 身份，五项低调 hardening (lock TOCTOU、realpath fallback、exit-reason masking、transcript-path boundary、listener accumulation)，workflow 规则获得双向 drift codification。

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -331,6 +331,17 @@ KIOKU 是一個存取**所有 Claude Code 工作階段 I/O** 的 Hook 系統。
 
 ## 更新歷史
 
+### 2026-05-07 — v0.7.2：可靠性衝刺 — `kioku doctor` + metadata drift test + URL test 穩定化
+
+v0.7.2 一次性 ship post-v0.7.1 可靠性 roadmap 的整個 **Sprint 1** —— 三個 diagnostic 工具將 KIOKU 的「什麼壞了?」surface 從直覺轉變為機器可檢查。
+
+- **`kioku doctor` (PR A)** — `bash scripts/doctor.sh` 在 7 個類別 (Environment / Runtime / CLI agents / Hook configs / MCP configs / Metadata parity / Dependencies) 中執行 22 個 read-only check。預設 human-readable，`--json` 用於 tooling。每個 `[fail]` / `[warn]` 都附帶具體的 `Next action`。36 個 BLUE-DOCTOR-* test，temp HOME / temp Vault isolation
+- **metadata drift test (PR B)** — `node --test tests/metadata-drift.test.mjs` 機器檢測 3 個 drift 類別：MCP tool registry / 5-place version parity / install command syntax。將 §44 install-syntax-drift incident (4/28) codify 為持續的 regression guard。9 個 BLUE-DRIFT-* test
+- **URL test 穩定化 (PR C)** — Quick suite (60s budget, `KIOKU_SKIP_NETWORKISH_TESTS=1`) + Full suite 分離。10 個 URL test 檔案採用 `{ timeout, skip }` 統一模式。測量：**Mac mini 上 quick suite 9.8s**
+- **Side-finding fixes (bundled)** — `mcp/package-lock.json` version 0.5.0 → 0.7.2 / `tests/post-release-sync.test.sh` PRS-S13 worktree skip guard
+- Tests: **Node 475 + Bash 22 suites + 36 doctor + 9 drift + 27 post-release-sync 全部 green**
+- [Release v0.7.2](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.7.2)
+
 ### 2026-04-30 — v0.7.1：打磨 — frontmatter 中 `agent:` 欄位 + 5 項 hardening + workflow 編碼
 
 v0.7.1 打磨 v0.7.0 落地的 multi-agent narrative：每個 session log 現在在 frontmatter 中攜帶其 agent 身份，五項低調 hardening (lock TOCTOU、realpath fallback、exit-reason masking、transcript-path boundary、listener accumulation)，workflow 規則獲得雙向 drift codification。


### PR DESCRIPTION
v0.7.2 release cascade Step 5: 10 言語 README に v0.7.2 Changelog entry。Reliability Sprint narrative。i18n parity 10/10 ✅。