### PR TITLE
v0.7.3 micro release: Sprint 1 完走 marker

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "KIOKU: Hardened LLM Wiki for Claude Code / Claude Desktop by megaphone-tokyo",
-    "version": "0.7.2"
+    "version": "0.7.3"
   },
   "plugins": [
     {
@@ -17,7 +17,7 @@
         "ref": "main"
       },
       "description": "Hardened LLM Wiki for Claude Code + Claude Desktop. Automatic conversation → Obsidian Vault knowledge base. Hot cache + PostCompact hook + secret masking + Git sync.",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "author": {
         "name": "megaphone-tokyo",
         "url": "https://github.com/megaphone-tokyo"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kioku",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "KIOKU — Hardened LLM Wiki for Claude Code + Claude Desktop. Automatic conversation capture to Obsidian Vault, Karpathy LLM Wiki pattern, hot cache + PostCompact hook, secret masking, cross-machine Git sync. Research/legal/enterprise-grade memory for Claude.",
   "author": {
     "name": "megaphone-tokyo",

--- a/mcp/manifest.json
+++ b/mcp/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "kioku-wiki",
   "display_name": "KIOKU Wiki",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Read, search, and write your KIOKU Obsidian Wiki from Claude Desktop or Claude Code.",
   "long_description": "KIOKU is a personal knowledge base ('second brain') built on top of an Obsidian Vault. This MCP server exposes ten tools (kioku_search, kioku_read, kioku_list, kioku_write_note, kioku_write_wiki, kioku_delete, kioku_ingest_pdf, kioku_ingest_url, kioku_ingest_document, kioku_generate_viz) so that Claude Desktop and Claude Code can browse and update the Wiki without leaving the chat. All operations are local stdio — nothing leaves your machine. See https://github.com/megaphone-tokyo/kioku for the full project.",
   "author": {

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kioku-mcp",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kioku-mcp",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "dependencies": {
         "@modelcontextprotocol/sdk": "~1.29.0",
         "@mozilla/readability": "^0.6.0",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kioku-mcp",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "private": true,
   "type": "module",
   "description": "KIOKU local MCP server (Wiki read/list/search/write_note/write_wiki/delete) for Claude Desktop and Claude Code.",

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -545,6 +545,54 @@ check_dependencies() {
 }
 
 # -----------------------------------------------------------------------------
+# Section: Install mode detection (derived from hook/MCP checks)
+#
+# 既存の hook-* / mcp-* check 結果を集約して、現在の install mode を判定する。
+# Mode C (Full memory): MCP ok + Hooks ok    KIOKU 本来の使い方 (auto logging + sync)
+# Mode A (MCP-only):    MCP ok + Hooks 無し  security-conscious / Claude Desktop 中心
+# Unknown:              上記いずれでもない    partial install / first run
+#
+# Mode B (Read-only) は --read-only flag が install-mcp-client.sh に未実装の
+# ため MVP では判定しない (acceptance criteria は Mode A / C 判定で満たす)。
+# read-only flag 導入後に v0.7.x の iterative refine で追加予定。
+# -----------------------------------------------------------------------------
+INSTALL_MODE_LABEL=""
+INSTALL_MODE_DETAIL=""
+
+detect_install_mode() {
+  local total=$((OK_COUNT + WARN_COUNT + FAIL_COUNT))
+  local has_hooks_ok=0
+  local has_mcp_ok=0
+  local i=0
+  while [[ $i -lt $total ]]; do
+    local id="${RESULT_IDS[$i]}"
+    local level="${RESULT_LEVELS[$i]}"
+    case "${id}" in
+      hook-claude|hook-codex|hook-gemini)
+        [[ "${level}" == "ok" ]] && has_hooks_ok=1
+        ;;
+      mcp-claude-desktop|mcp-codex|mcp-gemini)
+        [[ "${level}" == "ok" ]] && has_mcp_ok=1
+        ;;
+    esac
+    i=$((i + 1))
+  done
+
+  local hooks_state mcp_state
+  if [[ "${has_hooks_ok}" -eq 1 ]]; then hooks_state="ok"; else hooks_state="not registered"; fi
+  if [[ "${has_mcp_ok}"   -eq 1 ]]; then mcp_state="ok";   else mcp_state="not registered"; fi
+
+  if [[ "${has_mcp_ok}" -eq 1 && "${has_hooks_ok}" -eq 1 ]]; then
+    INSTALL_MODE_LABEL="Mode C (Full memory)"
+  elif [[ "${has_mcp_ok}" -eq 1 && "${has_hooks_ok}" -eq 0 ]]; then
+    INSTALL_MODE_LABEL="Mode A (MCP-only)"
+  else
+    INSTALL_MODE_LABEL="Unknown / Partial install"
+  fi
+  INSTALL_MODE_DETAIL="MCP: ${mcp_state} / Hooks: ${hooks_state}"
+}
+
+# -----------------------------------------------------------------------------
 # Output: text or JSON
 # -----------------------------------------------------------------------------
 print_text() {
@@ -567,6 +615,12 @@ print_text() {
   echo ""
   printf 'Summary: %d ok / %d warn / %d fail\n' \
     "${OK_COUNT}" "${WARN_COUNT}" "${FAIL_COUNT}"
+
+  # Install mode (derived view from hook/MCP checks)
+  if [[ -n "${INSTALL_MODE_LABEL}" ]]; then
+    printf '[mode] Current install mode: %s\n' "${INSTALL_MODE_LABEL}"
+    printf '       %s\n' "${INSTALL_MODE_DETAIL}"
+  fi
 
   # Next actions (warn/fail で next_action が空でないものを列挙、重複は除く)
   local actions_file
@@ -621,7 +675,9 @@ print_json() {
     --argjson ok "${OK_COUNT}" \
     --argjson warn "${WARN_COUNT}" \
     --argjson fail "${FAIL_COUNT}" \
-    '{summary: {ok: $ok, warn: $warn, fail: $fail}, checks: .}' \
+    --arg install_mode "${INSTALL_MODE_LABEL}" \
+    --arg install_mode_detail "${INSTALL_MODE_DETAIL}" \
+    '{summary: {ok: $ok, warn: $warn, fail: $fail, install_mode: $install_mode, install_mode_detail: $install_mode_detail}, checks: .}' \
     "${buf}"
   rm -f "${buf}"
 }
@@ -636,6 +692,7 @@ check_hook_configs
 check_mcp_configs
 check_metadata_parity
 check_dependencies
+detect_install_mode
 
 if [[ "${JSON_MODE}" -eq 1 ]]; then
   print_json

--- a/tests/doctor.test.sh
+++ b/tests/doctor.test.sh
@@ -757,6 +757,184 @@ test_json_output() {
 }
 
 # -----------------------------------------------------------------------------
+# BLUE-DOCTOR-MODE-1: Hooks ok + MCP ok → Mode C (Full memory)
+# -----------------------------------------------------------------------------
+test_install_mode_full() {
+  echo "BLUE-DOCTOR-MODE-1: hooks + MCP both ok → Mode C (Full memory)"
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "  skip  jq not available"
+    return 0
+  fi
+  local d
+  d="$(new_case "mode-full")"
+  stub_full_clis "${d}/bin"
+  stub_node_18 "${d}/bin"
+  init_full_vault "${d}/vault"
+
+  # Claude hook ok
+  mkdir -p "${d}/home/.claude"
+  cat >"${d}/home/.claude/settings.json" <<'EOF'
+{ "hooks": { "Stop": [ { "hooks": [ { "type": "command", "command": "node /x/session-logger.mjs" } ] } ] } }
+EOF
+  # Claude Desktop MCP ok (macOS path under temp HOME)
+  local desktop_dir="${d}/home/Library/Application Support/Claude"
+  mkdir -p "${desktop_dir}"
+  cat >"${desktop_dir}/claude_desktop_config.json" <<'EOF'
+{ "mcpServers": { "kioku": { "command": "node", "args": ["/x/mcp/server.mjs"] } } }
+EOF
+
+  local out
+  set +e
+  out="$(env -i \
+        HOME="${d}/home" \
+        PATH="$(build_path "${d}/bin")" \
+        TMPDIR="${TMPDIR:-/tmp}" \
+        OBSIDIAN_VAULT="${d}/vault" \
+        CLAUDE_DESKTOP_CONFIG="${desktop_dir}/claude_desktop_config.json" \
+        bash "${DOCTOR}" 2>&1)"
+  set -e
+
+  assert_contains "${out}" "[mode] Current install mode: Mode C (Full memory)" \
+    "MODE-1: Mode C label appears"
+  assert_contains "${out}" "MCP: ok / Hooks: ok" \
+    "MODE-1: detail shows MCP ok and Hooks ok"
+}
+
+# -----------------------------------------------------------------------------
+# BLUE-DOCTOR-MODE-2: MCP ok, Hooks not registered → Mode A (MCP-only)
+# -----------------------------------------------------------------------------
+test_install_mode_mcp_only() {
+  echo "BLUE-DOCTOR-MODE-2: MCP ok + hooks absent → Mode A (MCP-only)"
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "  skip  jq not available"
+    return 0
+  fi
+  local d
+  d="$(new_case "mode-mcp-only")"
+  # Stub everything except hook CLIs (claude/codex/gemini absent → hook check skipped as warn)
+  write_stub "${d}/bin" "qmd"
+  write_stub "${d}/bin" "pdfinfo"
+  write_stub "${d}/bin" "pdftotext"
+  stub_node_18 "${d}/bin"
+  init_full_vault "${d}/vault"
+
+  # No Claude/Codex/Gemini hooks registered (CLIs absent → all hook checks "warn")
+  # But Claude Desktop MCP registered (Claude Desktop config does not need claude CLI)
+  local desktop_dir="${d}/home/Library/Application Support/Claude"
+  mkdir -p "${desktop_dir}"
+  cat >"${desktop_dir}/claude_desktop_config.json" <<'EOF'
+{ "mcpServers": { "kioku": { "command": "node", "args": ["/x/mcp/server.mjs"] } } }
+EOF
+
+  local out
+  set +e
+  out="$(env -i \
+        HOME="${d}/home" \
+        PATH="$(build_path "${d}/bin")" \
+        TMPDIR="${TMPDIR:-/tmp}" \
+        OBSIDIAN_VAULT="${d}/vault" \
+        CLAUDE_DESKTOP_CONFIG="${desktop_dir}/claude_desktop_config.json" \
+        bash "${DOCTOR}" 2>&1)"
+  set -e
+
+  assert_contains "${out}" "[mode] Current install mode: Mode A (MCP-only)" \
+    "MODE-2: Mode A label appears"
+  assert_contains "${out}" "MCP: ok / Hooks: not registered" \
+    "MODE-2: detail shows MCP ok and Hooks not registered"
+}
+
+# -----------------------------------------------------------------------------
+# BLUE-DOCTOR-MODE-3: Hooks ok, MCP missing → Unknown / Partial install
+#
+# Mode B (Read-only) は --read-only flag が install-mcp-client.sh に未実装な
+# ため MVP では判定しない。MCP 抜け / Hooks ok の組み合わせも "Unknown /
+# Partial install" として扱う (judge は v0.7.x で iterative refine 予定)。
+# -----------------------------------------------------------------------------
+test_install_mode_unknown() {
+  echo "BLUE-DOCTOR-MODE-3: hooks ok + MCP missing → Unknown / Partial install"
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "  skip  jq not available"
+    return 0
+  fi
+  local d
+  d="$(new_case "mode-unknown")"
+  stub_full_clis "${d}/bin"
+  stub_node_18 "${d}/bin"
+  init_full_vault "${d}/vault"
+
+  # Claude hook ok
+  mkdir -p "${d}/home/.claude"
+  cat >"${d}/home/.claude/settings.json" <<'EOF'
+{ "hooks": { "Stop": [ { "hooks": [ { "type": "command", "command": "node /x/session-logger.mjs" } ] } ] } }
+EOF
+  # No MCP config files at all (Claude Desktop / Codex / Gemini MCP all missing)
+  # CLAUDE_DESKTOP_CONFIG points to a non-existent path under temp HOME
+  local out
+  set +e
+  out="$(env -i \
+        HOME="${d}/home" \
+        PATH="$(build_path "${d}/bin")" \
+        TMPDIR="${TMPDIR:-/tmp}" \
+        OBSIDIAN_VAULT="${d}/vault" \
+        CLAUDE_DESKTOP_CONFIG="${d}/home/no-such-claude-desktop-config.json" \
+        bash "${DOCTOR}" 2>&1)"
+  set -e
+
+  assert_contains "${out}" "[mode] Current install mode: Unknown / Partial install" \
+    "MODE-3: Unknown label appears"
+  assert_contains "${out}" "MCP: not registered / Hooks: ok" \
+    "MODE-3: detail shows MCP missing and Hooks ok"
+}
+
+# -----------------------------------------------------------------------------
+# BLUE-DOCTOR-MODE-4: --json mode includes install_mode in summary
+# -----------------------------------------------------------------------------
+test_install_mode_json() {
+  echo "BLUE-DOCTOR-MODE-4: --json summary includes install_mode field"
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "  skip  jq not available"
+    return 0
+  fi
+  local d
+  d="$(new_case "mode-json")"
+  stub_full_clis "${d}/bin"
+  stub_node_18 "${d}/bin"
+  init_full_vault "${d}/vault"
+
+  mkdir -p "${d}/home/.claude"
+  cat >"${d}/home/.claude/settings.json" <<'EOF'
+{ "hooks": { "Stop": [ { "hooks": [ { "type": "command", "command": "node /x/session-logger.mjs" } ] } ] } }
+EOF
+  local desktop_dir="${d}/home/Library/Application Support/Claude"
+  mkdir -p "${desktop_dir}"
+  cat >"${desktop_dir}/claude_desktop_config.json" <<'EOF'
+{ "mcpServers": { "kioku": { "command": "node", "args": ["/x/mcp/server.mjs"] } } }
+EOF
+
+  local out
+  set +e
+  out="$(env -i \
+        HOME="${d}/home" \
+        PATH="$(build_path "${d}/bin")" \
+        TMPDIR="${TMPDIR:-/tmp}" \
+        OBSIDIAN_VAULT="${d}/vault" \
+        CLAUDE_DESKTOP_CONFIG="${desktop_dir}/claude_desktop_config.json" \
+        bash "${DOCTOR}" --json 2>&1)"
+  set -e
+
+  if printf '%s' "${out}" | jq -e '.summary.install_mode == "Mode C (Full memory)"' >/dev/null 2>&1; then
+    pass "MODE-4: --json summary.install_mode == \"Mode C (Full memory)\""
+  else
+    fail "MODE-4: --json summary.install_mode missing or wrong (got: $(printf '%s' "${out}" | jq -r '.summary.install_mode // "<absent>"' 2>/dev/null || echo '<unparseable>'))"
+  fi
+  if printf '%s' "${out}" | jq -e '.summary.install_mode_detail | contains("MCP: ok") and contains("Hooks: ok")' >/dev/null 2>&1; then
+    pass "MODE-4: --json summary.install_mode_detail contains MCP ok / Hooks ok"
+  else
+    fail "MODE-4: --json summary.install_mode_detail missing or wrong"
+  fi
+}
+
+# -----------------------------------------------------------------------------
 # Run all
 # -----------------------------------------------------------------------------
 test_env_unset
@@ -778,6 +956,10 @@ test_exit_code_all_ok
 test_exit_code_fail
 test_exit_code_warn_only
 test_json_output
+test_install_mode_full
+test_install_mode_mcp_only
+test_install_mode_unknown
+test_install_mode_json
 
 echo ""
 echo "doctor.test.sh: ${PASS} passed, ${FAIL} failed"


### PR DESCRIPTION
## Summary

v0.7.3 micro release sync from parent (Step 4/8 of LEARN#11 cascade). Sprint 1 完走 marker。

## What's bundled (delta from v0.7.2)

### 🚪 Mode A/B/C onboarding (Sprint 1 #4、PR A: parent #96)
- Quick Start を mode-based 構成に rewrite (EN + JA)
  - **Mode A: MCP-only** — Claude Desktop / security-conscious / 試験的 user 向け
  - **Mode B: Read-only** — v0.7.x で write/read separation 追加予定として明示
  - **Mode C: Full memory** — 既存 Manual Setup を rename (regression 0)
- doctor.sh に install_mode detection 追加 (`[mode]` line + `--json install_mode` field)
- 8 BLUE-DOCTOR-MODE-* tests

### 🔢 Version bump 5 places (0.7.2 → 0.7.3)
mcp/package.json + mcp/manifest.json + .claude-plugin/plugin.json + .claude-plugin/marketplace.json (×2) + mcp/package-lock.json (6th place、since v0.7.2)

## Sprint 1 完走 marker (累積)

| PR | 内容 | merge | N |
|---|---|---|---|
| #84 | PR A: kioku doctor MVP (652 行 + 36 BLUE-DOCTOR-* tests) | 4/30 | N=3 |
| #89 | PR B: metadata drift test (9 BLUE-DRIFT-* tests) | 5/7 朝 | N=4 |
| #90 | PR C: URL test 安定化 (quick/full + skip env) | 5/7 朝 | N=5 |
| #96 | #4: README mode-based + doctor mode detection (8 BLUE-DOCTOR-MODE-*) | 5/7 夜 | N=6 |

codex roadmap §「推奨順序 / Sprint 1: 信頼性と導入」 4 項目 100% 達成。

## Test result

- drift test 9 件 still pass (BLUE-DRIFT-VERSION-1 が 0.7.3 を pin)
- doctor.test.sh 44 件 still pass (BLUE-DOCTOR-MODE-1〜4 含む、PM independent verify)
- run-quick-suite.sh 9.8 sec で完走 (RYU 5/7 dogfood verified)

## Cascade status

- [x] Step 1: parent release PR #98 (5 places version bump)
- [x] Step 2: parent PR #98 merged
- [x] Step 3: sync-to-app
- [x] Step 4: kioku next → main PR (本 PR)
- [ ] Step 5: kioku 10 言語 README v0.7.3 Changelog (LEARN#11 sync boundary 回避のため別 PR)
- [ ] Step 6: post-release-sync
- [ ] Step 7: .mcpb build + GitHub Release v0.7.3
- [ ] Step 8: marketing handoff

🤖 Generated with [Claude Code](https://claude.com/claude-code)