### PR TITLE
v0.7.4 micro release: Sprint 2 着手 (kioku_health + 記憶品質 dashboard)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "KIOKU: Hardened LLM Wiki for Claude Code / Claude Desktop by megaphone-tokyo",
-    "version": "0.7.3"
+    "version": "0.7.4"
   },
   "plugins": [
     {
@@ -17,7 +17,7 @@
         "ref": "main"
       },
       "description": "Hardened LLM Wiki for Claude Code + Claude Desktop. Automatic conversation → Obsidian Vault knowledge base. Hot cache + PostCompact hook + secret masking + Git sync.",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "author": {
         "name": "megaphone-tokyo",
         "url": "https://github.com/megaphone-tokyo"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kioku",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "KIOKU — Hardened LLM Wiki for Claude Code + Claude Desktop. Automatic conversation capture to Obsidian Vault, Karpathy LLM Wiki pattern, hot cache + PostCompact hook, secret masking, cross-machine Git sync. Research/legal/enterprise-grade memory for Claude.",
   "author": {
     "name": "megaphone-tokyo",

--- a/docs/install-guide-multi-agent.md
+++ b/docs/install-guide-multi-agent.md
@@ -6,9 +6,9 @@ updated: 2026-04-24
 # KIOKU Multi-Agent MCP Setup
 
 KIOKU ships an MCP-compliant stdio server at `mcp/server.mjs` that exposes
-**10 tools**: `kioku_read`, `kioku_list`, `kioku_search`, `kioku_write_note`,
+**11 tools**: `kioku_read`, `kioku_list`, `kioku_search`, `kioku_write_note`,
 `kioku_write_wiki`, `kioku_delete`, `kioku_ingest_pdf`, `kioku_ingest_document`,
-`kioku_ingest_url`, `kioku_generate_viz`.
+`kioku_ingest_url`, `kioku_generate_viz`, `kioku_health`.
 
 Because the server speaks the Model Context Protocol, any MCP-capable client
 can drive it — not just Claude Code / Claude Desktop. This guide shows how to
@@ -46,7 +46,7 @@ when this guide was written (2026-04-24):
 
 | Layer | Status | Evidence |
 |---|---|---|
-| MCP protocol compliance of `mcp/server.mjs` | **Verified** | Direct JSON-RPC `initialize` + `tools/list` + `tools/call kioku_list` against `node mcp/server.mjs` with a real Vault. Server returned `kioku-wiki` in `initialize`, 10 tools in `tools/list`, and 13 top-level entries from `tools/call kioku_list`. |
+| MCP protocol compliance of `mcp/server.mjs` | **Verified** | Direct JSON-RPC `initialize` + `tools/list` + `tools/call kioku_list` against `node mcp/server.mjs` with a real Vault. Server returned `kioku-wiki` in `initialize`, 11 tools in `tools/list` (Sprint 2 v0.7.4: added `kioku_health`), and 13 top-level entries from `tools/call kioku_list`. |
 | Per-CLI config-file integration (Codex / Gemini / OpenCode) | **Documented, not CLI-tested** | Config syntax below is quoted from each vendor's upstream docs (URLs cited per agent). End-to-end smoke tests (`codex` / `gemini` / `opencode` binaries + `kioku_list` round-trip) were **not** run in the delegation environment because the three CLIs were not installed and global npm install was declined by sandbox policy. |
 
 If you run the end-to-end flow successfully in any of the three CLIs, a PR
@@ -384,7 +384,7 @@ Expected output on a seeded Vault:
 
 ```
 initialize: { name: 'kioku-wiki', version: '0.1.0' }
-tools/list: 10 tools
+tools/list: 11 tools
   - kioku_read
   - kioku_list
   - kioku_search
@@ -395,6 +395,7 @@ tools/list: 10 tools
   - kioku_ingest_document
   - kioku_ingest_url
   - kioku_generate_viz
+  - kioku_health
 kioku_list: <n> entries
 ```
 

--- a/mcp/lib/health-metrics.mjs
+++ b/mcp/lib/health-metrics.mjs
@@ -1,0 +1,434 @@
+// health-metrics.mjs — KIOKU 記憶品質 dashboard の metric 計算ライブラリ
+//
+// codex roadmap §P1 (plan/codex/260430_kioku-product-improvement-roadmap.md L283-315)
+// に基づく "wiki が育っているか / 淀んでいるか" を測る 6 core metrics:
+//   1. orphan pages           — 他から wikilink で参照されていない page
+//   2. stale pages            — frontmatter `updated:` が 30 日以上前 (fallback: file mtime)
+//   3. duplicate title groups — 同一 title (frontmatter > H1 > basename) の 2+ page
+//   4. hot.md age             — wiki/hot.md の最終更新からの経過時間
+//   5. last ingest activity   — session-logs/ の最新 mtime + ログ件数
+//   6. unprocessed session-logs — frontmatter `ingested: false` の session-log 件数
+//
+// Acceptance criteria (codex roadmap L310-315):
+//   - 「Wiki が育っている / 淀んでいる」を見て分かる
+//   - auto-lint の結果と重複しすぎない (auto-lint は session→wiki ingest 品質、
+//     本 module は ingest 後の wiki 自体の状態、責務分離)
+//   - 数字だけでなく next action を出す (buildNextActions が actionable 提案を生成)
+//
+// 設計方針:
+//   - Node 18+ stdlib + 既存 lib (frontmatter / wikilinks) のみ、新規外部依存なし
+//   - 読み取り専用: wiki/ session-logs/ を **絶対に modify しない**
+//   - test 可能性を優先: 個別 metric 関数を export、orchestrator (collectHealthMetrics) で合成
+//   - vault root を引数で受け取り、environment 変数依存を持たない
+
+import { readFile, readdir, stat } from 'node:fs/promises';
+import { basename, join, relative, sep } from 'node:path';
+
+import { parseFrontmatter } from './frontmatter.mjs';
+import { findWikilinks } from './wikilinks.mjs';
+
+export const STALE_THRESHOLD_DAYS = 30;
+export const HEALTH_SCHEMA_VERSION = 1;
+
+// wiki/ 走査時にスキップするディレクトリ (kioku_list の EXCLUDE と整合)
+const EXCLUDE_DIRS = new Set(['.obsidian', '.archive', '.trash', 'templates', '.cache']);
+
+// orphan / stale / duplicate 判定から除外する system page
+//   - index.md / log.md / hot.md      : entry point + hot cache
+const ORPHAN_EXEMPT_FILES = new Set(['index.md', 'log.md', 'hot.md']);
+//   - meta/      : dashboard.md, health.md (本 module 出力)
+//   - summaries/ : LLM 生成の要約 (機械生成、人間の wikilink 対象外)
+//   - viz/       : visualizer 出力 (HTML、wikilink 対象外)
+const ORPHAN_EXEMPT_TOP_DIRS = new Set(['meta', 'summaries', 'viz']);
+
+function isSystemPage(rel) {
+  if (ORPHAN_EXEMPT_FILES.has(rel)) return true;
+  const top = rel.split('/')[0];
+  return ORPHAN_EXEMPT_TOP_DIRS.has(top);
+}
+
+// wiki/ を再帰的に walk して .md file path を集める。
+// 戻り値は { abs, rel } (rel は wiki/ からの相対パス、posix slash 統一)。
+async function listWikiPages(vault) {
+  const wikiDir = join(vault, 'wiki');
+  let baseStat;
+  try {
+    baseStat = await stat(wikiDir);
+  } catch (err) {
+    if (err.code === 'ENOENT') return [];
+    throw err;
+  }
+  if (!baseStat.isDirectory()) return [];
+
+  const out = [];
+  async function walk(absDir) {
+    let entries;
+    try {
+      entries = await readdir(absDir, { withFileTypes: true });
+    } catch (err) {
+      if (err.code === 'ENOENT') return;
+      throw err;
+    }
+    for (const ent of entries) {
+      if (ent.name.startsWith('.')) continue;
+      if (EXCLUDE_DIRS.has(ent.name)) continue;
+      const abs = join(absDir, ent.name);
+      if (ent.isDirectory()) {
+        await walk(abs);
+      } else if (ent.isFile() && ent.name.endsWith('.md')) {
+        out.push(abs);
+      }
+    }
+  }
+  await walk(wikiDir);
+  return out.map((abs) => ({ abs, rel: relative(wikiDir, abs).split(sep).join('/') }));
+}
+
+// 1 file から meta (frontmatter / body / mtime / wikilinks) を抽出。
+// 読み込み失敗時は null を返す (corrupt file は metrics 集計から除外、stderr に出さない)。
+async function readPageMeta(absPath) {
+  let text;
+  let st;
+  try {
+    [text, st] = await Promise.all([readFile(absPath, 'utf8'), stat(absPath)]);
+  } catch {
+    return null;
+  }
+  const { data, body } = parseFrontmatter(text);
+  return {
+    abs: absPath,
+    text,
+    body,
+    frontmatter: data,
+    mtime: st.mtime,
+    wikilinks: findWikilinks(text),
+  };
+}
+
+// title 解決: frontmatter title > 本文 H1 > file basename (.md 除く)
+function resolveTitle(meta, rel) {
+  const fmTitle = meta.frontmatter?.title;
+  if (typeof fmTitle === 'string' && fmTitle.trim()) return fmTitle.trim();
+  const h1 = meta.body.match(/^#\s+(.+?)\s*$/m);
+  if (h1) return h1[1].trim();
+  return basename(rel, '.md');
+}
+
+// frontmatter `updated:` を Date に解釈。null / 不正値 の場合は fallback (file mtime) を返す。
+function parseUpdatedDate(fmValue, fallbackMtime) {
+  if (fmValue) {
+    const s = typeof fmValue === 'string' ? fmValue.trim() : String(fmValue);
+    if (s) {
+      const d = new Date(s);
+      if (!Number.isNaN(d.getTime())) return d;
+    }
+  }
+  return fallbackMtime;
+}
+
+function humanDuration(seconds) {
+  if (seconds === null || seconds === undefined) return null;
+  const abs = Math.abs(seconds);
+  if (abs < 60) return `${seconds}s`;
+  if (abs < 3600) return `${Math.floor(seconds / 60)}m`;
+  if (abs < 86400) return `${Math.floor(seconds / 3600)}h`;
+  return `${Math.floor(seconds / 86400)}d`;
+}
+
+// Metric 1: orphan pages
+//
+// 「他のどの wiki page からも wikilink 参照されていない page」を返す。
+// system page (index.md / hot.md / meta/* / summaries/* / viz/*) は除外。
+//
+// マッチング規則 (Obsidian の wikilink resolution に倣う):
+//   [[concepts/jwt]] → "concepts/jwt" / "jwt"
+//   [[jwt]]          → "jwt"
+//   [[Title]]        → "Title"  (basename match のみ、frontmatter title は本実装では未対応)
+//
+// page の rel が "concepts/jwt.md" であれば、"concepts/jwt" / "jwt" のいずれかが
+// link target set に含まれていれば inbound あり扱い。
+export function detectOrphans(pages) {
+  const linkedTargets = new Set();
+  for (const p of pages) {
+    for (const target of p.meta.wikilinks) {
+      const t = String(target).trim();
+      if (!t) continue;
+      linkedTargets.add(t);
+      const last = t.split('/').pop();
+      if (last) linkedTargets.add(last);
+    }
+  }
+  const orphans = [];
+  for (const p of pages) {
+    if (isSystemPage(p.rel)) continue;
+    const relNoExt = p.rel.replace(/\.md$/, '');
+    const bn = basename(p.rel, '.md');
+    if (linkedTargets.has(p.rel)) continue;
+    if (linkedTargets.has(relNoExt)) continue;
+    if (linkedTargets.has(bn)) continue;
+    orphans.push(p.rel);
+  }
+  return orphans.sort();
+}
+
+// Metric 2: stale pages
+//
+// frontmatter `updated:` (YYYY-MM-DD or ISO) が thresholdDays 以上前の page を返す。
+// `updated:` が無い場合は file mtime で判定。system page は除外 (索引や hot は性質上頻度が違う)。
+export function detectStale(
+  pages,
+  { thresholdDays = STALE_THRESHOLD_DAYS, now = new Date() } = {},
+) {
+  const thresholdMs = thresholdDays * 24 * 60 * 60 * 1000;
+  const out = [];
+  for (const p of pages) {
+    if (isSystemPage(p.rel)) continue;
+    const updatedDate = parseUpdatedDate(p.meta.frontmatter?.updated, p.meta.mtime);
+    const ageMs = now.getTime() - updatedDate.getTime();
+    if (ageMs > thresholdMs) {
+      const ageDays = Math.floor(ageMs / (24 * 60 * 60 * 1000));
+      out.push({
+        rel: p.rel,
+        age_days: ageDays,
+        updated: updatedDate.toISOString().slice(0, 10),
+      });
+    }
+  }
+  return out.sort((a, b) => b.age_days - a.age_days);
+}
+
+// Metric 3: duplicate title groups
+//
+// 解決後の title が大文字小文字を無視して同一の page が 2 件以上 → 1 group。
+// system page は除外。表示順は title の locale compare で安定。
+export function detectDuplicateTitles(pages) {
+  const titleMap = new Map();
+  for (const p of pages) {
+    if (isSystemPage(p.rel)) continue;
+    const title = resolveTitle(p.meta, p.rel);
+    const key = title.toLowerCase();
+    if (!titleMap.has(key)) titleMap.set(key, []);
+    titleMap.get(key).push({ title, rel: p.rel });
+  }
+  const groups = [];
+  for (const list of titleMap.values()) {
+    if (list.length >= 2) {
+      groups.push({
+        title: list[0].title,
+        paths: list.map((g) => g.rel).sort(),
+      });
+    }
+  }
+  return groups.sort((a, b) => a.title.localeCompare(b.title));
+}
+
+// Metric 4: hot.md age
+//
+// wiki/hot.md の mtime からの経過秒。file 不在 (= まだ hot cache が初期化されていない)
+// の場合は exists:false を返す。
+export async function getHotMdAge(vault, now = new Date()) {
+  const path = join(vault, 'wiki', 'hot.md');
+  try {
+    const st = await stat(path);
+    const ageSec = Math.floor((now.getTime() - st.mtime.getTime()) / 1000);
+    return {
+      exists: true,
+      mtime_iso: st.mtime.toISOString(),
+      age_seconds: ageSec,
+      age_human: humanDuration(ageSec),
+    };
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      return { exists: false, mtime_iso: null, age_seconds: null, age_human: null };
+    }
+    throw err;
+  }
+}
+
+// session-logs/ を再帰 walk。空 / 不在は空配列を返す。
+async function listSessionLogs(dir) {
+  const out = [];
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch (err) {
+    if (err.code === 'ENOENT') return [];
+    throw err;
+  }
+  for (const ent of entries) {
+    if (ent.name.startsWith('.')) continue;
+    const abs = join(dir, ent.name);
+    if (ent.isDirectory()) {
+      const inner = await listSessionLogs(abs);
+      out.push(...inner);
+    } else if (ent.isFile() && ent.name.endsWith('.md')) {
+      try {
+        const st = await stat(abs);
+        out.push({ abs, mtime: st.mtime });
+      } catch {
+        // ignore unreadable file
+      }
+    }
+  }
+  return out;
+}
+
+// Metric 5: last ingest activity (session-logs/ の最新 mtime + 件数)
+export async function getLastIngestInfo(vault, now = new Date()) {
+  const sessionLogsDir = join(vault, 'session-logs');
+  const logs = await listSessionLogs(sessionLogsDir);
+  if (logs.length === 0) {
+    return { exists: false, log_count: 0, mtime_iso: null, age_seconds: null, age_human: null };
+  }
+  let latestMs = 0;
+  for (const f of logs) {
+    const ms = f.mtime.getTime();
+    if (ms > latestMs) latestMs = ms;
+  }
+  const ageSec = Math.floor((now.getTime() - latestMs) / 1000);
+  return {
+    exists: true,
+    log_count: logs.length,
+    mtime_iso: new Date(latestMs).toISOString(),
+    age_seconds: ageSec,
+    age_human: humanDuration(ageSec),
+  };
+}
+
+// Metric 6: unprocessed session-logs (frontmatter `ingested: false` の件数)
+//
+// session-logger-core.mjs:398 が `ingested: false` を初期値で書き、auto-ingest が成功時に
+// `ingested: true` に書き換える契約。本 metric は cron が遅延していないか / 失敗が貯まって
+// いないかの指標になる (5+ 件で next action を提案)。
+//
+// path 列挙は最大 PATH_SAMPLE_LIMIT 件で truncate (大量 backlog 時の output 肥大防止)。
+const PATH_SAMPLE_LIMIT = 20;
+
+export async function detectUnprocessedLogs(vault) {
+  const sessionLogsDir = join(vault, 'session-logs');
+  const logs = await listSessionLogs(sessionLogsDir);
+  const unprocessed = [];
+  for (const f of logs) {
+    let text;
+    try {
+      text = await readFile(f.abs, 'utf8');
+    } catch {
+      continue;
+    }
+    const { data } = parseFrontmatter(text);
+    // frontmatter.mjs は `false` literal を boolean に変換するので、念のため string 比較も持つ
+    if (data.ingested === false || data.ingested === 'false') {
+      unprocessed.push(relative(sessionLogsDir, f.abs).split(sep).join('/'));
+    }
+  }
+  unprocessed.sort();
+  return {
+    count: unprocessed.length,
+    sample_paths: unprocessed.slice(0, PATH_SAMPLE_LIMIT),
+    sample_truncated: unprocessed.length > PATH_SAMPLE_LIMIT,
+  };
+}
+
+// Next action 提案。数字だけでなく「次に何をすべきか」を出す (codex roadmap acceptance)。
+// 各提案は { reason, action, command? } の形。command は実行可能 1-line を載せる。
+export function buildNextActions(metrics) {
+  const actions = [];
+  if (metrics.orphan.count > 0) {
+    actions.push({
+      reason: `${metrics.orphan.count} orphan pages (no inbound wikilinks)`,
+      action: 'Add wikilinks from related pages, or move to wiki/.archive/ if obsolete',
+      command: 'cat wiki/meta/health.md  # see metrics.orphan.pages for full list',
+    });
+  }
+  if (metrics.stale.count > 0) {
+    actions.push({
+      reason: `${metrics.stale.count} pages older than ${metrics.stale.threshold_days} days`,
+      action: 'Open dashboard "Stale Pages" view and revisit / update / archive',
+      command: 'open wiki/meta/dashboard.md',
+    });
+  }
+  if (metrics.duplicate_title.count > 0) {
+    actions.push({
+      reason: `${metrics.duplicate_title.count} duplicate title groups`,
+      action: 'Merge or rename duplicate pages — see metrics.duplicate_title.groups',
+    });
+  }
+  if (metrics.hot_md_age.exists && metrics.hot_md_age.age_seconds > 7 * 24 * 3600) {
+    actions.push({
+      reason: `wiki/hot.md last updated ${metrics.hot_md_age.age_human} ago`,
+      action: 'Refresh wiki/hot.md, or run a session that triggers PostCompact hook',
+    });
+  }
+  if (metrics.last_ingest.exists && metrics.last_ingest.age_seconds > 24 * 3600) {
+    actions.push({
+      reason: `last session-log activity ${metrics.last_ingest.age_human} ago`,
+      action: 'Verify session-logger hook is active',
+      command: 'bash scripts/doctor.sh',
+    });
+  }
+  if (metrics.unprocessed_logs.count > 5) {
+    actions.push({
+      reason: `${metrics.unprocessed_logs.count} unprocessed session-logs (ingested:false)`,
+      action: 'Run auto-ingest manually, or wait for the next cron tick',
+      command: 'bash scripts/auto-ingest.sh',
+    });
+  }
+  return actions;
+}
+
+// Top-level orchestrator: 全 metric を 1 回の vault 走査で収集。
+//
+// options:
+//   now                : Date — テスト用に "現在時刻" を fix
+//   staleThresholdDays : number — stale 判定閾値 (default 30)
+export async function collectHealthMetrics(vault, options = {}) {
+  if (typeof vault !== 'string' || !vault) {
+    throw new Error('collectHealthMetrics: vault path is required');
+  }
+  const now = options.now instanceof Date ? options.now : new Date();
+  const thresholdDays = Number.isFinite(options.staleThresholdDays)
+    ? options.staleThresholdDays
+    : STALE_THRESHOLD_DAYS;
+
+  const pageRefs = await listWikiPages(vault);
+  const pages = [];
+  for (const ref of pageRefs) {
+    const meta = await readPageMeta(ref.abs);
+    if (meta) pages.push({ rel: ref.rel, meta });
+  }
+
+  const orphans = detectOrphans(pages);
+  const stale = detectStale(pages, { thresholdDays, now });
+  const duplicates = detectDuplicateTitles(pages);
+  const hotAge = await getHotMdAge(vault, now);
+  const lastIngest = await getLastIngestInfo(vault, now);
+  const unprocessed = await detectUnprocessedLogs(vault);
+
+  const metrics = {
+    orphan: { count: orphans.length, pages: orphans },
+    stale: { count: stale.length, threshold_days: thresholdDays, pages: stale },
+    duplicate_title: { count: duplicates.length, groups: duplicates },
+    hot_md_age: hotAge,
+    last_ingest: lastIngest,
+    unprocessed_logs: unprocessed,
+  };
+
+  return {
+    schema_version: HEALTH_SCHEMA_VERSION,
+    generated_at: now.toISOString(),
+    vault_pages_total: pages.length,
+    metrics,
+    next_actions: buildNextActions(metrics),
+  };
+}
+
+// Test 用 internals (test 以外から import しないこと)
+export const _internals = {
+  isSystemPage,
+  resolveTitle,
+  parseUpdatedDate,
+  humanDuration,
+  listWikiPages,
+  listSessionLogs,
+  PATH_SAMPLE_LIMIT,
+};

--- a/mcp/manifest.json
+++ b/mcp/manifest.json
@@ -3,9 +3,9 @@
   "manifest_version": "0.4",
   "name": "kioku-wiki",
   "display_name": "KIOKU Wiki",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Read, search, and write your KIOKU Obsidian Wiki from Claude Desktop or Claude Code.",
-  "long_description": "KIOKU is a personal knowledge base ('second brain') built on top of an Obsidian Vault. This MCP server exposes ten tools (kioku_search, kioku_read, kioku_list, kioku_write_note, kioku_write_wiki, kioku_delete, kioku_ingest_pdf, kioku_ingest_url, kioku_ingest_document, kioku_generate_viz) so that Claude Desktop and Claude Code can browse and update the Wiki without leaving the chat. All operations are local stdio — nothing leaves your machine. See https://github.com/megaphone-tokyo/kioku for the full project.",
+  "long_description": "KIOKU is a personal knowledge base ('second brain') built on top of an Obsidian Vault. This MCP server exposes eleven tools (kioku_search, kioku_read, kioku_list, kioku_write_note, kioku_write_wiki, kioku_delete, kioku_ingest_pdf, kioku_ingest_url, kioku_ingest_document, kioku_generate_viz, kioku_health) so that Claude Desktop and Claude Code can browse and update the Wiki without leaving the chat. All operations are local stdio — nothing leaves your machine. See https://github.com/megaphone-tokyo/kioku for the full project.",
   "author": {
     "name": "megaphone-tokyo",
     "url": "https://github.com/megaphone-tokyo/kioku"
@@ -85,6 +85,10 @@
     {
       "name": "kioku_generate_viz",
       "description": "Generate a visualization from a markdown note (mermaid / PlantUML / graph) and save under wiki/viz/. Used by V-2 Visualizer tool (v0.6.0)."
+    },
+    {
+      "name": "kioku_health",
+      "description": "Compute 6 KIOKU memory health metrics (orphan / stale / duplicate title / hot.md age / last ingest / unprocessed session-logs) and return them as JSON. Read-only — does not modify wiki/. Pair with scripts/generate-health.mjs which writes the same data to wiki/meta/health.md. (Sprint 2 v0.7.4)"
     }
   ]
 }

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kioku-mcp",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kioku-mcp",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "dependencies": {
         "@modelcontextprotocol/sdk": "~1.29.0",
         "@mozilla/readability": "^0.6.0",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kioku-mcp",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "private": true,
   "type": "module",
   "description": "KIOKU local MCP server (Wiki read/list/search/write_note/write_wiki/delete) for Claude Desktop and Claude Code.",

--- a/mcp/server.mjs
+++ b/mcp/server.mjs
@@ -20,6 +20,7 @@ import { INGEST_PDF_TOOL_DEF, handleIngestPdf } from './tools/ingest-pdf.mjs';
 import { INGEST_DOCUMENT_TOOL_DEF, handleIngestDocument } from './tools/ingest-document.mjs';
 import { INGEST_URL_TOOL_DEF, handleIngestUrl } from './tools/ingest-url.mjs';
 import { VISUALIZER_TOOL_DEF, handleGenerateViz } from './tools/visualizer.mjs';
+import { HEALTH_TOOL_DEF, handleHealth } from './tools/health.mjs';
 
 const VAULT = process.env.OBSIDIAN_VAULT;
 if (!VAULT) {
@@ -123,6 +124,7 @@ register(INGEST_PDF_TOOL_DEF, handleIngestPdf);
 register(INGEST_DOCUMENT_TOOL_DEF, handleIngestDocument);
 register(INGEST_URL_TOOL_DEF, handleIngestUrl);
 register(VISUALIZER_TOOL_DEF, handleGenerateViz);
+register(HEALTH_TOOL_DEF, handleHealth);
 
 // 致命エラーでもプロセスを生かしてエラー応答できるようにする
 process.on('uncaughtException', (err) => {

--- a/mcp/tools/health.mjs
+++ b/mcp/tools/health.mjs
@@ -1,0 +1,82 @@
+// kioku_health — KIOKU 記憶品質 metrics の即時取得 (Sprint 2 v0.7.4)
+//
+// codex roadmap §P1 (plan/codex/260430_kioku-product-improvement-roadmap.md L283-315)
+// に基づく 6 core metrics を Claude Desktop / Claude Code / Codex CLI から
+// 直接 query するための MCP tool。scripts/generate-health.mjs が定期生成する
+// wiki/meta/health.md は人間 / Obsidian Bases dashboard 向け、本 tool は
+// LLM agent が即時 read するための JSON 形式。
+//
+// 副作用: なし (read-only、wiki/ session-logs/ を一切 modify しない)
+//
+// 設計方針:
+//   - mcp/lib/health-metrics.mjs に処理委譲、tool layer は param 検証 + JSON 整形のみ
+//   - paths_limit param で大量結果を抑制 (default 30)
+//   - threshold_days param で stale 判定閾値を override 可能 (default 30)
+
+import { z } from 'zod';
+
+import { collectHealthMetrics, STALE_THRESHOLD_DAYS } from '../lib/health-metrics.mjs';
+
+const DEFAULT_PATHS_LIMIT = 30;
+
+export const HEALTH_TOOL_DEF = {
+  name: 'kioku_health',
+  title: 'Get KIOKU wiki health metrics',
+  description:
+    'Compute 6 KIOKU memory health metrics (orphan / stale / duplicate title / hot.md age / last ingest / unprocessed session-logs) and return them as JSON. Read-only — does not modify wiki/. Use to assess "how usable is the wiki right now" rather than "how much was saved". Pair with scripts/generate-health.mjs which writes the same data to wiki/meta/health.md.',
+  inputShape: {
+    threshold_days: z
+      .number()
+      .int()
+      .min(1)
+      .max(3650)
+      .optional()
+      .describe(`Stale page threshold in days (default ${STALE_THRESHOLD_DAYS}).`),
+    paths_limit: z
+      .number()
+      .int()
+      .min(0)
+      .max(500)
+      .optional()
+      .describe(`Cap for orphan/stale page lists in the response (default ${DEFAULT_PATHS_LIMIT}). 0 = no list, only counts.`),
+  },
+};
+
+export async function handleHealth(vault, args = {}) {
+  const thresholdDays = Number.isInteger(args.threshold_days)
+    ? args.threshold_days
+    : STALE_THRESHOLD_DAYS;
+  const pathsLimit = Number.isInteger(args.paths_limit)
+    ? args.paths_limit
+    : DEFAULT_PATHS_LIMIT;
+
+  const report = await collectHealthMetrics(vault, { staleThresholdDays: thresholdDays });
+
+  // path 配列を limit で truncate (response size 抑制、LLM context 節約)
+  const m = report.metrics;
+  const truncated = {
+    orphan_pages: m.orphan.pages.length > pathsLimit,
+    stale_pages: m.stale.pages.length > pathsLimit,
+  };
+  const limitedMetrics = {
+    ...m,
+    orphan: {
+      count: m.orphan.count,
+      pages: m.orphan.pages.slice(0, pathsLimit),
+    },
+    stale: {
+      count: m.stale.count,
+      threshold_days: m.stale.threshold_days,
+      pages: m.stale.pages.slice(0, pathsLimit),
+    },
+  };
+
+  return {
+    schema_version: report.schema_version,
+    generated_at: report.generated_at,
+    vault_pages_total: report.vault_pages_total,
+    metrics: limitedMetrics,
+    next_actions: report.next_actions,
+    truncated,
+  };
+}

--- a/scripts/generate-health.mjs
+++ b/scripts/generate-health.mjs
@@ -1,0 +1,292 @@
+#!/usr/bin/env node
+// generate-health.mjs — KIOKU 記憶品質 dashboard 生成 (Sprint 2 v0.7.4)
+//
+// codex roadmap §P1 (plan/codex/260430_kioku-product-improvement-roadmap.md L283-315)
+// 「KIOKU の価値を『どれだけ保存したか』ではなく『どれだけ使える記憶になっているか』
+//  で測る」を実装。
+//
+// 6 core metrics (orphan / stale / duplicate / hot.md age / last ingest /
+// unprocessed session-logs) を計算し wiki/meta/health.md (Markdown + JSON) として書く。
+//
+// 環境変数:
+//   OBSIDIAN_VAULT  Vault ルート (未設定時は $HOME/claude-brain/main-claude-brain)
+//   KIOKU_HEALTH_OUTPUT  output 相対パス (default: wiki/meta/health.md)
+//
+// 使用例:
+//   node scripts/generate-health.mjs           # health.md 生成
+//   node scripts/generate-health.mjs --json    # stdout に JSON 出力 (file 書かない)
+//   node scripts/generate-health.mjs --dry-run # file 書かず human summary のみ
+//
+// Exit code:
+//   0 = 正常終了
+//   1 = vault 不在 / write 失敗
+//
+// 設計方針:
+//   - 読み取り専用 (wiki/ session-logs/ は touch しない、出力先は wiki/meta/health.md のみ)
+//   - 既存 dashboard.base / auto-lint と非干渉 (出力先別 path、責務分離)
+//   - atomic write (temp + rename) で half-write 防止
+
+import { homedir } from 'node:os';
+import { mkdir, rename, writeFile, stat } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { randomBytes } from 'node:crypto';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { collectHealthMetrics } from '../mcp/lib/health-metrics.mjs';
+
+const DEFAULT_OUTPUT_REL = 'wiki/meta/health.md';
+
+function parseArgs(argv) {
+  const out = { json: false, dryRun: false };
+  for (const a of argv) {
+    if (a === '--json') out.json = true;
+    else if (a === '--dry-run') out.dryRun = true;
+    else if (a === '-h' || a === '--help') {
+      console.log(usageText());
+      process.exit(0);
+    } else {
+      console.error(`generate-health: unknown arg: ${a}`);
+      process.exit(2);
+    }
+  }
+  return out;
+}
+
+function usageText() {
+  return [
+    'Usage: node scripts/generate-health.mjs [--json|--dry-run]',
+    '',
+    'Computes 6 KIOKU memory health metrics and writes wiki/meta/health.md.',
+    '',
+    '  (no arg)   Generate wiki/meta/health.md (Markdown + JSON appendix)',
+    '  --json     Print metrics as JSON to stdout, do not write file',
+    '  --dry-run  Print human summary to stdout, do not write file',
+  ].join('\n');
+}
+
+function resolveVault() {
+  return process.env.OBSIDIAN_VAULT || join(homedir(), 'claude-brain', 'main-claude-brain');
+}
+
+// Markdown report renderer
+export function renderMarkdown(report) {
+  const m = report.metrics;
+  const lines = [];
+  lines.push('---');
+  lines.push('type: health-report');
+  lines.push('title: KIOKU Wiki Health');
+  lines.push(`generated_at: ${report.generated_at}`);
+  lines.push(`schema_version: ${report.schema_version}`);
+  lines.push(`vault_pages_total: ${report.vault_pages_total}`);
+  lines.push('---');
+  lines.push('');
+  lines.push('# KIOKU Wiki Health');
+  lines.push('');
+  lines.push(`> Generated at ${report.generated_at} — ${report.vault_pages_total} wiki pages total`);
+  lines.push('>');
+  lines.push('> This file is **auto-generated** by `scripts/generate-health.mjs`.');
+  lines.push('> Do not edit by hand — changes will be overwritten on next run.');
+  lines.push('');
+  lines.push('## Metrics');
+  lines.push('');
+  lines.push('| Metric | Value | Status |');
+  lines.push('|---|---|---|');
+  lines.push(`| Orphan pages | ${m.orphan.count} | ${statusBadge(m.orphan.count, 0)} |`);
+  lines.push(`| Stale pages (>${m.stale.threshold_days} days) | ${m.stale.count} | ${statusBadge(m.stale.count, 0)} |`);
+  lines.push(`| Duplicate title groups | ${m.duplicate_title.count} | ${statusBadge(m.duplicate_title.count, 0)} |`);
+  lines.push(`| hot.md age | ${m.hot_md_age.exists ? m.hot_md_age.age_human : '(missing)'} | ${hotMdStatus(m.hot_md_age)} |`);
+  lines.push(`| Last session-log activity | ${m.last_ingest.exists ? m.last_ingest.age_human + ` (${m.last_ingest.log_count} logs)` : '(empty)'} | ${ingestStatus(m.last_ingest)} |`);
+  lines.push(`| Unprocessed session-logs (ingested:false) | ${m.unprocessed_logs.count} | ${unprocessedStatus(m.unprocessed_logs)} |`);
+  lines.push('');
+
+  if (m.orphan.count > 0) {
+    lines.push(`## Orphan pages (${m.orphan.count})`);
+    lines.push('');
+    lines.push('Pages with no inbound wikilinks. Add a link from a related page or move to `wiki/.archive/` if obsolete.');
+    lines.push('');
+    for (const p of m.orphan.pages.slice(0, 30)) {
+      lines.push(`- [[${p.replace(/\.md$/, '')}]]`);
+    }
+    if (m.orphan.pages.length > 30) {
+      lines.push(`- ... (${m.orphan.pages.length - 30} more)`);
+    }
+    lines.push('');
+  }
+
+  if (m.stale.count > 0) {
+    lines.push(`## Stale pages (${m.stale.count}, >${m.stale.threshold_days} days)`);
+    lines.push('');
+    lines.push('| Page | Updated | Age (days) |');
+    lines.push('|---|---|---|');
+    for (const s of m.stale.pages.slice(0, 30)) {
+      lines.push(`| [[${s.rel.replace(/\.md$/, '')}]] | ${s.updated} | ${s.age_days} |`);
+    }
+    if (m.stale.pages.length > 30) {
+      lines.push(`| ... | ... | (+${m.stale.pages.length - 30} more) |`);
+    }
+    lines.push('');
+  }
+
+  if (m.duplicate_title.count > 0) {
+    lines.push(`## Duplicate title groups (${m.duplicate_title.count})`);
+    lines.push('');
+    for (const g of m.duplicate_title.groups) {
+      lines.push(`- **${g.title}**`);
+      for (const p of g.paths) {
+        lines.push(`  - \`${p}\``);
+      }
+    }
+    lines.push('');
+  }
+
+  if (m.unprocessed_logs.count > 0) {
+    lines.push(`## Unprocessed session-logs (${m.unprocessed_logs.count})`);
+    lines.push('');
+    lines.push('Session-logs with `ingested: false`. Auto-ingest cron will process these on the next tick.');
+    lines.push('');
+    for (const p of m.unprocessed_logs.sample_paths) {
+      lines.push(`- \`session-logs/${p}\``);
+    }
+    if (m.unprocessed_logs.sample_truncated) {
+      lines.push(`- ... (${m.unprocessed_logs.count - m.unprocessed_logs.sample_paths.length} more not shown)`);
+    }
+    lines.push('');
+  }
+
+  if (report.next_actions.length > 0) {
+    lines.push('## Next actions');
+    lines.push('');
+    for (const a of report.next_actions) {
+      lines.push(`- **${a.reason}**`);
+      lines.push(`  - ${a.action}`);
+      if (a.command) {
+        lines.push('  - Command: `' + a.command + '`');
+      }
+    }
+    lines.push('');
+  } else {
+    lines.push('## Next actions');
+    lines.push('');
+    lines.push('No actions needed — wiki health looks good. ✓');
+    lines.push('');
+  }
+
+  lines.push('## Raw metrics (JSON)');
+  lines.push('');
+  lines.push('```json');
+  lines.push(JSON.stringify(report, null, 2));
+  lines.push('```');
+  lines.push('');
+  return lines.join('\n');
+}
+
+function statusBadge(count, healthyValue) {
+  return count === healthyValue ? 'OK' : `WARN (${count})`;
+}
+
+function hotMdStatus(info) {
+  if (!info.exists) return 'INFO (not initialized)';
+  if (info.age_seconds > 7 * 24 * 3600) return `WARN (${info.age_human})`;
+  return 'OK';
+}
+
+function ingestStatus(info) {
+  if (!info.exists) return 'INFO (no logs yet)';
+  if (info.age_seconds > 24 * 3600) return `WARN (${info.age_human} since last log)`;
+  return 'OK';
+}
+
+function unprocessedStatus(info) {
+  if (info.count === 0) return 'OK';
+  if (info.count <= 5) return `INFO (${info.count})`;
+  return `WARN (${info.count})`;
+}
+
+function renderHumanSummary(report) {
+  const m = report.metrics;
+  const lines = [];
+  lines.push(`KIOKU Wiki Health — ${report.generated_at}`);
+  lines.push(`  Pages total: ${report.vault_pages_total}`);
+  lines.push(`  Orphan: ${m.orphan.count}`);
+  lines.push(`  Stale (>${m.stale.threshold_days}d): ${m.stale.count}`);
+  lines.push(`  Duplicate titles: ${m.duplicate_title.count}`);
+  lines.push(`  hot.md age: ${m.hot_md_age.exists ? m.hot_md_age.age_human : '(missing)'}`);
+  lines.push(`  Last ingest: ${m.last_ingest.exists ? m.last_ingest.age_human + ' ago (' + m.last_ingest.log_count + ' logs)' : '(empty)'}`);
+  lines.push(`  Unprocessed logs: ${m.unprocessed_logs.count}`);
+  if (report.next_actions.length > 0) {
+    lines.push('');
+    lines.push('Next actions:');
+    for (const a of report.next_actions) {
+      lines.push(`  - ${a.reason}`);
+      lines.push(`    → ${a.action}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+async function atomicWrite(absPath, content) {
+  await mkdir(dirname(absPath), { recursive: true });
+  const tmp = `${absPath}.tmp-${randomBytes(6).toString('hex')}`;
+  try {
+    await writeFile(tmp, content, 'utf8');
+    await rename(tmp, absPath);
+  } catch (err) {
+    try {
+      const { unlink } = await import('node:fs/promises');
+      await unlink(tmp);
+    } catch {
+      /* ignore */
+    }
+    throw err;
+  }
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv);
+  const vault = resolveVault();
+
+  let st;
+  try {
+    st = await stat(vault);
+  } catch {
+    console.error(`generate-health: OBSIDIAN_VAULT not found: ${vault}`);
+    process.exit(1);
+  }
+  if (!st.isDirectory()) {
+    console.error(`generate-health: OBSIDIAN_VAULT is not a directory: ${vault}`);
+    process.exit(1);
+  }
+
+  const report = await collectHealthMetrics(vault);
+
+  if (args.json) {
+    process.stdout.write(JSON.stringify(report, null, 2) + '\n');
+    return;
+  }
+
+  if (args.dryRun) {
+    process.stdout.write(renderHumanSummary(report) + '\n');
+    return;
+  }
+
+  const outputRel = process.env.KIOKU_HEALTH_OUTPUT || DEFAULT_OUTPUT_REL;
+  const absOutput = join(vault, outputRel);
+  const md = renderMarkdown(report);
+  await atomicWrite(absOutput, md);
+  process.stdout.write(`generate-health: wrote ${absOutput} (${report.vault_pages_total} pages, ${report.next_actions.length} actions)\n`);
+}
+
+// ESM entry gate (LEARN#14): test 等で import されたときは main() を実行しない
+function isEntry() {
+  return process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+}
+
+if (isEntry()) {
+  main().catch((err) => {
+    console.error(`generate-health: ${err.message}`);
+    process.exit(1);
+  });
+}
+
+// Test 用 export (test 以外から import しないこと)
+export const _internals = { renderMarkdown, renderHumanSummary, parseArgs, resolveVault };

--- a/skills/kioku-delegation-handoff/SKILL.md
+++ b/skills/kioku-delegation-handoff/SKILL.md
@@ -1,0 +1,298 @@
+---
+name: kioku-delegation-handoff
+description: "PM session が他 Claude / codex CLI session に task を委譲する handoff doc を `tools/claude-brain/handoff/YYMMDDNN_<topic>-delegation.md` として生成する skill。N=6 cycle (PR #70/#74/#84/#89/#90/#96) で組織知化された delegation pattern を再利用、LEARN#12 Rule 1 (branch+PR mandatory) + LEARN#10 双方向 precheck + LEARN#5/#6 test requirements + 完了報告 N 点セット を boilerplate として組み込み、scope-specific spec のみ user 入力で済む。`/kioku-delegation-handoff <scope-topic>` で起動、optional `--to=制作|codex|マーケ` で受け手 session type を指定。"
+---
+
+# kioku-delegation-handoff
+
+PM session が他 Claude session (制作 Claude / codex CLI / マーケ Claude) に impl / strategic / marketing task を委譲する handoff doc 作成 を skill 化。N=6 delegation cycles で固化した template + LEARN convention を 1 commands で展開、scope-specific 部分のみ手動入力で済ませる。
+
+## いつ使うか
+
+- **制作 Claude session に impl task を委譲**したい時 (bugfix / new feature / refactor / test infra 等)
+- **codex CLI session に strategic doc / 探索系 task を委譲**したい時 (roadmap 執筆 / 競合分析 / scope 検討)
+- **マーケ Claude session に article / publish task を委譲**したい時 (release narrative / SNS post / community comm)
+
+**使わない場面**:
+
+- PM session 直接 impl が経済的な scope (LEARN#7 「小 task < 4h、1-2 file」zone) → handoff overhead が impl より大きく ROI 逆転
+- 既に main に存在する task (LEARN#10 逆方向: 必ず `git log -10 origin/main --oneline` で先 verify)
+- main hygiene 違反 state (LEARN#12 Rule 2: `git log --oneline origin/main..main` が non-empty) → 先に local commit を retroactive PR 化
+
+## 前提 (handoff 作成前 mandatory)
+
+- **LEARN#12 Rule 2 main hygiene clean**: `git log --oneline origin/main..main` が empty
+- **LEARN#10 逆方向 precheck pass**: 委譲予定 task が main に既存しないことを `git log -10 origin/main --oneline` で verify
+- **target session type が確定**: 制作 Claude / codex / マーケ のどれか
+- **PM 側 LEARN#10 precheck 完了**: 委譲する spec の対象 file / function / line が現コードで verify 済 (handoff 内の "PM 側 LEARN#10 precheck 結果" table に記載するため)
+
+## 起動
+
+```
+/kioku-delegation-handoff <scope-topic>           # default --to=制作 Claude
+/kioku-delegation-handoff <scope-topic> --to=制作
+/kioku-delegation-handoff <scope-topic> --to=codex
+/kioku-delegation-handoff <scope-topic> --to=マーケ
+```
+
+例:
+```
+/kioku-delegation-handoff v0-7-3-readme-mode-based-setup
+/kioku-delegation-handoff v0-8-phase-d-visualizer-pivot-decision --to=codex
+/kioku-delegation-handoff v0-7-2-marketing-articles --to=マーケ
+```
+
+## 出力 path
+
+```
+tools/claude-brain/handoff/YYMMDDNN_<scope-topic>-delegation.md
+  YY: 年下 2 桁 (例: 26)
+  MM: 月 2 桁
+  DD: 日 2 桁
+  NN: 同日 N 件目の連番 (01, 02, ...)
+```
+
+例: `26050702_v0-7-3-readme-mode-based-setup-delegation.md` (= 2026-05-07 の 2 件目)
+
+## handoff doc 構造 (auto-generated boilerplate)
+
+以下の section を template として展開、`{{scope-specific}}` placeholder は user 入力で埋める:
+
+```markdown
+---
+title: {{scope-topic}} — {{target-session-type}} session 委譲 handoff
+date: YYYY-MM-DD
+author: PM Claude (RYU 委譲指示、{{strategic-origin-doc}} を origin とする場合)
+to: {{target-session-type}} session
+status: pending
+related:
+  - {{strategic-origin-doc-path}} (例: plan/codex/260430_kioku-product-improvement-roadmap.md §P0)
+  - {{prior-delegation-handoffs}} (例: 直前 PR #84 の handoff、N=3)
+  - .claude/rules/workflow.md LEARN#5/#6/#10/#11/#12 (workflow 規約)
+---
+
+# Context
+
+## 2-session origin (or 3-session for codex strategic → PM tactical → executor)
+
+{{何が origin で、なぜ本 task を委譲するか}}
+
+## 当該 release / feature との関係
+
+{{v0.X.Y release との関係、Sprint N との関係 等}}
+
+## LEARN#12 codification N={{N}}
+
+- N=1: §33-38 (PR #70、4/28)、5 件 hardening
+- N=2: §41 (PR #74、4/30)、frontmatter agent field
+- N=3: doctor MVP (PR #84、4/30)、Sprint 1 1 番目
+- N=4: drift test (PR #89、5/7)、Sprint 1 2 番目
+- N=5: URL test 安定化 (PR #90、5/7)、Sprint 1 3 番目
+- N=6: README mode-based (PR #96、5/7)、Sprint 1 完走 marker
+- **N={{N}}: 本 PR ({{scope-topic}})** ← 今ここ
+
+---
+
+# PM 側 LEARN#10 precheck 結果 (YYYY-MM-DD、verified)
+
+PM session で current state を grep verify。**全 N 確認項目 pass**:
+
+| # | 確認項目 | 結果 |
+|---|---|---|
+| 1 | {{strategic spec}} が存在 | ✅ verified |
+| 2 | LEARN#10 逆方向: 関連 commit が main に存在しないか | ✅ `git log -10 origin/main \| grep -iE "{{keyword}}"` 結果なし |
+| 3 | LEARN#12 Rule 2: `git log --oneline origin/main..main` empty | ✅ clean |
+| 4 | target file の不在 / 既存性 | ✅ {{verify result}} |
+| ... | {{additional checks}} | ✅ |
+
+---
+
+# Scope: {{scope-topic}} (1 item、目安 {{X-Y}}h)
+
+## {{strategic spec}} (原典の要点を embed)
+
+{{spec content from origin doc}}
+
+### Acceptance criteria
+
+{{from origin doc or PM addition}}
+
+### 採用方針 (mandatory)
+
+- **MVP scope**: {{何を MVP として land、stretch を別 PR にするか}}
+- **Read-only / 新規依存 / OS 互換** 等の制約
+- **既存 X への影響最小化**
+
+### file 構成
+
+```
+新規:
+  {{new files}}
+
+既存修正:
+  {{modified files}}
+
+context 更新:
+  {{context updates}}
+```
+
+---
+
+# Workflow requirements (LEARN#12 Rule 1、mandatory)
+
+- **Branch**: `feature/{{scope-topic}}` で作業開始、`main` への直 commit **厳禁**
+- **PR**: 完了時に `main` 向け PR 作成、body に以下を含める:
+  - 実装 summary
+  - **test result** (新規 + 既存 regression、件数明記)
+  - **LEARN#5 cross-suite grep 結果**
+  - **LEARN#6 final branch-wide integration review 結果**
+  - {{task-specific verify items}}
+- **完了報告の形式**: 「PR URL + test result + {{additional sample/verify items}} + merge 待ち or autonomous merge 可」の **{{N}} 点セット**
+
+違反時 escalation: 完了報告時に branch 外 commit が判明したら PM session が retroactive PR 化を試み、不可能なら LEARN#12 Rule 2 参照。
+
+---
+
+# 着手前 LEARN#10 precheck ({{target-session-type}} 側 mandatory)
+
+PM 側 precheck は YYYY-MM-DD の状態で実施。本 handoff 着手前に以下を再 verify:
+
+```bash
+# 1. {{strategic spec}} が現存
+grep -nE "{{spec marker}}" {{strategic-origin-doc-path}}
+
+# 2. target file の不在 / 既存性 (drift で既に impl 開始されていないか)
+ls {{target-files}} 2>&1
+
+# 3. LEARN#10 逆方向: main にも該当 commit が無いか
+git log -10 origin/main --oneline | grep -iE "{{keyword}}"
+
+# 4. {{additional precheck commands}}
+```
+
+discrepancy 発見時 → PM session に escalate、本 handoff の更新依頼。**着手前停止が原則**。
+
+---
+
+# Test requirements
+
+## per-item unit test (新規)
+
+新規 test ID **{{TEST-PREFIX}}-*** を `{{test-file-path}}` に追加:
+
+- **{{TEST-PREFIX}}-1**: {{scenario 1}}
+- **{{TEST-PREFIX}}-2**: {{scenario 2}}
+- ...
+
+## 全 suite regression (LEARN#5、Phase 最後の必須 task)
+
+```bash
+node --test tools/claude-brain/tests/hooks/
+node --test tools/claude-brain/tests/mcp/
+node --test tools/claude-brain/tests/metadata-drift.test.mjs
+bash tools/claude-brain/tests/setup-vault.test.sh
+bash tools/claude-brain/tests/install-hooks.test.sh
+bash tools/claude-brain/tests/install-hooks-gemini.test.sh
+bash tools/claude-brain/tests/install-hooks-codex.test.sh
+bash tools/claude-brain/tests/auto-ingest.test.sh
+bash tools/claude-brain/tests/auto-lint.test.sh
+bash tools/claude-brain/tests/scan-secrets.test.sh
+bash tools/claude-brain/tests/doctor.test.sh
+bash tools/claude-brain/tests/build-mcpb.test.sh
+bash tools/claude-brain/tests/sync-to-app.test.sh
+bash tools/claude-brain/tests/post-release-sync.test.sh
+bash tools/claude-brain/tests/run-quick-suite.sh
+```
+
+期待値: 既存全 test pass + 新規 {{TEST-PREFIX}}-* pass。
+
+## LEARN#6 final branch-wide integration review
+
+PR 作成後、自分で以下を検査し PR body に "branch-wide review pass" を記載:
+
+- {{cross-boundary check 1}}
+- {{cross-boundary check 2}}
+
+---
+
+# 完了後 PM 側で実施する事 ({{target-session-type}} は触らない)
+
+- handoff 受け取り後、PR review (LEARN#10 trust-but-verify 独立 grep + 実機 verify)
+- merge OK なら本 handoff file を **削除** (CLAUDE.md handoff 運用ルール)
+- {{related cleanup, release 判定 等}}
+
+---
+
+# 参考 ({{target-session-type}} が参照する正典)
+
+- {{strategic-origin-doc-path}} (本 task 正典 spec)
+- {{related code files / scripts}}
+- `.claude/rules/code-style.md` (Bash: `set -euo pipefail` / Node.js: ES Module / camelCase)
+- `.claude/rules/workflow.md` LEARN#5/#6/#10/#11/#12 (workflow 規約)
+- 直前 PR #{{prior}} ({{prior-scope}}、N={{N-1}} delegation の好例)
+
+---
+
+# Metadata
+
+- **委譲開始**: YYYY-MM-DD PM session の RYU 指示
+- **想定工数**: {{X-Y}}h
+- **target release**: v0.X.Y ({{Sprint N}} {{position}} 番目の PR)
+- **delegation pattern**: LEARN#12 codify 後の正規 pattern、PR #{{prior PRs}} で N={{N-1}} 完了済、本 PR で N={{N}} 強化
+- **品質優先方針**: RYU 指示「時間かかってもいいから安全でクオリティが高い方」、PM-impl の single point of failure を避け {{target-session}} impl + PM trust-but-verify review の 2 段品質保証
+- **2-session origin** (or 3-session): {{describe session role separation}}
+```
+
+## scope-specific 入力 (skill 起動時に対話 / pre-filled)
+
+skill 実行時は以下を user に確認 (or 引数 / context から推定):
+
+| 入力 | 説明 | 例 |
+|---|---|---|
+| `<scope-topic>` | handoff filename + branch name に使う short topic | `v0-7-3-readme-mode-based-setup` |
+| `--to=` | 受け手 session type | `制作` (default) / `codex` / `マーケ` |
+| **strategic origin doc** | 本 task の出発点となる spec doc path | `plan/codex/260430_*.md §P1` |
+| **N counter** | LEARN#12 codification の何 cycle 目か | `N=7` (open-issues や PR history から判定) |
+| **MVP scope** | 1-2h で land する最小単位 | "EN+JA README + doctor mode detection" |
+| **stretch scope** | MVP land 後 別 PR で OK な拡張 | "8 言語 README" |
+| **完了報告 N 点セット** | PR URL + test + その他 evidence の点数 | "5 点セット (PR URL + test + 出力 sample + diff summary + merge OK)" |
+| **想定工数** | "1-2h" 等 | LEARN#7 zone 判定の根拠 |
+
+## 動作
+
+1. **入力 prompt**: 上記 8 項目を user に inline 確認 (省略可は default 適用)
+2. **filename auto-generate**: `YYMMDDNN_<scope-topic>-delegation.md`
+3. **template 展開**: 上記 boilerplate に user 入力を merge
+4. **save**: `tools/claude-brain/handoff/<filename>` に書き込み
+5. **next action 提示**:
+   ```
+   handoff doc 作成完了: tools/claude-brain/handoff/{{filename}}
+
+   次:
+   1. branch + PR + main hygiene check + merge
+   2. RYU が {{target-session}} session を spawn して以下 prompt 投入:
+      "tools/claude-brain/handoff/{{filename}} を読んで実装してください"
+   ```
+
+## 過去 handoff 例 (template fill 参考)
+
+PR #84 doctor MVP (N=3): scope spec L147-200 from codex roadmap、target files = `scripts/doctor.sh` + `tests/doctor.test.sh` + `context/26-doctor.md`、TEST-PREFIX = `BLUE-DOCTOR-`、想定工数 4-6h、4 点セット完了報告
+
+PR #89 metadata drift test (N=4): scope = §44 incident codification、target = `tests/metadata-drift.test.mjs` + `context/27-metadata-drift.md`、TEST-PREFIX = `BLUE-DRIFT-`、想定工数 4-6h、4 点セット
+
+PR #90 URL test 安定化 (N=5): scope = quick/full suite 分離、target = 10 既存 url test file + `tests/run-{quick,full}-suite.sh`、想定工数 3-5h、5 点セット (timeout 発火 verify 含む)
+
+PR #96 README mode-based (N=6): scope = Mode A/B/C onboarding + doctor mode detection、target = README.md + README.ja.md + `scripts/doctor.sh` + `tests/doctor.test.sh`、TEST-PREFIX = `BLUE-DOCTOR-MODE-`、想定工数 1-2h、5 点セット
+
+## 関連 (本 skill が参照する正典)
+
+- `.claude/rules/workflow.md` LEARN#5 (cross-suite test) / LEARN#6 (cross-boundary integration review) / LEARN#10 (双方向 PM precheck) / LEARN#11 (release cycle sync boundary) / LEARN#12 (delegation = branch + PR mandatory)
+- `.claude/rules/code-style.md` (bash + Node.js style 規約)
+- `tools/claude-brain/skills/marketing-release-handoff/SKILL.md` (precedent skill、release-time handoff 自動生成)
+- 過去 6 delegation handoff (本 skill の boilerplate 抽出 source、git log で復元可能)
+
+## メタ運用
+
+- **新 N cycle で本 skill 利用** = N counter / Metadata 更新
+- **8 cycle 以上経過時に本 skill 自体を refactor**: 共通要素の更なる抽出 / scope-specific 入力の自動推論強化
+- **session type 別の specialized variant**: 制作 Claude / codex / マーケ で handoff 内容が大きく異なる場合は別 skill 化検討 (現状は 1 skill で 3 type cover、N=6 cycle 中は 制作 N=6 / codex N=0 / マーケ N=1 で 制作 偏重、要 observe)

--- a/templates/wiki/meta/dashboard.base
+++ b/templates/wiki/meta/dashboard.base
@@ -109,3 +109,15 @@ views:
     order:
       - formula.age_days
       - file.name
+
+  - type: table
+    name: "Wiki Health (記憶品質 dashboard、Sprint 2 v0.7.4)"
+    limit: 5
+    filters:
+      and:
+        - 'file.name == "health"'
+        - file.inFolder("wiki/meta")
+    order:
+      - file.name
+      - updated
+      - formula.age_days

--- a/tests/health-metrics.test.mjs
+++ b/tests/health-metrics.test.mjs
@@ -1,0 +1,423 @@
+// tests/health-metrics.test.mjs — Sprint 2 v0.7.4 記憶品質 dashboard
+//
+// Targets: mcp/lib/health-metrics.mjs の 6 core metrics + next action 提案。
+// Test prefixes (BLUE-HEALTH-* namespace, per LEARN#8a no collision verified):
+//   BLUE-HEALTH-ORPHAN-1     : orphan page あり → count = 1
+//   BLUE-HEALTH-ORPHAN-2     : 全 page リンク済 → count = 0
+//   BLUE-HEALTH-ORPHAN-3     : system page (index/hot/meta/summaries) は除外
+//   BLUE-HEALTH-STALE-1      : updated: 30 日以上前 → stale count = 1
+//   BLUE-HEALTH-STALE-2      : 全 page 30 日以内 → stale count = 0
+//   BLUE-HEALTH-STALE-3      : updated: 不在時は file mtime で判定
+//   BLUE-HEALTH-DUPLICATE-1  : 同 title 2 page → duplicate count = 1
+//   BLUE-HEALTH-DUPLICATE-2  : title source priority (frontmatter > H1 > basename)
+//   BLUE-HEALTH-HOT-MD-AGE   : hot.md mtime → 経過秒
+//   BLUE-HEALTH-HOT-MD-MISSING : hot.md 不在 → exists:false
+//   BLUE-HEALTH-LAST-INGEST  : session-logs/ 最新 mtime + 件数
+//   BLUE-HEALTH-LAST-INGEST-EMPTY : session-logs/ 空 → exists:false
+//   BLUE-HEALTH-UNPROCESSED-1 : ingested:false 件数
+//   BLUE-HEALTH-NEXT-ACTION-1 : orphan ありなら action 提案
+//   BLUE-HEALTH-COLLECT-ALL  : empty vault でも crash せず全 metric = 0
+//   BLUE-HEALTH-COLLECT-INTEGRATED : 複数 metric が同時発火する fixture で整合
+//
+// 設計方針: mktemp Vault に fixture を組み立てて collectHealthMetrics の出力を assert。
+// 実 Vault には絶対 touch しない (.claude/rules/testing.md)。
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, mkdir, writeFile, utimes } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  collectHealthMetrics,
+  detectOrphans,
+  detectStale,
+  detectDuplicateTitles,
+  getHotMdAge,
+  getLastIngestInfo,
+  detectUnprocessedLogs,
+  buildNextActions,
+  STALE_THRESHOLD_DAYS,
+  HEALTH_SCHEMA_VERSION,
+} from '../mcp/lib/health-metrics.mjs';
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+async function makeVault() {
+  const root = await mkdtemp(join(tmpdir(), 'kioku-health-test-'));
+  await mkdir(join(root, 'wiki'), { recursive: true });
+  await mkdir(join(root, 'session-logs'), { recursive: true });
+  return root;
+}
+
+async function writeWikiPage(root, rel, frontmatter, body) {
+  const abs = join(root, 'wiki', rel);
+  const dir = abs.substring(0, abs.lastIndexOf('/'));
+  await mkdir(dir, { recursive: true });
+  const fmLines = Object.entries(frontmatter).map(([k, v]) => `${k}: ${v}`);
+  const text = `---\n${fmLines.join('\n')}\n---\n\n${body}\n`;
+  await writeFile(abs, text, 'utf8');
+  return abs;
+}
+
+async function writeSessionLog(root, name, frontmatter, body = '') {
+  const abs = join(root, 'session-logs', name);
+  const fmLines = Object.entries(frontmatter).map(([k, v]) => `${k}: ${v}`);
+  const text = `---\n${fmLines.join('\n')}\n---\n\n${body}\n`;
+  await writeFile(abs, text, 'utf8');
+  return abs;
+}
+
+async function setMtime(abs, date) {
+  await utimes(abs, date, date);
+}
+
+// listWikiPages を直接呼ぶ helper (lib 内 private なので readPageMeta 相当を再現)
+import { readFile, stat } from 'node:fs/promises';
+import { parseFrontmatter } from '../mcp/lib/frontmatter.mjs';
+import { findWikilinks } from '../mcp/lib/wikilinks.mjs';
+import { _internals as healthInternals } from '../mcp/lib/health-metrics.mjs';
+
+async function loadPagesForOrphanTest(root) {
+  const refs = await healthInternals.listWikiPages(root);
+  const pages = [];
+  for (const ref of refs) {
+    const text = await readFile(ref.abs, 'utf8');
+    const st = await stat(ref.abs);
+    const { data, body } = parseFrontmatter(text);
+    pages.push({
+      rel: ref.rel,
+      meta: {
+        abs: ref.abs,
+        text,
+        body,
+        frontmatter: data,
+        mtime: st.mtime,
+        wikilinks: findWikilinks(text),
+      },
+    });
+  }
+  return pages;
+}
+
+// ---------------------------------------------------------------------------
+// Orphan detection
+// ---------------------------------------------------------------------------
+
+describe('BLUE-HEALTH-ORPHAN: orphan page detection', () => {
+  test('BLUE-HEALTH-ORPHAN-1: 1 orphan page → count = 1', async () => {
+    const root = await makeVault();
+    try {
+      // index.md (system page) は除外、concepts/jwt は orphan、
+      // concepts/oauth は jwt にリンクしているが自身も誰からもリンクされない → orphan
+      // → expected: 2 件 (jwt / oauth)
+      await writeWikiPage(root, 'index.md', { type: 'index' }, '# Index');
+      await writeWikiPage(root, 'concepts/jwt.md', { type: 'concept', title: 'JWT' }, '# JWT');
+      await writeWikiPage(root, 'concepts/oauth.md', { type: 'concept', title: 'OAuth' }, '[[jwt]]');
+      const pages = await loadPagesForOrphanTest(root);
+      const orphans = detectOrphans(pages);
+      // jwt is linked from oauth → not orphan; oauth has no inbound → orphan
+      assert.deepEqual(orphans, ['concepts/oauth.md']);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('BLUE-HEALTH-ORPHAN-2: all pages linked → count = 0', async () => {
+    const root = await makeVault();
+    try {
+      await writeWikiPage(root, 'index.md', { type: 'index' }, '[[a]]\n[[b]]');
+      await writeWikiPage(root, 'a.md', { type: 'concept' }, '[[b]]');
+      await writeWikiPage(root, 'b.md', { type: 'concept' }, '[[a]]');
+      const pages = await loadPagesForOrphanTest(root);
+      const orphans = detectOrphans(pages);
+      assert.deepEqual(orphans, []);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('BLUE-HEALTH-ORPHAN-3: system pages (index/log/hot/meta/summaries/viz) excluded', async () => {
+    const root = await makeVault();
+    try {
+      // 全て system page or system folder — orphan であっても 0 件
+      await writeWikiPage(root, 'index.md', { type: 'index' }, '');
+      await writeWikiPage(root, 'log.md', { type: 'log' }, '');
+      await writeWikiPage(root, 'hot.md', { type: 'hot-cache' }, '');
+      await writeWikiPage(root, 'meta/dashboard.md', { type: 'dashboard' }, '');
+      await writeWikiPage(root, 'summaries/foo.md', { type: 'summary' }, '');
+      await writeWikiPage(root, 'viz/x.md', { type: 'viz' }, '');
+      const pages = await loadPagesForOrphanTest(root);
+      const orphans = detectOrphans(pages);
+      assert.deepEqual(orphans, []);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Stale detection
+// ---------------------------------------------------------------------------
+
+describe('BLUE-HEALTH-STALE: stale page detection', () => {
+  test('BLUE-HEALTH-STALE-1: page updated 31 days ago → stale count = 1', async () => {
+    const root = await makeVault();
+    try {
+      const now = new Date('2026-05-07T12:00:00Z');
+      await writeWikiPage(root, 'a.md', { type: 'concept', updated: '2026-04-05' }, '# A');
+      await writeWikiPage(root, 'b.md', { type: 'concept', updated: '2026-05-01' }, '# B');
+      const pages = await loadPagesForOrphanTest(root);
+      const stale = detectStale(pages, { thresholdDays: 30, now });
+      assert.equal(stale.length, 1);
+      assert.equal(stale[0].rel, 'a.md');
+      assert.equal(stale[0].age_days, 32);
+      assert.equal(stale[0].updated, '2026-04-05');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('BLUE-HEALTH-STALE-2: all pages within 30 days → stale count = 0', async () => {
+    const root = await makeVault();
+    try {
+      const now = new Date('2026-05-07T12:00:00Z');
+      await writeWikiPage(root, 'a.md', { type: 'concept', updated: '2026-04-20' }, '# A');
+      await writeWikiPage(root, 'b.md', { type: 'concept', updated: '2026-05-01' }, '# B');
+      const pages = await loadPagesForOrphanTest(root);
+      const stale = detectStale(pages, { thresholdDays: 30, now });
+      assert.deepEqual(stale, []);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('BLUE-HEALTH-STALE-3: no updated: → fall back to file mtime', async () => {
+    const root = await makeVault();
+    try {
+      const now = new Date('2026-05-07T12:00:00Z');
+      const oldDate = new Date('2026-03-01T00:00:00Z'); // 67 days before now
+      const abs = await writeWikiPage(root, 'old.md', { type: 'concept' }, '# Old');
+      await setMtime(abs, oldDate);
+      const pages = await loadPagesForOrphanTest(root);
+      const stale = detectStale(pages, { thresholdDays: 30, now });
+      assert.equal(stale.length, 1);
+      assert.equal(stale[0].rel, 'old.md');
+      assert.ok(stale[0].age_days >= 60);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Duplicate title
+// ---------------------------------------------------------------------------
+
+describe('BLUE-HEALTH-DUPLICATE: duplicate title detection', () => {
+  test('BLUE-HEALTH-DUPLICATE-1: 2 pages same title → 1 group', async () => {
+    const root = await makeVault();
+    try {
+      await writeWikiPage(root, 'a.md', { type: 'concept', title: 'JWT' }, '# JWT');
+      await writeWikiPage(root, 'concepts/jwt.md', { type: 'concept', title: 'JWT' }, '# JWT');
+      await writeWikiPage(root, 'unique.md', { type: 'concept', title: 'Unique' }, '# Unique');
+      const pages = await loadPagesForOrphanTest(root);
+      const dups = detectDuplicateTitles(pages);
+      assert.equal(dups.length, 1);
+      assert.equal(dups[0].title, 'JWT');
+      assert.deepEqual(dups[0].paths, ['a.md', 'concepts/jwt.md']);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('BLUE-HEALTH-DUPLICATE-2: title source priority frontmatter > H1 > basename', async () => {
+    const root = await makeVault();
+    try {
+      // a.md: frontmatter title → "Foo"
+      // b.md: H1 → "Foo"
+      // c.md: basename → "foo" (case-insensitive match → 同 group)
+      await writeWikiPage(root, 'a.md', { type: 'concept', title: 'Foo' }, '# Different');
+      await writeWikiPage(root, 'b.md', { type: 'concept' }, '# Foo');
+      await writeWikiPage(root, 'sub/foo.md', { type: 'concept' }, 'no h1');
+      const pages = await loadPagesForOrphanTest(root);
+      const dups = detectDuplicateTitles(pages);
+      assert.equal(dups.length, 1);
+      assert.equal(dups[0].title.toLowerCase(), 'foo');
+      assert.equal(dups[0].paths.length, 3);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hot.md age
+// ---------------------------------------------------------------------------
+
+describe('BLUE-HEALTH-HOT-MD: hot.md mtime', () => {
+  test('BLUE-HEALTH-HOT-MD-AGE: returns elapsed seconds', async () => {
+    const root = await makeVault();
+    try {
+      const now = new Date('2026-05-07T12:00:00Z');
+      const past = new Date('2026-05-07T11:30:00Z'); // 30 min ago = 1800 s
+      const abs = await writeWikiPage(root, 'hot.md', { type: 'hot-cache' }, '# hot');
+      await setMtime(abs, past);
+      const info = await getHotMdAge(root, now);
+      assert.equal(info.exists, true);
+      assert.equal(info.age_seconds, 1800);
+      assert.equal(info.age_human, '30m');
+      assert.equal(info.mtime_iso, past.toISOString());
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('BLUE-HEALTH-HOT-MD-MISSING: hot.md absent → exists:false', async () => {
+    const root = await makeVault();
+    try {
+      const info = await getHotMdAge(root, new Date());
+      assert.equal(info.exists, false);
+      assert.equal(info.age_seconds, null);
+      assert.equal(info.mtime_iso, null);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// last ingest info
+// ---------------------------------------------------------------------------
+
+describe('BLUE-HEALTH-LAST-INGEST: session-logs latest mtime', () => {
+  test('BLUE-HEALTH-LAST-INGEST: returns latest mtime + count', async () => {
+    const root = await makeVault();
+    try {
+      const now = new Date('2026-05-07T12:00:00Z');
+      const old = new Date('2026-05-06T12:00:00Z');
+      const recent = new Date('2026-05-07T11:00:00Z'); // 1h ago
+      const a = await writeSessionLog(root, '20260506-120000-aaaa-old.md', { type: 'session-log', ingested: 'true' });
+      const b = await writeSessionLog(root, '20260507-110000-bbbb-recent.md', { type: 'session-log', ingested: 'true' });
+      await setMtime(a, old);
+      await setMtime(b, recent);
+      const info = await getLastIngestInfo(root, now);
+      assert.equal(info.exists, true);
+      assert.equal(info.log_count, 2);
+      assert.equal(info.mtime_iso, recent.toISOString());
+      assert.equal(info.age_seconds, 3600);
+      assert.equal(info.age_human, '1h');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('BLUE-HEALTH-LAST-INGEST-EMPTY: empty session-logs/ → exists:false', async () => {
+    const root = await makeVault();
+    try {
+      const info = await getLastIngestInfo(root, new Date());
+      assert.equal(info.exists, false);
+      assert.equal(info.log_count, 0);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// unprocessed session-logs
+// ---------------------------------------------------------------------------
+
+describe('BLUE-HEALTH-UNPROCESSED: ingested:false count', () => {
+  test('BLUE-HEALTH-UNPROCESSED-1: 2 ingested:false + 1 ingested:true → count = 2', async () => {
+    const root = await makeVault();
+    try {
+      await writeSessionLog(root, '20260507-100000-aaaa-pending1.md', { type: 'session-log', ingested: 'false' });
+      await writeSessionLog(root, '20260507-100100-bbbb-pending2.md', { type: 'session-log', ingested: 'false' });
+      await writeSessionLog(root, '20260507-100200-cccc-done.md', { type: 'session-log', ingested: 'true' });
+      const info = await detectUnprocessedLogs(root);
+      assert.equal(info.count, 2);
+      assert.equal(info.sample_paths.length, 2);
+      assert.ok(info.sample_paths[0].includes('pending1'));
+      assert.equal(info.sample_truncated, false);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Next action proposals
+// ---------------------------------------------------------------------------
+
+describe('BLUE-HEALTH-NEXT-ACTION: actionable suggestions', () => {
+  test('BLUE-HEALTH-NEXT-ACTION-1: orphan exists → suggests review action', () => {
+    const metrics = {
+      orphan: { count: 3, pages: ['a.md', 'b.md', 'c.md'] },
+      stale: { count: 0, threshold_days: 30, pages: [] },
+      duplicate_title: { count: 0, groups: [] },
+      hot_md_age: { exists: true, age_seconds: 60, age_human: '1m', mtime_iso: '2026-05-07T11:59:00Z' },
+      last_ingest: { exists: true, log_count: 1, age_seconds: 60, age_human: '1m', mtime_iso: '2026-05-07T11:59:00Z' },
+      unprocessed_logs: { count: 0, sample_paths: [], sample_truncated: false },
+    };
+    const actions = buildNextActions(metrics);
+    assert.ok(actions.length >= 1);
+    const orphanAction = actions.find((a) => a.reason.includes('orphan'));
+    assert.ok(orphanAction, 'orphan action should be present');
+    assert.match(orphanAction.action, /wikilink|archive/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end orchestrator
+// ---------------------------------------------------------------------------
+
+describe('BLUE-HEALTH-COLLECT: collectHealthMetrics orchestrator', () => {
+  test('BLUE-HEALTH-COLLECT-ALL: empty vault → all metrics = 0, no crash', async () => {
+    const root = await makeVault();
+    try {
+      const result = await collectHealthMetrics(root);
+      assert.equal(result.schema_version, HEALTH_SCHEMA_VERSION);
+      assert.ok(typeof result.generated_at === 'string');
+      assert.equal(result.vault_pages_total, 0);
+      assert.equal(result.metrics.orphan.count, 0);
+      assert.equal(result.metrics.stale.count, 0);
+      assert.equal(result.metrics.duplicate_title.count, 0);
+      assert.equal(result.metrics.hot_md_age.exists, false);
+      assert.equal(result.metrics.last_ingest.exists, false);
+      assert.equal(result.metrics.unprocessed_logs.count, 0);
+      assert.deepEqual(result.next_actions, []);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('BLUE-HEALTH-COLLECT-INTEGRATED: multiple metrics fire simultaneously', async () => {
+    const root = await makeVault();
+    try {
+      const now = new Date('2026-05-07T12:00:00Z');
+      // 1 orphan + 1 stale + 1 unprocessed log
+      await writeWikiPage(root, 'index.md', { type: 'index' }, '# Index');
+      await writeWikiPage(root, 'orphan.md', { type: 'concept', title: 'Orphan' }, '# Orphan');
+      await writeWikiPage(root, 'old.md', { type: 'concept', title: 'Old', updated: '2026-03-01' }, '# Old');
+      await writeSessionLog(root, '20260507-100000-aaaa-pending.md', { type: 'session-log', ingested: 'false' });
+
+      const result = await collectHealthMetrics(root, { now });
+      assert.equal(result.vault_pages_total, 3);
+      assert.equal(result.metrics.orphan.count, 2); // orphan + old (both unlinked)
+      assert.equal(result.metrics.stale.count, 1);
+      assert.equal(result.metrics.unprocessed_logs.count, 1);
+      assert.equal(result.metrics.last_ingest.log_count, 1);
+      assert.ok(result.next_actions.some((a) => a.reason.includes('orphan')));
+      assert.ok(result.next_actions.some((a) => a.reason.includes('older than')));
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('BLUE-HEALTH-COLLECT-STALE-DEFAULT: STALE_THRESHOLD_DAYS default is 30', () => {
+    assert.equal(STALE_THRESHOLD_DAYS, 30);
+  });
+});

--- a/tests/mcp-server-registration.test.sh
+++ b/tests/mcp-server-registration.test.sh
@@ -21,4 +21,9 @@ grep -q 'VISUALIZER_TOOL_DEF' "${SERVER_MJS}" || fail 'VISUALIZER_TOOL_DEF not i
 grep -q 'handleGenerateViz' "${SERVER_MJS}" || fail 'handleGenerateViz not imported in server.mjs'
 grep -q 'register(VISUALIZER_TOOL_DEF' "${SERVER_MJS}" || fail 'VISUALIZER_TOOL_DEF not registered'
 
+# Sprint 2 v0.7.4: kioku_health が register されていること
+grep -q 'HEALTH_TOOL_DEF' "${SERVER_MJS}" || fail 'HEALTH_TOOL_DEF not imported in server.mjs'
+grep -q 'handleHealth' "${SERVER_MJS}" || fail 'handleHealth not imported in server.mjs'
+grep -q 'register(HEALTH_TOOL_DEF' "${SERVER_MJS}" || fail 'HEALTH_TOOL_DEF not registered'
+
 echo "PASS: mcp-server-registration"

--- a/tests/mcp/server.test.mjs
+++ b/tests/mcp/server.test.mjs
@@ -109,7 +109,7 @@ describe('kioku-mcp server', () => {
     assert.equal(init.result?.serverInfo?.name, 'kioku-wiki');
   });
 
-  test('MCP2 tools/list returns 10 kioku_ tools (incl. kioku_generate_viz)', async () => {
+  test('MCP2 tools/list returns 11 kioku_ tools (incl. kioku_health)', async () => {
     const child = startServer();
     const responses = await rpc(child, [
       {
@@ -127,6 +127,7 @@ describe('kioku-mcp server', () => {
     assert.deepEqual(names, [
       'kioku_delete',
       'kioku_generate_viz',
+      'kioku_health',
       'kioku_ingest_document',
       'kioku_ingest_pdf',
       'kioku_ingest_url',

--- a/tests/mcp/tools-health.test.mjs
+++ b/tests/mcp/tools-health.test.mjs
@@ -1,0 +1,150 @@
+// tests/mcp/tools-health.test.mjs — kioku_health MCP tool (Sprint 2 v0.7.4)
+//
+// Test prefixes (MCP-HEALTH-* namespace, per LEARN#8a no collision verified):
+//   MCP-HEALTH-1: TOOL_DEF shape (name / title / description / inputShape)
+//   MCP-HEALTH-2: empty vault → metrics = 0, no crash
+//   MCP-HEALTH-3: 正常 vault で valid metrics 返却
+//   MCP-HEALTH-4: paths_limit で orphan/stale 配列が truncate される
+//   MCP-HEALTH-5: threshold_days override が stale 判定に効く
+//   MCP-HEALTH-6: 大量 page (mock 100+) でも timeout なし
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, mkdir, writeFile, utimes } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { HEALTH_TOOL_DEF, handleHealth } from '../../mcp/tools/health.mjs';
+
+async function makeVault() {
+  const root = await mkdtemp(join(tmpdir(), 'kioku-health-mcp-test-'));
+  await mkdir(join(root, 'wiki'), { recursive: true });
+  await mkdir(join(root, 'session-logs'), { recursive: true });
+  return root;
+}
+
+async function writeWikiPage(root, rel, frontmatter, body) {
+  const abs = join(root, 'wiki', rel);
+  const dir = abs.substring(0, abs.lastIndexOf('/'));
+  await mkdir(dir, { recursive: true });
+  const fmLines = Object.entries(frontmatter).map(([k, v]) => `${k}: ${v}`);
+  const text = `---\n${fmLines.join('\n')}\n---\n\n${body}\n`;
+  await writeFile(abs, text, 'utf8');
+  return abs;
+}
+
+describe('kioku_health (Sprint 2 v0.7.4)', () => {
+  test('MCP-HEALTH-1: TOOL_DEF shape', () => {
+    assert.equal(HEALTH_TOOL_DEF.name, 'kioku_health');
+    assert.ok(typeof HEALTH_TOOL_DEF.title === 'string' && HEALTH_TOOL_DEF.title.length > 0);
+    assert.ok(typeof HEALTH_TOOL_DEF.description === 'string');
+    assert.match(HEALTH_TOOL_DEF.description, /metric/i);
+    assert.match(HEALTH_TOOL_DEF.description, /Read-only/);
+    assert.ok(HEALTH_TOOL_DEF.inputShape.threshold_days);
+    assert.ok(HEALTH_TOOL_DEF.inputShape.paths_limit);
+  });
+
+  test('MCP-HEALTH-2: empty vault → metrics = 0, no crash', async () => {
+    const root = await makeVault();
+    try {
+      const result = await handleHealth(root);
+      assert.equal(result.vault_pages_total, 0);
+      assert.equal(result.metrics.orphan.count, 0);
+      assert.equal(result.metrics.stale.count, 0);
+      assert.equal(result.metrics.duplicate_title.count, 0);
+      assert.equal(result.metrics.hot_md_age.exists, false);
+      assert.equal(result.metrics.last_ingest.exists, false);
+      assert.equal(result.metrics.unprocessed_logs.count, 0);
+      assert.deepEqual(result.next_actions, []);
+      assert.equal(result.truncated.orphan_pages, false);
+      assert.equal(result.truncated.stale_pages, false);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('MCP-HEALTH-3: valid metrics for non-empty vault', async () => {
+    const root = await makeVault();
+    try {
+      await writeWikiPage(root, 'index.md', { type: 'index' }, '[[a]]');
+      await writeWikiPage(root, 'a.md', { type: 'concept', title: 'A' }, '# A');
+      await writeWikiPage(root, 'orphan.md', { type: 'concept', title: 'Orphan' }, '# Orphan');
+      const result = await handleHealth(root);
+      assert.equal(result.vault_pages_total, 3);
+      assert.equal(result.metrics.orphan.count, 1);
+      assert.deepEqual(result.metrics.orphan.pages, ['orphan.md']);
+      assert.ok(result.next_actions.some((a) => a.reason.includes('orphan')));
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('MCP-HEALTH-4: paths_limit truncates orphan/stale lists', async () => {
+    const root = await makeVault();
+    try {
+      // 5 orphan pages
+      for (let i = 0; i < 5; i++) {
+        await writeWikiPage(root, `orphan-${i}.md`, { type: 'concept' }, `# ${i}`);
+      }
+      const limited = await handleHealth(root, { paths_limit: 2 });
+      assert.equal(limited.metrics.orphan.count, 5);
+      assert.equal(limited.metrics.orphan.pages.length, 2);
+      assert.equal(limited.truncated.orphan_pages, true);
+
+      // paths_limit: 0 → counts only
+      const zeroLimit = await handleHealth(root, { paths_limit: 0 });
+      assert.equal(zeroLimit.metrics.orphan.count, 5);
+      assert.equal(zeroLimit.metrics.orphan.pages.length, 0);
+      assert.equal(zeroLimit.truncated.orphan_pages, true);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('MCP-HEALTH-5: threshold_days override changes stale judgement', async () => {
+    const root = await makeVault();
+    try {
+      // page from 10 days ago: stale at threshold 5, not stale at threshold 30
+      const tenDaysAgo = new Date(Date.now() - 10 * 24 * 3600 * 1000);
+      const abs = await writeWikiPage(
+        root,
+        'recent.md',
+        { type: 'concept', updated: tenDaysAgo.toISOString().slice(0, 10) },
+        '# recent',
+      );
+      await utimes(abs, tenDaysAgo, tenDaysAgo);
+
+      const tight = await handleHealth(root, { threshold_days: 5 });
+      assert.equal(tight.metrics.stale.threshold_days, 5);
+      assert.equal(tight.metrics.stale.count, 1);
+
+      const loose = await handleHealth(root, { threshold_days: 30 });
+      assert.equal(loose.metrics.stale.threshold_days, 30);
+      assert.equal(loose.metrics.stale.count, 0);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('MCP-HEALTH-6: 100 pages mock — completes within reasonable time (<2s)', async () => {
+    const root = await makeVault();
+    try {
+      // generate 100 small pages, each linked from index.md to keep orphan = 0
+      const links = [];
+      for (let i = 0; i < 100; i++) {
+        await writeWikiPage(root, `p-${i}.md`, { type: 'concept', title: `P${i}` }, `# P${i}`);
+        links.push(`[[p-${i}]]`);
+      }
+      await writeWikiPage(root, 'index.md', { type: 'index' }, links.join('\n'));
+
+      const t0 = Date.now();
+      const result = await handleHealth(root);
+      const elapsed = Date.now() - t0;
+      assert.ok(elapsed < 2000, `MCP-HEALTH-6: 100 pages took ${elapsed}ms (expected < 2000)`);
+      assert.equal(result.vault_pages_total, 101);
+      assert.equal(result.metrics.orphan.count, 0);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

v0.7.4 micro release sync from parent (Step 4/8 of LEARN#11 cascade). Sprint 2 主軸 PR ship。

## What's bundled (delta from v0.7.3)

### 🩺 kioku_health MCP tool (Sprint 2 主軸、parent #103)
- `mcp/tools/health.mjs` 新 MCP tool (11th tool、tools/list で 10 → 11)
- `mcp/lib/health-metrics.mjs` business logic (separation、test 容易)
- `scripts/generate-health.mjs` Node script、`wiki/meta/health.md` 生成

### 📊 6 core metrics
- orphan / stale (>30d) / duplicate title / hot.md age / last ingest / unprocessed session-log
- `Next actions:` 行で actionable suggestion 提示

### 🔢 Version bump 5+1 places (0.7.3 → 0.7.4)
mcp/package.json + mcp/manifest.json + .claude-plugin/plugin.json + .claude-plugin/marketplace.json (×2) + mcp/package-lock.json

### 🛡 LEARN#5 wave 2 catch (制作 Claude side、PM trust-but-verify でリファクタ要求 0)
- `tests/mcp/server.test.mjs` hardcoded 10 tools array → 11
- `tests/mcp-server-registration.test.sh` 同様
- `docs/install-guide-multi-agent.md` ×3 箇所 (10 tools → 11 tools)

## Test result

- Node 475+ + Bash 22 suites + 23 BLUE-HEALTH-* / MCP-HEALTH-* + 9 drift (11 tools 整合) all green
- run-quick-suite.sh 10s で完走
- PM 環境 dogfood: 151 pages / 8 orphan / 0 stale / 0 duplicate / hot.md 14d / last ingest 4s

## Cascade status

- [x] Step 1: parent release PR #105
- [x] Step 2: parent PR #105 merged
- [x] Step 3: sync-to-app
- [x] Step 4: kioku next → main PR (本 PR)
- [ ] Step 5: kioku 10 言語 README v0.7.4 Changelog (LEARN#11 sync boundary 回避のため別 PR)
- [ ] Step 6: post-release-sync
- [ ] Step 7: .mcpb build + GitHub Release v0.7.4
- [ ] Step 8: marketing handoff

🤖 Generated with [Claude Code](https://claude.com/claude-code)