### PR TITLE
docs: v0.7.5 Changelog entry を 10 言語 README に展開 (LEARN#11 mandatory)

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -263,6 +263,16 @@ Si encuentras un problema de seguridad, repórtalo a través de [SECURITY.md](SE
 
 ## Cambios
 
+### 2026-05-08 — v0.7.5: Sprint 2 completado — `kioku_health` 11 metricas (5 stretch agregadas) + auto-lint refactor
+
+v0.7.5 marca la **finalizacion del Sprint 2 (記憶品質 dashboard)** — micro cascade del mismo dia tras el release matutino de v0.7.4.
+
+- **`kioku_health` 6 → 11 metricas**: agregadas `broken_wikilink` / `source_sha256_duplicate` / `pages_warm_zone` (7-30d) / `page_count_by_type` / `summaries_growth_rate`
+- **auto-lint LINT_PROMPT 6 → 4 observaciones refactor**: excluye explicitamente las 11 metricas machine-checkable de `kioku_health`, deja solo problemas semanticos que requieren juicio LLM (contradiccion / splinter de conceptos / pagina dedicada faltante / gap de wikilinks semanticos)
+- **Real-world dogfood (PM Vault, 155 paginas)**: primer run surfaced `broken=21 / sha256_dup=2 / warm zone=99 / growth 30d=33`
+- **Tests**: 33 BLUE-HEALTH-* + 9 BLUE-DRIFT-* + 53 BLUE-LINT-PROMPT-* + 475+ Node + 22 Bash todos green
+- [Release v0.7.5](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.7.5)
+
 ### 2026-05-08 — v0.7.4: Sprint 2 inicio — `kioku_health` MCP tool + 6 metricas de salud de memoria
 
 v0.7.4 lanza el **Sprint 2 (記憶品質 dashboard)** del reliability roadmap post-v0.7.1. Donde Sprint 1 dio diagnostico / drift / onboarding, Sprint 2 hace que la **memoria de KIOKU sea consciente de si misma** — `kioku_health` responde en 5 segundos.

--- a/README.fr.md
+++ b/README.fr.md
@@ -326,6 +326,16 @@ Si vous trouvez un probleme de securite, veuillez le signaler via [SECURITY.md](
 
 ## Journal des modifications
 
+### 2026-05-08 — v0.7.5 : Sprint 2 termine — `kioku_health` 11 metriques (5 stretch ajoutees) + auto-lint refactor
+
+v0.7.5 marque la **finalisation du Sprint 2 (記憶品質 dashboard)** — micro cascade le meme jour apres la release matinale de v0.7.4.
+
+- **`kioku_health` 6 → 11 metriques** : ajoutees `broken_wikilink` / `source_sha256_duplicate` / `pages_warm_zone` (7-30j) / `page_count_by_type` / `summaries_growth_rate`
+- **auto-lint LINT_PROMPT 6 → 4 observations refactor** : exclut explicitement les 11 metriques machine-checkable de `kioku_health`, ne laisse que les problemes semantiques necessitant un jugement LLM (contradiction / splinter de concepts / page dediee manquante / gap de wikilinks semantiques)
+- **Real-world dogfood (PM Vault, 155 pages)** : premier run a surface `broken=21 / sha256_dup=2 / warm zone=99 / growth 30d=33`
+- **Tests** : 33 BLUE-HEALTH-* + 9 BLUE-DRIFT-* + 53 BLUE-LINT-PROMPT-* + 475+ Node + 22 Bash tous green
+- [Release v0.7.5](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.7.5)
+
 ### 2026-05-08 — v0.7.4 : Sprint 2 demarrage — `kioku_health` MCP tool + 6 metriques de sante de memoire
 
 v0.7.4 lance le **Sprint 2 (記憶品質 dashboard)** du reliability roadmap post-v0.7.1. La ou Sprint 1 a donne diagnostique / drift / onboarding, **Sprint 2 rend la memoire de KIOKU auto-consciente** — `kioku_health` repond en 5 secondes.

--- a/README.hi.md
+++ b/README.hi.md
@@ -263,6 +263,16 @@ KIOKU एक Hook सिस्टम है जो **सभी Claude Code स�
 
 ## परिवर्तन इतिहास
 
+### 2026-05-08 — v0.7.5: Sprint 2 पूर्ण — `kioku_health` 11 metrics (5 stretch जोड़े गए) + auto-lint refactor
+
+v0.7.5 **Sprint 2 (記憶品質 dashboard) के पूर्ण होने** को chihnit करता है — v0.7.4 की सुबह की release के बाद उसी दिन का micro cascade।
+
+- **`kioku_health` 6 → 11 metrics**: जोड़े गए `broken_wikilink` / `source_sha256_duplicate` / `pages_warm_zone` (7-30d) / `page_count_by_type` / `summaries_growth_rate`
+- **auto-lint LINT_PROMPT 6 → 4 अवलोकन refactor**: `kioku_health` के 11 machine-checkable metrics को explicitly exclude करता है, सिर्फ LLM judgment-required semantic समस्याएं छोड़ता है (विरोधाभास / concept splinter / dedicated page मिसिंग / semantic wikilink gap)
+- **Real-world dogfood (PM Vault, 155 पेज)**: पहला run `broken=21 / sha256_dup=2 / warm zone=99 / growth 30d=33` surface किया
+- **Tests**: 33 BLUE-HEALTH-* + 9 BLUE-DRIFT-* + 53 BLUE-LINT-PROMPT-* + 475+ Node + 22 Bash सभी green
+- [Release v0.7.5](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.7.5)
+
 ### 2026-05-08 — v0.7.4: Sprint 2 शुरू — `kioku_health` MCP tool + 6 memory health metrics
 
 v0.7.4 post-v0.7.1 reliability roadmap के **Sprint 2 (記憶品質 dashboard)** को launch करता है। Sprint 1 ने diagnostic / drift / onboarding दिए, **Sprint 2 KIOKU की memory को self-aware बनाता है** — `kioku_health` 5 seconds में जवाब देता है।

--- a/README.ja.md
+++ b/README.ja.md
@@ -484,6 +484,25 @@ KIOKU は Claude Code の**全セッション入出力にアクセスする Hook
 
 ## 更新履歴
 
+### 2026-05-08 — v0.7.5: Sprint 2 完走 — `kioku_health` 11 メトリクス (stretch 5 追加) + auto-lint 改訂
+
+v0.7.5 は **Sprint 2 (記憶品質 dashboard) の完走 marker** — v0.7.4 (本日朝) との overnight micro cascade。v0.7.4 が **コア 6 メトリクス** (orphan / stale / duplicate title / hot.md age / last ingest / unprocessed session-logs) を ship したのに対し、v0.7.5 は codex roadmap §「指標案」 の **stretch 5 メトリクス** を追加 + **auto-lint を refactor** して `kioku_health` の machine-checkable な領域と重複しないよう役割分担を明示する。
+
+- **`kioku_health` 6 → 11 メトリクス** — 追加された 5 メトリクス:
+  - `broken_wikilink` — `[[link]]` で参照されているが wiki/ 内に存在しない件数 (= 切れたリンク)
+  - `source_sha256_duplicate` — frontmatter `source_sha256:` が同値の page group 数 (= 冪等 ingest が壊れている、または手動重複)
+  - `pages_warm_zone` — `updated:` が 7-30 日の warm 帯 page 件数 (fresh と stale-30d の中間)
+  - `page_count_by_type` — type (concept / project / decision / source-summary / log / index / meta / その他) 別 breakdown
+  - `summaries_growth_rate` — 直近 7d / 30d の `wiki/sources/*-summary.md` 増加件数 (件/日 換算)
+- **`auto-lint` LINT_PROMPT 6 → 4 観点 refactor** — `scripts/auto-lint.sh` が `kioku_health` の 11 machine-checkable メトリクスを観察対象から **明示的に exclude**、**LLM judgment 必須の semantic な問題** だけに絞り込み:
+  1. **概念の矛盾** (同じ事実について異なる記述、新しいソースで上書きされた古い主張)
+  2. **概念の splinter** (同概念を複数ページに分散している、merge 候補)
+  3. **専用ページが必要な繰り返し言及概念** (sources/summaries で複数言及されているが `wiki/concepts/` 等に専用ページが昇格していない)
+  4. **意味的な相互リンク欠落** (内容上関連が深いのに wikilink が張られていない semantic gap、wikilink 構文の broken は `kioku_health` で別 detect 済)
+- **実環境 dogfood (PM Vault, 155 ページ)** — 2026-05-08 初回実行で `broken=21 / sha256_dup=2 / warm zone=99 / growth 30d=33` を即時 surface、各々が `next_actions` で actionable な改善候補に直結
+- **テスト**: 33 BLUE-HEALTH-* + MCP-HEALTH-* (STRETCH-1..7 含む) + 9 BLUE-DRIFT-* + 53 BLUE-LINT-PROMPT-* + 既存 475+ Node + 22 Bash 全 pass、`npm audit` clean
+- [Release v0.7.5](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.7.5) — `kioku-wiki-0.7.5.mcpb` attached
+
 ### 2026-05-08 — v0.7.4: Sprint 2 着手 — `kioku_health` MCP tool + 6 件のメモリ健康メトリクス
 
 v0.7.4 は post-v0.7.1 信頼性ロードマップの **Sprint 2 (記憶品質 dashboard)** を ship。Sprint 1 (v0.7.2 / v0.7.3) が KIOKU の診断 / drift / オンボーディングのツール群を提供したのに対し、**Sprint 2 は KIOKU の記憶そのものを自己診断可能に** — Wiki に orphan page は? stale note は? 重複 title は? すべて `kioku_health` が 5 秒で答える。

--- a/README.ko.md
+++ b/README.ko.md
@@ -326,6 +326,16 @@ KIOKU은 **모든 Claude Code 세션 입출력**에 접근하는 Hook 시스템�
 
 ## 변경 이력
 
+### 2026-05-08 — v0.7.5: Sprint 2 완주 — `kioku_health` 11개 metrics (stretch 5개 추가) + auto-lint refactor
+
+v0.7.5는 **Sprint 2 (記憶品質 dashboard) 완주 marker** — v0.7.4 아침 release 후 같은 날의 micro cascade.
+
+- **`kioku_health` 6 → 11개 metrics**: 추가된 5개는 `broken_wikilink` / `source_sha256_duplicate` / `pages_warm_zone` (7-30d) / `page_count_by_type` / `summaries_growth_rate`
+- **auto-lint LINT_PROMPT 6 → 4개 관점 refactor**: `kioku_health`의 11개 machine-checkable metrics를 명시적으로 exclude, LLM judgment-required한 semantic 문제만 남김 (모순 / 개념 splinter / dedicated 페이지 누락 / semantic wikilink gap)
+- **Real-world dogfood (PM Vault, 155 페이지)**: 첫 run에서 `broken=21 / sha256_dup=2 / warm zone=99 / growth 30d=33` 즉시 surface
+- **Tests**: 33 BLUE-HEALTH-* + 9 BLUE-DRIFT-* + 53 BLUE-LINT-PROMPT-* + 475+ Node + 22 Bash 모두 green
+- [Release v0.7.5](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.7.5)
+
 ### 2026-05-08 — v0.7.4: Sprint 2 착수 — `kioku_health` MCP tool + 6개 메모리 health metrics
 
 v0.7.4는 post-v0.7.1 reliability roadmap의 **Sprint 2 (記憶品質 dashboard)**를 launch. Sprint 1이 diagnostic / drift / onboarding을 제공한 데 비해, **Sprint 2는 KIOKU의 memory 자체를 self-aware하게** — `kioku_health`가 5초 안에 답함.

--- a/README.md
+++ b/README.md
@@ -465,6 +465,25 @@ If you find a security issue, please report it via [SECURITY.md](SECURITY.md) �
 
 ## Changelog
 
+### 2026-05-08 — v0.7.5: Sprint 2 完走 — `kioku_health` 11 metrics (stretch 5 追加) + auto-lint refactor
+
+v0.7.5 marks **Sprint 2 (記憶品質 dashboard) completion** — same-day micro cascade after v0.7.4 morning release. Where v0.7.4 shipped the **core 6 metrics** (orphan / stale / duplicate title / hot.md age / last ingest / unprocessed session-logs), v0.7.5 adds the **stretch 5 metrics** identified in the codex roadmap §「指標案」 and **refactors auto-lint** to no longer overlap with `kioku_health`'s machine-checkable surface.
+
+- **`kioku_health` 6 → 11 metrics** — the 5 added metrics:
+  - `broken_wikilink` — `[[link]]` references that don't resolve to any page in wiki/ (= orphan link)
+  - `source_sha256_duplicate` — pages sharing the same `source_sha256:` frontmatter (= idempotent ingest broken or manual dup)
+  - `pages_warm_zone` — pages with `updated:` between 7-30 days (= warm zone, between fresh and stale-30d)
+  - `page_count_by_type` — breakdown by page type (concept / project / decision / source-summary / log / index / meta / その他)
+  - `summaries_growth_rate` — `wiki/sources/*-summary.md` additions in last 7d / 30d, expressed as count/day
+- **`auto-lint` LINT_PROMPT 6 → 4 観点 refactor** — `scripts/auto-lint.sh` now explicitly excludes the 11 `kioku_health` machine-checkable metrics from its observation list, leaving only **LLM judgment-required semantic patterns**:
+  1. **概念の矛盾** (contradicting facts across pages, old claims overwritten by newer sources)
+  2. **概念の splinter** (same concept split across multiple pages, merge candidates)
+  3. **専用ページが必要な繰り返し言及概念** (mentioned repeatedly in sources/summaries but no dedicated `wiki/concepts/` page)
+  4. **意味的な相互リンク欠落** (semantic gap — pages thematically related but not wikilinked; broken wikilink syntax handled by `kioku_health`)
+- **Real-world dogfood (PM Vault, 155 pages)** — first run on 2026-05-08 surfaced `broken=21 / sha256_dup=2 / warm zone=99 / growth 30d=33`, immediately actionable via `next_actions` text
+- **Tests**: 33 BLUE-HEALTH-* + MCP-HEALTH-* (incl. STRETCH-1..7) + 9 BLUE-DRIFT-* + 53 BLUE-LINT-PROMPT-* + 475+ existing Node + 22 Bash all green; `npm audit` clean
+- [Release v0.7.5](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.7.5) — `kioku-wiki-0.7.5.mcpb` attached
+
 ### 2026-05-08 — v0.7.4: Sprint 2 着手 — `kioku_health` MCP tool + 6 memory health metrics
 
 v0.7.4 launches **Sprint 2 (記憶品質 dashboard)** of the post-v0.7.1 reliability roadmap. Where Sprint 1 (v0.7.2 / v0.7.3) gave KIOKU diagnostic / drift / onboarding tools, **Sprint 2 makes KIOKU's memory itself self-aware** — does the Wiki contain orphan pages? stale notes? duplicate titles? `kioku_health` answers all of these in 5 seconds.

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -326,6 +326,16 @@ Se voce encontrar um problema de seguranca, por favor reporte via [SECURITY.md](
 
 ## Histórico de mudanças
 
+### 2026-05-08 — v0.7.5: Sprint 2 concluido — `kioku_health` 11 metricas (5 stretch adicionadas) + auto-lint refactor
+
+v0.7.5 marca a **conclusao do Sprint 2 (記憶品質 dashboard)** — micro cascade do mesmo dia apos a release matinal de v0.7.4.
+
+- **`kioku_health` 6 → 11 metricas**: adicionadas `broken_wikilink` / `source_sha256_duplicate` / `pages_warm_zone` (7-30d) / `page_count_by_type` / `summaries_growth_rate`
+- **auto-lint LINT_PROMPT 6 → 4 observacoes refactor**: exclui explicitamente as 11 metricas machine-checkable de `kioku_health`, deixa apenas problemas semanticos que requerem julgamento LLM (contradicao / splinter de conceitos / pagina dedicada faltante / gap de wikilinks semanticos)
+- **Real-world dogfood (PM Vault, 155 paginas)**: primeiro run surfaced `broken=21 / sha256_dup=2 / warm zone=99 / growth 30d=33`
+- **Tests**: 33 BLUE-HEALTH-* + 9 BLUE-DRIFT-* + 53 BLUE-LINT-PROMPT-* + 475+ Node + 22 Bash todos green
+- [Release v0.7.5](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.7.5)
+
 ### 2026-05-08 — v0.7.4: Sprint 2 inicio — `kioku_health` MCP tool + 6 metricas de saude de memoria
 
 v0.7.4 lanca o **Sprint 2 (記憶品質 dashboard)** do reliability roadmap post-v0.7.1. Onde Sprint 1 deu diagnostico / drift / onboarding, **Sprint 2 torna a memoria de KIOKU autoconsciente** — `kioku_health` responde em 5 segundos.

--- a/README.ru.md
+++ b/README.ru.md
@@ -331,6 +331,16 @@ KIOKU спроектирован для **совместного использ�
 
 ## История изменений
 
+### 2026-05-08 — v0.7.5: Sprint 2 завершен — `kioku_health` 11 метрик (5 stretch добавлены) + auto-lint refactor
+
+v0.7.5 отмечает **завершение Sprint 2 (記憶品質 dashboard)** — micro cascade в тот же день после утренней release v0.7.4.
+
+- **`kioku_health` 6 → 11 метрик**: добавлены `broken_wikilink` / `source_sha256_duplicate` / `pages_warm_zone` (7-30d) / `page_count_by_type` / `summaries_growth_rate`
+- **auto-lint LINT_PROMPT 6 → 4 наблюдения refactor**: явно исключает 11 machine-checkable метрик `kioku_health`, оставляет только семантические проблемы, требующие LLM judgment (противоречие / splinter концепций / отсутствие dedicated page / семантический wikilink gap)
+- **Real-world dogfood (PM Vault, 155 страниц)**: первый run surface `broken=21 / sha256_dup=2 / warm zone=99 / growth 30d=33`
+- **Tests**: 33 BLUE-HEALTH-* + 9 BLUE-DRIFT-* + 53 BLUE-LINT-PROMPT-* + 475+ Node + 22 Bash все green
+- [Release v0.7.5](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.7.5)
+
 ### 2026-05-08 — v0.7.4: Sprint 2 запуск — `kioku_health` MCP tool + 6 метрик здоровья памяти
 
 v0.7.4 запускает **Sprint 2 (記憶品質 dashboard)** post-v0.7.1 reliability roadmap. Где Sprint 1 дал diagnostic / drift / onboarding, **Sprint 2 делает память KIOKU самоосознающей** — `kioku_health` отвечает за 5 секунд.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -331,6 +331,16 @@ KIOKU 是一个可以访问**所有 Claude Code 会话输入输出**的 Hook 系
 
 ## 更新历史
 
+### 2026-05-08 — v0.7.5：Sprint 2 完成 — `kioku_health` 11 个指标 (新增 stretch 5) + auto-lint refactor
+
+v0.7.5 标志着 **Sprint 2 (記憶品質 dashboard) 完成** — v0.7.4 上午 release 后同日的 micro cascade。
+
+- **`kioku_health` 6 → 11 个指标**: 新增 `broken_wikilink` / `source_sha256_duplicate` / `pages_warm_zone` (7-30d) / `page_count_by_type` / `summaries_growth_rate`
+- **auto-lint LINT_PROMPT 6 → 4 个观察 refactor**: 显式 exclude `kioku_health` 的 11 个 machine-checkable 指标，只保留需要 LLM 判断的语义问题 (矛盾 / 概念 splinter / 缺失专属页 / 语义 wikilink gap)
+- **Real-world dogfood (PM Vault, 155 页)**: 首次 run 即时 surface `broken=21 / sha256_dup=2 / warm zone=99 / growth 30d=33`
+- **Tests**: 33 BLUE-HEALTH-* + 9 BLUE-DRIFT-* + 53 BLUE-LINT-PROMPT-* + 475+ Node + 22 Bash 全部 green
+- [Release v0.7.5](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.7.5)
+
 ### 2026-05-08 — v0.7.4：Sprint 2 启动 — `kioku_health` MCP tool + 6 个内存健康指标
 
 v0.7.4 启动 post-v0.7.1 reliability roadmap 的 **Sprint 2 (記憶品質 dashboard)**。Sprint 1 给出 diagnostic / drift / onboarding，**Sprint 2 让 KIOKU 的内存自我感知** — `kioku_health` 在 5 秒内回答。

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -331,6 +331,16 @@ KIOKU 是一個存取**所有 Claude Code 工作階段 I/O** 的 Hook 系統。
 
 ## 更新歷史
 
+### 2026-05-08 — v0.7.5：Sprint 2 完成 — `kioku_health` 11 個指標 (新增 stretch 5) + auto-lint refactor
+
+v0.7.5 標記 **Sprint 2 (記憶品質 dashboard) 完成** — v0.7.4 上午 release 後同日的 micro cascade。
+
+- **`kioku_health` 6 → 11 個指標**：新增 `broken_wikilink` / `source_sha256_duplicate` / `pages_warm_zone` (7-30d) / `page_count_by_type` / `summaries_growth_rate`
+- **auto-lint LINT_PROMPT 6 → 4 個觀察 refactor**：顯式 exclude `kioku_health` 的 11 個 machine-checkable 指標，只保留需要 LLM 判斷的語義問題 (矛盾 / 概念 splinter / 缺少專屬頁 / 語義 wikilink gap)
+- **Real-world dogfood (PM Vault, 155 頁)**：首次 run 即時 surface `broken=21 / sha256_dup=2 / warm zone=99 / growth 30d=33`
+- **Tests**：33 BLUE-HEALTH-* + 9 BLUE-DRIFT-* + 53 BLUE-LINT-PROMPT-* + 475+ Node + 22 Bash 全部 green
+- [Release v0.7.5](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.7.5)
+
 ### 2026-05-08 — v0.7.4：Sprint 2 啟動 — `kioku_health` MCP tool + 6 個記憶健康指標
 
 v0.7.4 啟動 post-v0.7.1 reliability roadmap 的 **Sprint 2 (記憶品質 dashboard)**。Sprint 1 給出 diagnostic / drift / onboarding，**Sprint 2 讓 KIOKU 的記憶自我感知** — `kioku_health` 在 5 秒內回答。


### PR DESCRIPTION
Sprint 2 完走 (kioku_health 11 metrics + auto-lint refactor) narrative を 10 言語 README に parity で挿入。

LEARN#11 mandatory step (README は parent release PR に含めず、別 PR で kioku 側に直接 push、post-release-sync の rsync 全上書きで消失する trap 回避)。

## Parity 10/10

EN (README.md) + JA (英語混入最小化) + es / fr / hi / ko / pt-BR / ru / zh-CN / zh-TW、全言語に v0.7.4 entry 直前に v0.7.5 entry 挿入済。

## 各 entry 構成

- Sprint 2 完走 narrative
- kioku_health 6 → 11 metrics (5 stretch 列挙)
- auto-lint LINT_PROMPT 6 → 4 観点 refactor + 役割分担明示
- Real-world dogfood (PM Vault 155 page、broken=21 / sha256_dup=2 / warm zone=99 / growth 30d=33)
- Tests (33 health + 9 drift + 53 lint)
- Release link

## Parent ref

- 主軸 PR (parent): #109 + #110 cleanup + #111 release version bump
- kioku next → main sync PR: #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)