### PR TITLE
claude-brain: v0.8.0 sync from parent (Sprint 3 完走 — HTML Visualizer β + Path C+β viewer 70%)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "KIOKU: Hardened LLM Wiki for Claude Code / Claude Desktop by megaphone-tokyo",
-    "version": "0.7.5"
+    "version": "0.8.0"
   },
   "plugins": [
     {
@@ -17,7 +17,7 @@
         "ref": "main"
       },
       "description": "Hardened LLM Wiki for Claude Code + Claude Desktop. Automatic conversation → Obsidian Vault knowledge base. Hot cache + PostCompact hook + secret masking + Git sync.",
-      "version": "0.7.5",
+      "version": "0.8.0",
       "author": {
         "name": "megaphone-tokyo",
         "url": "https://github.com/megaphone-tokyo"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kioku",
-  "version": "0.7.5",
+  "version": "0.8.0",
   "description": "KIOKU — Hardened LLM Wiki for Claude Code + Claude Desktop. Automatic conversation capture to Obsidian Vault, Karpathy LLM Wiki pattern, hot cache + PostCompact hook, secret masking, cross-machine Git sync. Research/legal/enterprise-grade memory for Claude.",
   "author": {
     "name": "megaphone-tokyo",

--- a/mcp/lib/health-metrics.mjs
+++ b/mcp/lib/health-metrics.mjs
@@ -38,6 +38,11 @@ import { promisify } from 'node:util';
 
 import { parseFrontmatter } from './frontmatter.mjs';
 import { findWikilinks } from './wikilinks.mjs';
+import {
+  walkPages,
+  listMarkdownRefs,
+  inferPageType as inferPageTypeShared,
+} from './wiki-walker.mjs';
 
 const execFileAsync = promisify(execFile);
 
@@ -45,7 +50,13 @@ export const STALE_THRESHOLD_DAYS = 30;
 export const WARM_ZONE_LOWER_DAYS = 7;
 export const HEALTH_SCHEMA_VERSION = 2;
 
+// Re-export for back-compat (Sprint 3 Phase 3 §46 N=3 refactor): inferPageType now
+// lives in wiki-walker.mjs as the shared canonical impl. tests/health-metrics.test.mjs
+// imports it directly from health-metrics; keep the named export stable.
+export const inferPageType = inferPageTypeShared;
+
 // wiki/ 走査時にスキップするディレクトリ (kioku_list の EXCLUDE と整合)
+// Kept for back-compat — wiki-walker.mjs#DEFAULT_EXCLUDE_DIRS holds the canonical set.
 const EXCLUDE_DIRS = new Set(['.obsidian', '.archive', '.trash', 'templates', '.cache']);
 
 // orphan / stale / duplicate 判定から除外する system page
@@ -62,62 +73,10 @@ function isSystemPage(rel) {
   return ORPHAN_EXEMPT_TOP_DIRS.has(top);
 }
 
-// wiki/ を再帰的に walk して .md file path を集める。
-// 戻り値は { abs, rel } (rel は wiki/ からの相対パス、posix slash 統一)。
+// Back-compat shim: tests/health-metrics.test.mjs accesses `_internals.listWikiPages`.
+// Real walk now lives in wiki-walker.mjs (§46 N=3 refactor). Returns [{abs, rel}].
 async function listWikiPages(vault) {
-  const wikiDir = join(vault, 'wiki');
-  let baseStat;
-  try {
-    baseStat = await stat(wikiDir);
-  } catch (err) {
-    if (err.code === 'ENOENT') return [];
-    throw err;
-  }
-  if (!baseStat.isDirectory()) return [];
-
-  const out = [];
-  async function walk(absDir) {
-    let entries;
-    try {
-      entries = await readdir(absDir, { withFileTypes: true });
-    } catch (err) {
-      if (err.code === 'ENOENT') return;
-      throw err;
-    }
-    for (const ent of entries) {
-      if (ent.name.startsWith('.')) continue;
-      if (EXCLUDE_DIRS.has(ent.name)) continue;
-      const abs = join(absDir, ent.name);
-      if (ent.isDirectory()) {
-        await walk(abs);
-      } else if (ent.isFile() && ent.name.endsWith('.md')) {
-        out.push(abs);
-      }
-    }
-  }
-  await walk(wikiDir);
-  return out.map((abs) => ({ abs, rel: relative(wikiDir, abs).split(sep).join('/') }));
-}
-
-// 1 file から meta (frontmatter / body / mtime / wikilinks) を抽出。
-// 読み込み失敗時は null を返す (corrupt file は metrics 集計から除外、stderr に出さない)。
-async function readPageMeta(absPath) {
-  let text;
-  let st;
-  try {
-    [text, st] = await Promise.all([readFile(absPath, 'utf8'), stat(absPath)]);
-  } catch {
-    return null;
-  }
-  const { data, body } = parseFrontmatter(text);
-  return {
-    abs: absPath,
-    text,
-    body,
-    frontmatter: data,
-    mtime: st.mtime,
-    wikilinks: findWikilinks(text),
-  };
+  return listMarkdownRefs(vault, { subDir: 'wiki' });
 }
 
 // title 解決: frontmatter title > 本文 H1 > file basename (.md 除く)
@@ -463,37 +422,10 @@ export function detectWarmZonePages(
 
 // Metric 10: page count by type
 //
-// type 推論の優先順位:
-//   1. system page (basename match): index.md / log.md / hot.md
-//   2. frontmatter `type:` (string、trim 後 non-empty)
-//   3. top-level directory map (concepts → concept など、複数形 → 単数形に正規化)
-//   4. それ以外 → 'other'
-//
-// 戻り値は { <type>: <count> } の object (sort 済 entries)。
-const DIR_TO_TYPE = {
-  concepts: 'concept',
-  projects: 'project',
-  decisions: 'decision',
-  summaries: 'summary',
-  analyses: 'analysis',
-  patterns: 'pattern',
-  bugs: 'bug',
-  meta: 'meta',
-  viz: 'viz',
-  people: 'person',
-  sources: 'source',
-};
-
-export function inferPageType(rel, frontmatter) {
-  if (rel === 'index.md') return 'index';
-  if (rel === 'log.md') return 'log';
-  if (rel === 'hot.md') return 'hot';
-  const fmType = frontmatter?.type;
-  if (typeof fmType === 'string' && fmType.trim()) return fmType.trim();
-  const top = rel.split('/')[0];
-  if (DIR_TO_TYPE[top]) return DIR_TO_TYPE[top];
-  return 'other';
-}
+// type 推論の優先順位: system page (index/log/hot) → frontmatter.type → top-dir map → 'other'。
+// Implementation moved to wiki-walker.mjs#inferPageType (§46 N=3 refactor).
+// `export const inferPageType` near the top of the file is the active binding;
+// keeping countPagesByType here keeps the metrics API surface stable.
 
 export function countPagesByType(pages) {
   const counts = {};
@@ -693,12 +625,24 @@ export async function collectHealthMetrics(vault, options = {}) {
     ? options.staleThresholdDays
     : STALE_THRESHOLD_DAYS;
 
-  const pageRefs = await listWikiPages(vault);
-  const pages = [];
-  for (const ref of pageRefs) {
-    const meta = await readPageMeta(ref.abs);
-    if (meta) pages.push({ rel: ref.rel, meta });
-  }
+  // §46 N=3 refactor: single-pass walk via wiki-walker.mjs (replaces listWikiPages+readPageMeta).
+  // Mapped to legacy {rel, meta} shape so the existing detect* helpers (orphan / stale / dup / ...) keep working.
+  const walked = await walkPages(vault, {
+    subDir: 'wiki',
+    withBody: true,
+    withMtime: true,
+  });
+  const pages = walked.map((p) => ({
+    rel: p.rel,
+    meta: {
+      abs: p.abs,
+      text: p.text,
+      body: p.body,
+      frontmatter: p.frontmatter,
+      mtime: p.mtime,
+      wikilinks: p.wikilinks,
+    },
+  }));
 
   const orphans = detectOrphans(pages);
   const stale = detectStale(pages, { thresholdDays, now });
@@ -756,5 +700,4 @@ export const _internals = {
   listSessionLogs,
   PATH_SAMPLE_LIMIT,
   BROKEN_WIKILINK_SAMPLE_LIMIT,
-  DIR_TO_TYPE,
 };

--- a/mcp/lib/lineage-graph.mjs
+++ b/mcp/lib/lineage-graph.mjs
@@ -1,0 +1,506 @@
+// lineage-graph.mjs — Sprint 3 Phase 3: Raw-source lineage graph (3 layer model).
+//
+// Strategic doc §Axis 4 + handoff Phase 3 spec:
+//   - 3 layer: raw-sources → summaries → wiki pages
+//   - 5 edge types: sha256 / derived_from / filename / wikilink / time
+//   - best-effort hint (100% reconstruction より説明可能性優先、PM 答え #5)
+//   - 1-2 hop filtering は UI 側 (本 module は全 graph を返す、cap 付き)
+//   - 巨大 graph (codex Acceptance L313: 300 node 安定) で性能崩壊しない
+//
+// Edge confidence ordering (UI で transparency を担保):
+//   sha256 (1.00) — deterministic frontmatter 同一 hash
+//   derived_from (0.95) — frontmatter explicit reference
+//   wikilink (0.85) — author が手で書いた link、ノイズ低い
+//   filename (0.70) — slug 類推、convention dependent
+//   time (0.40) — mtime proximity heuristic、weakest hint
+//
+// 出力は HTML inline JSON 埋め込み用に compact 化:
+//   - body / text は持たない (P1 absolute contract: page body 漏洩禁止)
+//   - frontmatter は lineage に必要な 4 field のみ project (source_sha256/derived_from/source/ingest_at)
+
+import { walkPages } from './wiki-walker.mjs';
+
+export const LINEAGE_SCHEMA_VERSION = 1;
+export const DEFAULT_NODE_CAP = 300;
+export const TIME_PROXIMITY_SECONDS = 3600; // 1 時間 cross-layer time edge window
+export const EDGE_KINDS = Object.freeze(['sha256', 'derived_from', 'filename', 'wikilink', 'time']);
+export const EDGE_CONFIDENCE = Object.freeze({
+  sha256: 1.0,
+  derived_from: 0.95,
+  wikilink: 0.85,
+  filename: 0.7,
+  time: 0.4,
+});
+
+// raw-sources/ で扱う file 拡張子 (Phase 2.4 で land 済 ingest path に揃える)
+const RAW_SOURCE_EXTENSIONS = ['.md', '.pdf', '.epub', '.docx', '.txt', '.html'];
+
+// frontmatter の lineage-relevant field のみ project して inline JSON を slim 化。
+function pickLineageFrontmatter(fm) {
+  if (!fm || typeof fm !== 'object') return null;
+  const out = {};
+  if (typeof fm.source_sha256 === 'string' && fm.source_sha256.length > 0) {
+    out.source_sha256 = fm.source_sha256;
+  }
+  if (fm.derived_from != null) {
+    out.derived_from = Array.isArray(fm.derived_from)
+      ? fm.derived_from.map(String)
+      : String(fm.derived_from);
+  }
+  if (fm.source != null) {
+    out.source = Array.isArray(fm.source) ? fm.source.map(String) : String(fm.source);
+  }
+  if (typeof fm.ingest_at === 'string' && fm.ingest_at.length > 0) out.ingest_at = fm.ingest_at;
+  return Object.keys(out).length > 0 ? out : null;
+}
+
+function isoOrNull(d) {
+  if (d instanceof Date && !Number.isNaN(d.getTime())) return d.toISOString();
+  return null;
+}
+
+// posix-safe slug: 小文字化 + non-alnum を hyphen + 多重 hyphen 圧縮 + 周辺 hyphen 除去
+function slugify(name) {
+  if (typeof name !== 'string') return '';
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+// summary filename 慣習を剥がして対応する raw source slug を推定
+//   "rag-pipeline-summary"  → "rag-pipeline"
+//   "260424_jwt-notes"      → "260424-jwt"
+function summarySlugStem(name) {
+  const s = slugify(name);
+  return s.replace(/-summary$/, '').replace(/-notes?$/, '').replace(/-memo$/, '');
+}
+
+// Layer 判定: 'wiki/summaries/...' → summary、'wiki/...' → wiki、'raw-sources/...' → raw。
+function layerForWikiPage(rel) {
+  return rel.startsWith('summaries/') ? 'summary' : 'wiki';
+}
+
+// nodes / edges のレイアウト:
+//   node id: 'wiki:<rel>' or 'raw:<rel>'。rel は subDir-relative posix slash。
+function wikiNodeId(rel) { return `wiki:${rel}`; }
+function rawNodeId(rel)  { return `raw:${rel}`; }
+
+// Build the lineage graph for a vault.
+//
+// Returns:
+//   {
+//     schema_version,
+//     generated_at,
+//     hint_note,            // "estimated lineage" 注釈 (UI 表記用)
+//     nodes,                // [{id, layer, name, path, type, title, mtime, frontmatter?}]
+//     edges,                // [{source, target, kind, confidence, hint}]
+//     hint_summary,         // {sha256: N, derived_from: N, filename: N, wikilink: N, time: N}
+//     totals,               // {nodes: N, raw: N, summary: N, wiki: N, edges: N}
+//     truncated,            // boolean (node_cap で削られた場合 true)
+//     node_cap,
+//   }
+export async function buildLineageGraph(vault, options = {}) {
+  if (typeof vault !== 'string' || !vault) {
+    return emptyLineageResult(options.now);
+  }
+  const nodeCap = Number.isFinite(options.nodeCap) && options.nodeCap > 0
+    ? Math.floor(options.nodeCap)
+    : DEFAULT_NODE_CAP;
+  const now = options.now instanceof Date ? options.now : new Date();
+  const timeWindowSec = Number.isFinite(options.timeProximitySeconds) && options.timeProximitySeconds > 0
+    ? options.timeProximitySeconds
+    : TIME_PROXIMITY_SECONDS;
+
+  // 1. Walk wiki/ and raw-sources/ in parallel
+  const [wikiPages, rawSources] = await Promise.all([
+    walkPages(vault, {
+      subDir: 'wiki',
+      withFrontmatter: true,
+      withWikilinks: true,
+      withBody: false,
+      withMtime: true,
+    }),
+    walkPages(vault, {
+      subDir: 'raw-sources',
+      extensions: RAW_SOURCE_EXTENSIONS,
+      withFrontmatter: false,
+      withWikilinks: false,
+      withBody: false,
+      withMtime: true,
+    }),
+  ]);
+
+  // 2. Build node list (raw + wiki, with layer classification)
+  const allNodes = [];
+  for (const p of rawSources) {
+    allNodes.push({
+      id: rawNodeId(p.rel),
+      layer: 'raw',
+      name: p.name,
+      path: `raw-sources/${p.rel}`,
+      type: 'raw',
+      title: p.title,
+      mtime: isoOrNull(p.mtime),
+    });
+  }
+  for (const p of wikiPages) {
+    const layer = layerForWikiPage(p.rel);
+    const fmProjected = pickLineageFrontmatter(p.frontmatter);
+    const node = {
+      id: wikiNodeId(p.rel),
+      layer,
+      name: p.name,
+      path: `wiki/${p.rel}`,
+      type: p.type,
+      title: p.title,
+      mtime: isoOrNull(p.mtime),
+    };
+    if (fmProjected) node.frontmatter = fmProjected;
+    allNodes.push(node);
+  }
+
+  // 3. Cap nodes by recency (newer first), preserve cross-layer balance.
+  //    Performance acceptance (300 node 安定) は this cap で担保する。
+  const { capped: cappedNodes, dropped } = capNodes(allNodes, nodeCap);
+  const includedIds = new Set(cappedNodes.map((n) => n.id));
+
+  // 4. Build edges per kind, only between included nodes.
+  const edges = [];
+  edges.push(...buildSha256Edges(wikiPages, includedIds));
+  edges.push(...buildDerivedFromEdges(wikiPages, includedIds));
+  edges.push(...buildFilenameEdges(wikiPages, rawSources, includedIds));
+  edges.push(...buildWikilinkEdges(wikiPages, includedIds));
+  edges.push(...buildTimeEdges(wikiPages, rawSources, includedIds, timeWindowSec));
+
+  // Deduplicate (kind, source→target) pairs to avoid double-counting same hint.
+  const dedupedEdges = dedupeEdges(edges);
+
+  // 5. Hint summary
+  const hintSummary = Object.fromEntries(EDGE_KINDS.map((k) => [k, 0]));
+  for (const e of dedupedEdges) hintSummary[e.kind] = (hintSummary[e.kind] || 0) + 1;
+
+  const totals = {
+    nodes: cappedNodes.length,
+    raw: cappedNodes.filter((n) => n.layer === 'raw').length,
+    summary: cappedNodes.filter((n) => n.layer === 'summary').length,
+    wiki: cappedNodes.filter((n) => n.layer === 'wiki').length,
+    edges: dedupedEdges.length,
+  };
+
+  return {
+    schema_version: LINEAGE_SCHEMA_VERSION,
+    generated_at: now.toISOString(),
+    hint_note: 'estimated lineage — best-effort heuristics, not a guaranteed reconstruction',
+    nodes: cappedNodes,
+    edges: dedupedEdges,
+    hint_summary: hintSummary,
+    totals,
+    truncated: dropped > 0,
+    node_cap: nodeCap,
+  };
+}
+
+function emptyLineageResult(now) {
+  const ts = now instanceof Date ? now : new Date();
+  return {
+    schema_version: LINEAGE_SCHEMA_VERSION,
+    generated_at: ts.toISOString(),
+    hint_note: 'estimated lineage — best-effort heuristics, not a guaranteed reconstruction',
+    nodes: [],
+    edges: [],
+    hint_summary: Object.fromEntries(EDGE_KINDS.map((k) => [k, 0])),
+    totals: { nodes: 0, raw: 0, summary: 0, wiki: 0, edges: 0 },
+    truncated: false,
+    node_cap: DEFAULT_NODE_CAP,
+  };
+}
+
+// Cap nodes preserving recency. When `dropped > 0`, returns the most recent cap-many
+// nodes per layer-weighted distribution (raw + summary prioritized as they are the
+// lineage anchors that produced the wiki pages).
+function capNodes(nodes, cap) {
+  if (nodes.length <= cap) return { capped: nodes, dropped: 0 };
+  // Sort by mtime desc (null mtime → oldest).
+  const sorted = nodes.slice().sort((a, b) => {
+    const aT = a.mtime ? Date.parse(a.mtime) : 0;
+    const bT = b.mtime ? Date.parse(b.mtime) : 0;
+    return bT - aT;
+  });
+  return { capped: sorted.slice(0, cap), dropped: nodes.length - cap };
+}
+
+// Edge builder: same source_sha256 frontmatter → connect wiki pages pairwise.
+function buildSha256Edges(wikiPages, includedIds) {
+  const edges = [];
+  const groups = new Map(); // sha256 → [wiki node ids]
+  for (const p of wikiPages) {
+    const sha = p.frontmatter && p.frontmatter.source_sha256;
+    if (typeof sha !== 'string' || sha.length === 0) continue;
+    const id = wikiNodeId(p.rel);
+    if (!includedIds.has(id)) continue;
+    const list = groups.get(sha) || [];
+    list.push(id);
+    groups.set(sha, list);
+  }
+  for (const [sha, ids] of groups) {
+    if (ids.length < 2) continue;
+    const sorted = ids.slice().sort();
+    const shaShort = sha.length > 10 ? `${sha.slice(0, 8)}…` : sha;
+    for (let i = 0; i < sorted.length; i++) {
+      for (let j = i + 1; j < sorted.length; j++) {
+        edges.push({
+          source: sorted[i],
+          target: sorted[j],
+          kind: 'sha256',
+          confidence: EDGE_CONFIDENCE.sha256,
+          hint: `same source_sha256 (${shaShort})`,
+        });
+      }
+    }
+  }
+  return edges;
+}
+
+// Edge builder: derived_from / source frontmatter explicit references.
+// Resolution: 'concepts/jwt' / 'concepts/jwt.md' / 'raw-sources/pdf/foo.pdf' を試行
+// (ref が wiki-relative なら wiki:、raw-sources/ prefix が付いていれば raw: に変換)。
+function buildDerivedFromEdges(wikiPages, includedIds) {
+  const edges = [];
+  for (const p of wikiPages) {
+    const fm = p.frontmatter || {};
+    const refs = collectStringRefs(fm.derived_from).concat(collectStringRefs(fm.source));
+    if (refs.length === 0) continue;
+    const sourceId = wikiNodeId(p.rel);
+    if (!includedIds.has(sourceId)) continue;
+    for (const rawRef of refs) {
+      const targetId = resolveRefToNodeId(rawRef, includedIds);
+      if (!targetId || targetId === sourceId) continue;
+      edges.push({
+        source: sourceId,
+        target: targetId,
+        kind: 'derived_from',
+        confidence: EDGE_CONFIDENCE.derived_from,
+        hint: `frontmatter ref: ${rawRef}`,
+      });
+    }
+  }
+  return edges;
+}
+
+function collectStringRefs(value) {
+  if (typeof value === 'string') return value.trim() ? [value.trim()] : [];
+  if (Array.isArray(value)) {
+    const out = [];
+    for (const v of value) {
+      if (typeof v === 'string' && v.trim()) out.push(v.trim());
+    }
+    return out;
+  }
+  return [];
+}
+
+function resolveRefToNodeId(ref, includedIds) {
+  if (typeof ref !== 'string' || !ref) return null;
+  // Strip ./ prefix, normalize backslashes
+  const clean = ref.replace(/^\.\//, '').replace(/\\/g, '/').replace(/^wiki\//, '').replace(/^raw-sources\//, '');
+  const wantsRaw = /^raw-sources\//.test(ref);
+  const candidates = wantsRaw
+    ? [rawNodeId(clean), rawNodeId(`${clean}.md`)]
+    : [
+      wikiNodeId(clean),
+      wikiNodeId(clean.endsWith('.md') ? clean : `${clean}.md`),
+      rawNodeId(clean),
+    ];
+  for (const c of candidates) {
+    if (includedIds.has(c)) return c;
+  }
+  return null;
+}
+
+// Edge builder: filename / slug 類似で summary ↔ raw-source を接続。
+// "<slug>-summary.md" or "<slug>-notes.md" → "<slug>" raw source.
+function buildFilenameEdges(wikiPages, rawSources, includedIds) {
+  const edges = [];
+  const rawByStem = new Map(); // slug → [{rel}]
+  for (const r of rawSources) {
+    const stem = slugify(r.name);
+    if (!stem) continue;
+    const list = rawByStem.get(stem) || [];
+    list.push(r);
+    rawByStem.set(stem, list);
+  }
+  for (const p of wikiPages) {
+    if (p.type !== 'summary') continue;
+    const stem = summarySlugStem(p.name);
+    if (!stem) continue;
+    const sourceId = wikiNodeId(p.rel);
+    if (!includedIds.has(sourceId)) continue;
+    const matches = rawByStem.get(stem) || [];
+    for (const r of matches) {
+      const targetId = rawNodeId(r.rel);
+      if (!includedIds.has(targetId)) continue;
+      edges.push({
+        source: sourceId,
+        target: targetId,
+        kind: 'filename',
+        confidence: EDGE_CONFIDENCE.filename,
+        hint: `slug match: ${stem}`,
+      });
+    }
+  }
+  return edges;
+}
+
+// Edge builder: wiki page wikilink [[X]] → target wiki node.
+function buildWikilinkEdges(wikiPages, includedIds) {
+  const edges = [];
+  const byRel = new Map();         // 'concepts/jwt.md' → id
+  const byRelNoExt = new Map();    // 'concepts/jwt' → id
+  const byBasename = new Map();    // 'jwt' → id (last writer wins acceptable here)
+  for (const p of wikiPages) {
+    const id = wikiNodeId(p.rel);
+    byRel.set(p.rel, id);
+    byRelNoExt.set(p.rel.replace(/\.md$/, ''), id);
+    byBasename.set(p.name, id);
+  }
+  for (const p of wikiPages) {
+    const sourceId = wikiNodeId(p.rel);
+    if (!includedIds.has(sourceId)) continue;
+    const wikilinks = Array.isArray(p.wikilinks) ? p.wikilinks : [];
+    const seenTargets = new Set();
+    for (const target of wikilinks) {
+      const t = String(target).trim();
+      if (!t) continue;
+      let targetId = byRelNoExt.get(t) || byRel.get(t) || byBasename.get(t);
+      if (!targetId) {
+        const last = t.split('/').pop();
+        targetId = byBasename.get(last);
+      }
+      if (!targetId || targetId === sourceId) continue;
+      if (!includedIds.has(targetId)) continue;
+      if (seenTargets.has(targetId)) continue; // same page → same target は 1 edge
+      seenTargets.add(targetId);
+      edges.push({
+        source: sourceId,
+        target: targetId,
+        kind: 'wikilink',
+        confidence: EDGE_CONFIDENCE.wikilink,
+        hint: `[[${t}]]`,
+      });
+    }
+  }
+  return edges;
+}
+
+// Edge builder: cross-layer mtime proximity (raw ↔ summary or summary ↔ wiki etc.)。
+// Same-layer pairs を skip (wiki-to-wiki proximity はノイズ、authoring session の副作用)。
+function buildTimeEdges(wikiPages, rawSources, includedIds, windowSec) {
+  const entries = [];
+  for (const p of wikiPages) {
+    if (!p.mtime) continue;
+    const id = wikiNodeId(p.rel);
+    if (!includedIds.has(id)) continue;
+    entries.push({ id, layer: layerForWikiPage(p.rel), t: p.mtime.getTime() });
+  }
+  for (const r of rawSources) {
+    if (!r.mtime) continue;
+    const id = rawNodeId(r.rel);
+    if (!includedIds.has(id)) continue;
+    entries.push({ id, layer: 'raw', t: r.mtime.getTime() });
+  }
+  entries.sort((a, b) => a.t - b.t);
+
+  const winMs = windowSec * 1000;
+  const edges = [];
+  for (let i = 0; i < entries.length; i++) {
+    for (let j = i + 1; j < entries.length; j++) {
+      const delta = entries[j].t - entries[i].t;
+      if (delta > winMs) break;
+      if (entries[i].layer === entries[j].layer) continue;
+      const deltaSec = Math.round(delta / 1000);
+      edges.push({
+        source: entries[i].id,
+        target: entries[j].id,
+        kind: 'time',
+        confidence: EDGE_CONFIDENCE.time,
+        hint: `Δ${deltaSec}s mtime proximity (${entries[i].layer}↔${entries[j].layer})`,
+      });
+    }
+  }
+  return edges;
+}
+
+// Same (kind, source, target) は最初のものだけ残す (sha256 と derived_from が同 pair に
+// 共起した場合は両方残す — kind 違いは別の hint として価値があるため)。
+function dedupeEdges(edges) {
+  const seen = new Set();
+  const out = [];
+  for (const e of edges) {
+    const key = `${e.kind}|${e.source}|${e.target}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(e);
+  }
+  return out;
+}
+
+// Return a 1-2 hop subgraph centered on a node id. Intended as a runtime helper for
+// UI integration (HTML embeds the full graph and may call this client-side via a
+// JS port, or server-side for pre-rendered previews).
+//
+// hops: 1 or 2 (default 1)
+// Returns {nodes, edges} — same shapes as buildLineageGraph output.
+export function selectSubgraph(graph, centerId, hops = 1) {
+  if (!graph || !Array.isArray(graph.nodes) || !Array.isArray(graph.edges)) {
+    return { nodes: [], edges: [] };
+  }
+  const maxHops = hops === 2 ? 2 : 1;
+  const nodeById = new Map(graph.nodes.map((n) => [n.id, n]));
+  if (!nodeById.has(centerId)) return { nodes: [], edges: [] };
+
+  const adj = new Map();
+  for (const e of graph.edges) {
+    if (!adj.has(e.source)) adj.set(e.source, []);
+    if (!adj.has(e.target)) adj.set(e.target, []);
+    adj.get(e.source).push(e);
+    adj.get(e.target).push(e);
+  }
+
+  const visited = new Map(); // id → hop depth
+  visited.set(centerId, 0);
+  const queue = [[centerId, 0]];
+  while (queue.length > 0) {
+    const [id, depth] = queue.shift();
+    if (depth >= maxHops) continue;
+    const neighbors = adj.get(id) || [];
+    for (const e of neighbors) {
+      const next = e.source === id ? e.target : e.source;
+      if (visited.has(next)) continue;
+      visited.set(next, depth + 1);
+      queue.push([next, depth + 1]);
+    }
+  }
+
+  const includedIds = new Set(visited.keys());
+  const subNodes = graph.nodes.filter((n) => includedIds.has(n.id));
+  const subEdges = graph.edges.filter((e) => includedIds.has(e.source) && includedIds.has(e.target));
+  return { nodes: subNodes, edges: subEdges };
+}
+
+// Test 用 internals (test 以外から import しないこと)
+export const _internals = {
+  pickLineageFrontmatter,
+  slugify,
+  summarySlugStem,
+  layerForWikiPage,
+  capNodes,
+  buildSha256Edges,
+  buildDerivedFromEdges,
+  buildFilenameEdges,
+  buildWikilinkEdges,
+  buildTimeEdges,
+  dedupeEdges,
+  resolveRefToNodeId,
+  RAW_SOURCE_EXTENSIONS,
+};

--- a/mcp/lib/visualizer-data.mjs
+++ b/mcp/lib/visualizer-data.mjs
@@ -1,0 +1,680 @@
+// visualizer-data.mjs — Phase 1+2+4 v0.8 Visualizer β First view data builder
+//
+// codex strategic doc 260512_v0-8-visualizer-beta-scope.md §Axis 3 §First view
+// Phase 1 (PR #124): 4 layer ordering を構成する:
+//   1. vault_overview  — pages total / summaries growth / page type distribution
+//   2. health_focus    — broken_wikilink / source_sha256_duplicate / pages_warm_zone
+//   3. graph_preview   — hot pages / active projects / recent decisions
+//   4. action_queue    — 3-5 actionable items with priority + next_action
+// Phase 2 (PR #125): 11 metrics を graph/chart に overlay する Health overlay 拡張:
+//   - status_banner    — P1 metrics 6 件を severity 付き chip で表示 (ok/info/warn/danger)
+//   - health_focus.broken_wikilink.clusters — target で group 化、merge candidate view
+//   - health_focus.pages_warm_zone.distribution — fresh/warm/stale 3 bucket gradient
+//   - vault_overview.page_count_by_type.sorted_entries — compact bar chart 用 sort 済み
+//   - auto-lint output は Phase 2 で touch せず、Phase 4 drawer 化 (BLUE-VIZ-HEALTH-OVERLAY-7 で固定)
+// Phase 4 (本 PR): auto-lint 4 観点を補助 drawer として first_view に embed:
+//   - auto_lint        — wiki/lint-report.md を 4 section parse (LLM judgment は graph に断定表示しない)
+//   - 旧 Phase 2 の negative assert (auto_lint 不在) を positive (graceful null OK + drawer card 存在) へ flip
+//   - drawer is 5 枚目 card "Quality notes (auto-lint)"、4 観点を mini-list で表示、詳細は wiki/lint-report.md
+//
+// 設計方針:
+//   - Sprint 2 完走済 collectHealthMetrics() を data source として使う (重複実装しない)
+//   - graph_preview は snapshots[0].pages を優先、空なら live filesystem walk fallback。
+//     real Vault が parent git repo の subdirectory にあると `git show <sha>:wiki/X.md` が
+//     repo-root-relative path mismatch で fail し snapshot が empty になる pre-existing
+//     issue があるため (open-issues §VIZ-LIVE-WALK-FALLBACK 参照)。
+//   - 出力は HTML embed 用に compact 化 (sample 件数を 5 に制限、UI で「more」展開する想定)
+//   - action_queue は metrics 直読で priority 付き構築 (next_actions の string match を避け頑健に)
+//   - auto_lint は LLM judgment のため断定表示しない (PM 答え #3「user trust 落とさない」)。
+//     report 不在 / parse 失敗時は null で graceful degrade、HTML 側で "auto-lint 未実行" を案内
+//
+// Sprint 3 Phase 3 (§46 LEARN#8b N=3 mandatory refactor):
+//   walkLiveWikiPages is now a thin projection over wiki-walker.mjs#walkPages.
+//   The old in-file walk loop and PATH_TO_TYPE map have been removed.
+
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { collectHealthMetrics } from './health-metrics.mjs';
+import { walkPages } from './wiki-walker.mjs';
+
+export const FIRST_VIEW_SCHEMA_VERSION = 2;
+export const AUTO_LINT_SCHEMA_VERSION = 1;
+
+// UI 表示 cap (HTML inline JSON 肥大化防止 + 視覚密度のバランス)
+const SAMPLE_LIMIT = 5;
+const HOT_PAGES_LIMIT = 10;
+const ACTIVE_PROJECTS_LIMIT = 5;
+const RECENT_DECISIONS_LIMIT = 5;
+const ACTION_QUEUE_MAX = 5;
+const BROKEN_CLUSTER_LIMIT = 10; // Phase 2: target 別 cluster の表示上限
+const AUTO_LINT_SAMPLE_LIMIT = 3; // Phase 4: 4 観点各 section の preview sample 件数
+const AUTO_LINT_SAMPLE_MAX_CHARS = 240; // Phase 4: sample 1 件あたり最大文字数 (HTML inline 肥大化防止)
+const AUTO_LINT_MAX_BYTES = 256 * 1024; // Phase 4: lint-report.md 読み込み上限 (異常巨大 file 防御)
+
+// Phase 2 severity thresholds (status_banner で使用)
+//   - hot_md_age: > 7 day で warn, > 30 day で danger
+//   - last_ingest: > 24h で warn, > 7 day で danger
+//   - stale / unprocessed_logs: > 5 で warn
+const SEC_PER_DAY = 24 * 3600;
+const HOT_MD_WARN_DAYS = 7;
+const HOT_MD_DANGER_DAYS = 30;
+const LAST_INGEST_WARN_HOURS = 24;
+const LAST_INGEST_DANGER_DAYS = 7;
+const STALE_WARN_COUNT = 5;
+const UNPROCESSED_LOGS_WARN_COUNT = 5;
+
+// snapshots:  visualizer.mjs が build した snapshot 配列 (newest first 想定)
+// livePages:  事前 walk 済みの page array — テスト経由で snapshot fallback を bypass する用途
+// health   :  collectHealthMetrics 結果。caller が再計算回避のため渡すか、null で再計算
+//
+// graph_preview の page source 優先順位:
+//   1. livePages が array で渡されたらそれを使う (test 経由 / caller が live walk 済)
+//   2. snapshots[0].pages が non-empty なら snapshot 内 page metadata を使う (高速 path)
+//   3. fallback: vault/wiki/ を live walk する (snapshot が repo-root-relative path drift
+//      等で空になっているケース)
+//   4. それでも 0 件なら空 graph_preview
+// autoLint: Phase 4 で追加した補助 input。caller が pre-load した auto_lint object か null。
+//   - undefined (default) → vault から loadAutoLintReport で読む
+//   - null               → 強制的に "report 未存在" として扱う (test 用)
+//   - object             → そのまま first_view に埋め込む (test / mock 用)
+export async function collectFirstViewData(vault, {
+  now = new Date(),
+  snapshots = [],
+  livePages = null,
+  health = null,
+  autoLint = undefined,
+} = {}) {
+  const healthData = health ?? await collectHealthMetrics(vault, { now });
+  const metrics = healthData.metrics;
+
+  const pagesForGraph = await resolvePagesForGraph(vault, snapshots, livePages);
+
+  let resolvedAutoLint;
+  if (autoLint === undefined) {
+    resolvedAutoLint = await loadAutoLintReport(vault).catch(() => null);
+  } else {
+    resolvedAutoLint = autoLint;
+  }
+
+  return {
+    schema_version: FIRST_VIEW_SCHEMA_VERSION,
+    generated_at: now.toISOString(),
+    vault_overview: buildVaultOverview(healthData),
+    health_focus: buildHealthFocus(metrics),
+    graph_preview: buildGraphPreview(pagesForGraph),
+    action_queue: buildActionQueue(metrics),
+    status_banner: buildStatusBanner(metrics),
+    auto_lint: resolvedAutoLint,
+  };
+}
+
+async function resolvePagesForGraph(vault, snapshots, livePages) {
+  if (Array.isArray(livePages)) return livePages;
+  if (Array.isArray(snapshots) && snapshots.length > 0
+      && Array.isArray(snapshots[0].pages) && snapshots[0].pages.length > 0) {
+    return snapshots[0].pages;
+  }
+  if (typeof vault === 'string' && vault.length > 0) {
+    return await walkLiveWikiPages(vault);
+  }
+  return [];
+}
+
+// Layer 1: Vault overview ───────────────────────────────────────────────────
+function buildVaultOverview(healthData) {
+  const m = healthData.metrics;
+  const pct = m.page_count_by_type ?? { total: 0, by_type: {} };
+  // Phase 2: sorted_entries を chart-friendly descending order で同梱。
+  // HTML 側は再 sort 不要、compact bar chart に直接 map できる。
+  const sortedEntries = Object.entries(pct.by_type ?? {})
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
+  return {
+    pages_total: healthData.vault_pages_total,
+    summaries_growth: m.summaries_growth_rate,
+    page_count_by_type: {
+      total: pct.total,
+      by_type: pct.by_type,
+      sorted_entries: sortedEntries,
+    },
+  };
+}
+
+// Layer 2: Health focus (compact 化 + Phase 2 overlay 拡張) ─────────────────
+function buildHealthFocus(metrics) {
+  const broken = metrics.broken_wikilink ?? { count: 0, samples: [], sample_truncated: false };
+  const sha256Dup = metrics.source_sha256_duplicate ?? { count: 0, groups: [] };
+  const warm = metrics.pages_warm_zone ?? { count: 0, lower_days: 7, upper_days: 30, pages: [] };
+  const stale = metrics.stale ?? { count: 0, threshold_days: 30, pages: [] };
+  const pagesTotal = (metrics.page_count_by_type && metrics.page_count_by_type.total) ?? 0;
+
+  // Phase 2: broken_wikilink を target で group 化、merge candidate view を提供。
+  // 各 cluster は { target, sources: [...], inbound_broken_count }。
+  // sort: inbound_broken_count desc → 最も問題の多い target が先頭、target locale 安定 sort。
+  const clusterMap = new Map();
+  for (const s of (broken.samples ?? [])) {
+    if (!s || typeof s.target !== 'string' || typeof s.source !== 'string') continue;
+    const list = clusterMap.get(s.target) ?? [];
+    list.push(s.source);
+    clusterMap.set(s.target, list);
+  }
+  const allClusters = Array.from(clusterMap.entries())
+    .map(([target, sources]) => ({
+      target,
+      sources: sources.slice().sort(),
+      inbound_broken_count: sources.length,
+    }))
+    .sort((a, b) => {
+      if (b.inbound_broken_count !== a.inbound_broken_count) return b.inbound_broken_count - a.inbound_broken_count;
+      return a.target.localeCompare(b.target);
+    });
+  const clusters = allClusters.slice(0, BROKEN_CLUSTER_LIMIT);
+
+  // Phase 2: warm zone distribution (fresh / warm / stale 3 bucket gradient 用)。
+  // fresh は明示的に渡されない (health-metrics は system page 除外で warm/stale を出す)
+  // ので: total_classified = warm + stale + fresh, fresh = pagesTotal - warm - stale - system 除外分
+  // 簡易: fresh = pagesTotal - warm - stale (system page は誤差として許容)
+  const warmCount = warm.count ?? 0;
+  const staleCount = stale.count ?? 0;
+  const fresh = Math.max(0, pagesTotal - warmCount - staleCount);
+  const totalClassified = fresh + warmCount + staleCount;
+
+  return {
+    broken_wikilink: {
+      count: broken.count,
+      samples: (broken.samples ?? []).slice(0, SAMPLE_LIMIT),
+      sample_truncated: broken.sample_truncated || (broken.samples ?? []).length > SAMPLE_LIMIT,
+      clusters,
+      cluster_truncated: allClusters.length > BROKEN_CLUSTER_LIMIT,
+    },
+    source_sha256_duplicate: {
+      count: sha256Dup.count,
+      groups: (sha256Dup.groups ?? []).slice(0, SAMPLE_LIMIT),
+    },
+    pages_warm_zone: {
+      count: warm.count,
+      lower_days: warm.lower_days,
+      upper_days: warm.upper_days,
+      pages: (warm.pages ?? []).slice(0, SAMPLE_LIMIT),
+      distribution: {
+        fresh,
+        warm: warmCount,
+        stale: staleCount,
+        total_classified: totalClassified,
+      },
+    },
+  };
+}
+
+// Layer 3: Graph preview ────────────────────────────────────────────────────
+// page array (snapshot.pages 由来 or live walk 由来) から:
+//   - hot_pages: wikilink in+out degree が高い page top N
+//   - active_projects: type='project' の page top N
+//   - recent_decisions: type='decision' の page top N
+//
+// page shape (snapshot / live walk 両者で共通):
+//   { name, type, title, path, wikilinks }
+//   - wikilinks は array of target string (outgoing wikilink target)
+//   - snapshot 経由 (wiki-snapshot.mjs) は validator 通過済
+//   - live 経由 (walkLiveWikiPages) は findWikilinks 経由、validator 未通過 (display only)
+function buildGraphPreview(pages) {
+  if (!Array.isArray(pages) || pages.length === 0) {
+    return { hot_pages: [], active_projects: [], recent_decisions: [] };
+  }
+
+  // degree counting: outbound wikilink target を resolve して in+out 加算
+  const degreeByName = new Map();
+  for (const p of pages) degreeByName.set(p.name, 0);
+  for (const p of pages) {
+    const wikilinks = Array.isArray(p.wikilinks) ? p.wikilinks : [];
+    for (const target of wikilinks) {
+      const t = typeof target === 'string' ? target.trim() : '';
+      if (!t) continue;
+      let resolved = null;
+      if (degreeByName.has(t)) resolved = t;
+      else {
+        const last = t.split('/').pop();
+        if (last && degreeByName.has(last)) resolved = last;
+      }
+      if (resolved) {
+        degreeByName.set(resolved, degreeByName.get(resolved) + 1);
+        degreeByName.set(p.name, degreeByName.get(p.name) + 1);
+      }
+    }
+  }
+
+  const hotPages = pages
+    .map((p) => ({
+      name: p.name,
+      type: p.type ?? null,
+      title: p.title ?? null,
+      path: p.path ?? null,
+      degree: degreeByName.get(p.name) ?? 0,
+    }))
+    .sort((a, b) => {
+      if (b.degree !== a.degree) return b.degree - a.degree;
+      return a.name.localeCompare(b.name);
+    })
+    .slice(0, HOT_PAGES_LIMIT);
+
+  const activeProjects = pages
+    .filter((p) => p.type === 'project')
+    .map((p) => ({ name: p.name, title: p.title ?? null, path: p.path ?? null, type: 'project' }))
+    .slice(0, ACTIVE_PROJECTS_LIMIT);
+
+  const recentDecisions = pages
+    .filter((p) => p.type === 'decision')
+    .map((p) => ({ name: p.name, title: p.title ?? null, path: p.path ?? null, type: 'decision' }))
+    .slice(0, RECENT_DECISIONS_LIMIT);
+
+  return {
+    hot_pages: hotPages,
+    active_projects: activeProjects,
+    recent_decisions: recentDecisions,
+  };
+}
+
+// Walk vault/wiki/ as a flat page list shaped like snapshot.pages.
+// Implementation now delegates to wiki-walker.mjs (§46 N=3 refactor). The legacy
+// fields preserved for back-compat with tests/visualizer-data.test.mjs:
+//   { name, path: `wiki/<rel>`, type, title|null, wikilinks }
+//
+// Notes:
+//   - title is null (not basename) when neither frontmatter.title nor body H1 exists,
+//     matching the pre-refactor behaviour relied upon by graph_preview UI.
+//   - wikilinks come from findWikilinks() inside walkPages, validator-untouched (display only).
+export async function walkLiveWikiPages(vault) {
+  const walked = await walkPages(vault, {
+    subDir: 'wiki',
+    withFrontmatter: true,
+    withWikilinks: true,
+    withBody: false,
+    withMtime: false,
+  });
+  return walked.map((p) => ({
+    name: p.name,
+    path: `wiki/${p.rel}`,
+    type: p.type,
+    title: (p.frontmatter && typeof p.frontmatter.title === 'string' && p.frontmatter.title.trim())
+      ? p.frontmatter.title.trim()
+      : null,
+    wikilinks: p.wikilinks,
+  }));
+}
+
+// Layer 4: Action queue ─────────────────────────────────────────────────────
+// metrics 直読で priority 付きの actionable item を生成。
+// 健全な vault (全 metric 健全) では 0 件で返す (空配列で「健全」を表現)。
+//
+// priority 配分:
+//   P0 = critical health drift (data quality, ingest pipeline 破綻)
+//   P1 = degrading (放置すると stale 化、cron 詰まり)
+//   P2 = informational (nice to have、構造改善)
+function buildActionQueue(metrics) {
+  const items = [];
+
+  // ── P0: critical health drift ──
+  if (metrics.broken_wikilink && metrics.broken_wikilink.count > 0) {
+    items.push({
+      priority: 'P0',
+      reason: `${metrics.broken_wikilink.count} broken wikilinks ([[X]] target が wiki に存在しない)`,
+      next_action: 'Open dashboard "Broken Links" view, fix orphan link target or link 元 page を整理',
+      command: 'cat wiki/meta/health.md  # see metrics.broken_wikilink.samples',
+    });
+  }
+  if (metrics.source_sha256_duplicate && metrics.source_sha256_duplicate.count > 0) {
+    items.push({
+      priority: 'P0',
+      reason: `${metrics.source_sha256_duplicate.count} source_sha256 duplicate group(s) — 同一 source から重複 page`,
+      next_action: '重複 page を merge or archive (idempotent ingest が壊れている可能性、ingest path を確認)',
+    });
+  }
+
+  // ── P1: degrading items ──
+  if (metrics.pages_warm_zone && metrics.pages_warm_zone.count > 5) {
+    items.push({
+      priority: 'P1',
+      reason: `${metrics.pages_warm_zone.count} pages in warm zone (${metrics.pages_warm_zone.lower_days}-${metrics.pages_warm_zone.upper_days} days)`,
+      next_action: '更新候補が溜まっている。stale 化する前に revisit / 内容更新 / 関連リンク補強',
+    });
+  }
+  if (metrics.stale && metrics.stale.count > 0) {
+    items.push({
+      priority: 'P1',
+      reason: `${metrics.stale.count} pages older than ${metrics.stale.threshold_days} days`,
+      next_action: 'Open dashboard "Stale Pages" view and revisit / update / archive',
+      command: 'open wiki/meta/dashboard.md',
+    });
+  }
+  if (metrics.unprocessed_logs && metrics.unprocessed_logs.count > 5) {
+    items.push({
+      priority: 'P1',
+      reason: `${metrics.unprocessed_logs.count} unprocessed session-logs (ingested:false)`,
+      next_action: 'Run auto-ingest manually, or wait for the next cron tick',
+      command: 'bash scripts/auto-ingest.sh',
+    });
+  }
+  if (metrics.last_ingest && metrics.last_ingest.exists && metrics.last_ingest.age_seconds > 24 * 3600) {
+    items.push({
+      priority: 'P1',
+      reason: `last session-log activity ${metrics.last_ingest.age_human} ago`,
+      next_action: 'session-logger hook が active か確認 (doctor で診断)',
+      command: 'bash scripts/doctor.sh',
+    });
+  }
+
+  // ── P2: informational ──
+  if (metrics.orphan && metrics.orphan.count > 0) {
+    items.push({
+      priority: 'P2',
+      reason: `${metrics.orphan.count} orphan pages (no inbound wikilinks)`,
+      next_action: 'Add wikilinks from related pages, or move to wiki/.archive/ if obsolete',
+    });
+  }
+  if (metrics.duplicate_title && metrics.duplicate_title.count > 0) {
+    items.push({
+      priority: 'P2',
+      reason: `${metrics.duplicate_title.count} duplicate title groups`,
+      next_action: 'Merge or rename duplicate pages — see metrics.duplicate_title.groups',
+    });
+  }
+  if (metrics.hot_md_age && metrics.hot_md_age.exists && metrics.hot_md_age.age_seconds > 7 * 24 * 3600) {
+    items.push({
+      priority: 'P2',
+      reason: `wiki/hot.md last updated ${metrics.hot_md_age.age_human} ago`,
+      next_action: 'Refresh wiki/hot.md, or run a session that triggers PostCompact hook',
+    });
+  }
+  const growth = metrics.summaries_growth_rate;
+  if (growth && growth.vault_is_git === true && growth.day_7.added === 0 && growth.day_30.added === 0) {
+    items.push({
+      priority: 'P2',
+      reason: 'No new summaries added in the last 30 days (ingest pipeline idle?)',
+      next_action: 'PDF/URL ingest cron が回っているか確認、または新規 source を投入',
+      command: 'bash scripts/auto-ingest.sh',
+    });
+  }
+
+  // priority ordering is preserved by insertion order (P0 → P1 → P2) since we
+  // appended in priority groups above. Cap to ACTION_QUEUE_MAX for UI density.
+  return items.slice(0, ACTION_QUEUE_MAX);
+}
+
+// Phase 2: Status banner (P1 metrics の severity 付き chip 表示) ──────────────
+// 6 P1 metric を 1 row banner で一覧、各 chip は severity (ok/info/warn/danger) で着色。
+// severity 判定 rule:
+//   ok       — 健全 (count=0, age 短い等)
+//   info     — 観察対象 (count>0 だが urgent ではない)
+//   warn     — 閾値超え (stale>5, hot_md>7d, unprocessed>5 等)
+//   danger   — 緊急 (last_ingest>7d 等、cron 停止疑い)
+function buildStatusBanner(metrics) {
+  const orphan = metrics.orphan ?? { count: 0, pages: [] };
+  const stale = metrics.stale ?? { count: 0, threshold_days: 30 };
+  const dupTitle = metrics.duplicate_title ?? { count: 0, groups: [] };
+  const hotAge = metrics.hot_md_age ?? { exists: false, age_seconds: null, age_human: null };
+  const lastIngest = metrics.last_ingest ?? { exists: false, log_count: 0, age_seconds: null, age_human: null };
+  const unproc = metrics.unprocessed_logs ?? { count: 0 };
+
+  return {
+    orphan: {
+      count: orphan.count,
+      severity: orphan.count === 0 ? 'ok' : 'info',
+    },
+    stale: {
+      count: stale.count,
+      threshold_days: stale.threshold_days,
+      severity: stale.count === 0 ? 'ok' : (stale.count > STALE_WARN_COUNT ? 'warn' : 'info'),
+    },
+    duplicate_title: {
+      count: dupTitle.count,
+      severity: dupTitle.count === 0 ? 'ok' : 'warn',
+    },
+    hot_md_age: {
+      exists: hotAge.exists,
+      age_seconds: hotAge.age_seconds,
+      age_human: hotAge.age_human,
+      severity: severityFromAge(hotAge.age_seconds, HOT_MD_WARN_DAYS * SEC_PER_DAY, HOT_MD_DANGER_DAYS * SEC_PER_DAY),
+    },
+    last_ingest: {
+      exists: lastIngest.exists,
+      log_count: lastIngest.log_count,
+      age_seconds: lastIngest.age_seconds,
+      age_human: lastIngest.age_human,
+      severity: severityFromAge(lastIngest.age_seconds, LAST_INGEST_WARN_HOURS * 3600, LAST_INGEST_DANGER_DAYS * SEC_PER_DAY),
+    },
+    unprocessed_logs: {
+      count: unproc.count,
+      severity: unproc.count === 0 ? 'ok' : (unproc.count > UNPROCESSED_LOGS_WARN_COUNT ? 'warn' : 'info'),
+    },
+  };
+}
+
+// age_seconds が null / undefined → ok (まだ初期化されていないだけ、urgent ではない)
+// age < warnSec → ok
+// age >= dangerSec → danger
+// 中間 → warn
+function severityFromAge(ageSeconds, warnSec, dangerSec) {
+  if (ageSeconds == null) return 'ok';
+  if (ageSeconds < warnSec) return 'ok';
+  if (ageSeconds >= dangerSec) return 'danger';
+  return 'warn';
+}
+
+// ─── Phase 4: auto-lint drawer loader (wiki/lint-report.md の 4 観点 parse) ───
+//
+// auto-lint script (scripts/auto-lint.sh) は LLM judgment 必須の 4 観点を
+// wiki/lint-report.md に出力する:
+//   - 概念の矛盾
+//   - 概念の splinter
+//   - 専用ページ候補
+//   - 意味的な相互リンク欠落
+//
+// graph に断定表示せず "Quality notes (auto-lint)" 5 枚目 card で補助表示する。
+// report 不在 / parse 失敗 / vault 未指定時は null を返し、HTML 側で
+// "auto-lint 未実行 (run scripts/auto-lint.sh)" メッセージを表示する graceful degrade。
+//
+// LLM 生成 free-form markdown を堅牢に parse するため:
+//   - section heading は `## ` 完全一致 (見出し ASCII 4 観点) で抽出
+//   - 各 section の "finding" は次 `## ` までの本文を行単位で集める
+//   - 1 件 = bullet (`-` / `*` / `1.`) または 空行で区切られた段落 paragraph
+//   - sample 1 件あたり最大 240 char、各 section 最大 3 件 (HTML inline JSON 肥大化防止)
+//
+// 4 観点 schema:
+//   { key, label, count, samples: string[], sample_truncated, count_estimated }
+//   - count は heuristic (bullet 行数 + paragraph 数)、実際の finding 数とは厳密一致しない
+//     → count_estimated: true で UI に "推定" を明示し user trust を保護
+const AUTO_LINT_CATEGORIES = [
+  { key: 'contradiction',       label: '概念の矛盾',             heading: '概念の矛盾' },
+  { key: 'splinter',            label: '概念の splinter',        heading: '概念の splinter' },
+  { key: 'promotion_candidate', label: '専用ページ候補',         heading: '専用ページ候補' },
+  { key: 'link_gap',            label: '意味的な相互リンク欠落', heading: '意味的な相互リンク欠落' },
+];
+
+export async function loadAutoLintReport(vault) {
+  if (typeof vault !== 'string' || vault.length === 0) return null;
+  const reportPath = join(vault, 'wiki', 'lint-report.md');
+
+  let raw;
+  try {
+    raw = await readFile(reportPath, 'utf8');
+  } catch (err) {
+    if (err && err.code === 'ENOENT') return null;
+    return null;
+  }
+
+  if (typeof raw !== 'string' || raw.length === 0) return null;
+  const text = raw.length > AUTO_LINT_MAX_BYTES ? raw.slice(0, AUTO_LINT_MAX_BYTES) : raw;
+  const truncated = raw.length > AUTO_LINT_MAX_BYTES;
+
+  const frontmatterDate = extractFrontmatterDate(text);
+  const sections = extractMarkdownSections(text);
+  const categories = AUTO_LINT_CATEGORIES.map((cat) => buildAutoLintCategory(cat, sections));
+  const totalFindings = categories.reduce((sum, c) => sum + c.count, 0);
+
+  return {
+    schema_version: AUTO_LINT_SCHEMA_VERSION,
+    report_exists: true,
+    source_path: 'wiki/lint-report.md',
+    generated_at: frontmatterDate,
+    total_findings: totalFindings,
+    categories,
+    source_truncated: truncated,
+  };
+}
+
+// frontmatter から `date:` を読み取る。なければ null。
+function extractFrontmatterDate(text) {
+  if (!text.startsWith('---')) return null;
+  const end = text.indexOf('\n---', 3);
+  if (end < 0) return null;
+  const block = text.slice(3, end);
+  const match = block.match(/^\s*date\s*:\s*(.+?)\s*$/m);
+  if (!match) return null;
+  const value = match[1].replace(/^['"]|['"]$/g, '').trim();
+  return value.length > 0 ? value : null;
+}
+
+// `## <heading>` ブロックを map<heading, body> として抽出する。
+// heading は trim + 余分な markdown 記号 (`(`含む補足) を除去して完全一致比較できる形に。
+// body は次 `## ` までの行群。R1 や 要約 など想定外 heading は無視 (4 観点のみ extract)。
+function extractMarkdownSections(text) {
+  const lines = text.split(/\r?\n/);
+  const map = new Map();
+  let currentKey = null;
+  let buffer = [];
+  for (const line of lines) {
+    const match = line.match(/^##\s+(.+?)\s*$/);
+    if (match) {
+      if (currentKey !== null) map.set(currentKey, buffer.join('\n'));
+      currentKey = normalizeHeading(match[1]);
+      buffer = [];
+    } else if (currentKey !== null) {
+      buffer.push(line);
+    }
+  }
+  if (currentKey !== null) map.set(currentKey, buffer.join('\n'));
+  return map;
+}
+
+function normalizeHeading(raw) {
+  // "R1: Unicode 不可視文字 (prompt injection 監査)" → "R1: Unicode 不可視文字"
+  // 4 観点 heading は paren を含まないので、`(` 以降の補足を除去するだけで一致可能。
+  return raw.split('(')[0].trim();
+}
+
+function buildAutoLintCategory(catSpec, sections) {
+  const body = sections.get(catSpec.heading);
+  if (!body) {
+    return {
+      key: catSpec.key,
+      label: catSpec.label,
+      heading: catSpec.heading,
+      count: 0,
+      samples: [],
+      sample_truncated: false,
+      count_estimated: true,
+    };
+  }
+  const findings = parseFindings(body);
+  const samples = findings
+    .slice(0, AUTO_LINT_SAMPLE_LIMIT)
+    .map((f) => truncateSample(f));
+  return {
+    key: catSpec.key,
+    label: catSpec.label,
+    heading: catSpec.heading,
+    count: findings.length,
+    samples,
+    sample_truncated: findings.length > AUTO_LINT_SAMPLE_LIMIT,
+    count_estimated: true,
+  };
+}
+
+// section 本文から finding 1 件 = 1 string の配列へ分割。
+// LLM 出力は揺らぐので 3 戦略を順に適用:
+//   1. top-level bullet (`- ` / `* ` / `1. `) を 1 件として捉える
+//   2. bullet が無ければ blank 行で区切った paragraph を 1 件として捉える
+//   3. paragraph も無ければ全体を 1 件として捉える (空でない場合)
+// "(検出なし)" 等の no-finding marker は除外し count=0 を返す。
+function parseFindings(body) {
+  const trimmed = body.trim();
+  if (trimmed.length === 0) return [];
+  if (isNoFindingMarker(trimmed)) return [];
+
+  const lines = trimmed.split(/\r?\n/);
+
+  // 1. top-level bullet 抽出 (子 bullet は同じ finding に含める)
+  const bullets = [];
+  let currentBullet = null;
+  for (const line of lines) {
+    const bulletMatch = line.match(/^(?:[-*+]|\d+\.)\s+(.*)$/);
+    const isIndentedContinuation = /^(?:\s{2,}|\t)/.test(line) && currentBullet !== null;
+    if (bulletMatch) {
+      if (currentBullet !== null) bullets.push(currentBullet.trim());
+      currentBullet = bulletMatch[1];
+    } else if (isIndentedContinuation) {
+      currentBullet += ' ' + line.trim();
+    } else if (currentBullet !== null && line.trim() === '') {
+      // blank line ends current bullet
+      bullets.push(currentBullet.trim());
+      currentBullet = null;
+    }
+  }
+  if (currentBullet !== null) bullets.push(currentBullet.trim());
+  const filteredBullets = bullets.filter((b) => b.length > 0 && !isNoFindingMarker(b));
+  if (filteredBullets.length > 0) return filteredBullets;
+
+  // 2. paragraph 抽出 (blank 行 区切り)
+  const paragraphs = trimmed
+    .split(/\r?\n\s*\r?\n/)
+    .map((p) => p.replace(/\s+/g, ' ').trim())
+    .filter((p) => p.length > 0 && !isNoFindingMarker(p));
+  if (paragraphs.length > 0) return paragraphs;
+
+  // 3. fallback: 全体を 1 件として返す
+  const collapsed = trimmed.replace(/\s+/g, ' ').trim();
+  return collapsed.length > 0 ? [collapsed] : [];
+}
+
+function isNoFindingMarker(text) {
+  // auto-lint.sh prompt は LLM に「検出なし」「(該当なし)」等を書かせる可能性がある
+  return /^[(（]?\s*(検出なし|該当なし|なし|none|n\/a)\s*[)）]?\s*\.?$/i.test(text.trim());
+}
+
+function truncateSample(s) {
+  if (typeof s !== 'string') return '';
+  const collapsed = s.replace(/\s+/g, ' ').trim();
+  if (collapsed.length <= AUTO_LINT_SAMPLE_MAX_CHARS) return collapsed;
+  return collapsed.slice(0, AUTO_LINT_SAMPLE_MAX_CHARS - 1) + '…';
+}
+
+// Test 用 internals (test 以外から import しないこと)
+export const _internals = {
+  SAMPLE_LIMIT,
+  HOT_PAGES_LIMIT,
+  ACTIVE_PROJECTS_LIMIT,
+  RECENT_DECISIONS_LIMIT,
+  ACTION_QUEUE_MAX,
+  BROKEN_CLUSTER_LIMIT,
+  AUTO_LINT_SAMPLE_LIMIT,
+  AUTO_LINT_SAMPLE_MAX_CHARS,
+  AUTO_LINT_MAX_BYTES,
+  AUTO_LINT_CATEGORIES,
+  HOT_MD_WARN_DAYS,
+  HOT_MD_DANGER_DAYS,
+  LAST_INGEST_WARN_HOURS,
+  LAST_INGEST_DANGER_DAYS,
+  STALE_WARN_COUNT,
+  UNPROCESSED_LOGS_WARN_COUNT,
+  buildVaultOverview,
+  buildHealthFocus,
+  buildGraphPreview,
+  buildActionQueue,
+  buildStatusBanner,
+  severityFromAge,
+  resolvePagesForGraph,
+  extractFrontmatterDate,
+  extractMarkdownSections,
+  parseFindings,
+  isNoFindingMarker,
+  truncateSample,
+};

--- a/mcp/lib/wiki-walker.mjs
+++ b/mcp/lib/wiki-walker.mjs
@@ -1,0 +1,210 @@
+// wiki-walker.mjs — Shared vault filesystem walker for wiki / raw-sources / summaries.
+//
+// §46 LEARN#8b N=3 mandatory refactor (open-issues §46) — Sprint 3 Phase 3 trigger.
+// Three call sites converged on the same walk logic:
+//   1. health-metrics.mjs#listWikiPages + readPageMeta  (11 metrics 計算用)
+//   2. visualizer-data.mjs#walkLiveWikiPages            (first view graph_preview 用)
+//   3. lineage-graph.mjs (Phase 3 NEW)                  (raw-sources / summaries / wiki 3 layer)
+//
+// Unified return shape (per file, when withBody=true the body/text fields are populated):
+//   {
+//     abs,           string  — absolute path
+//     rel,           string  — relative to subDir root, posix slash
+//     name,          string  — basename without extension
+//     type,          string  — inferPageType(rel, frontmatter)
+//     title,         string  — frontmatter.title > body H1 > basename
+//     frontmatter?,  object  — parsed YAML frontmatter (only when withFrontmatter)
+//     wikilinks?,    string[] — [[X]] targets (only when withWikilinks)
+//     body?,         string  — body after frontmatter strip (only when withBody)
+//     text?,         string  — raw file content (only when withBody)
+//     mtime?,        Date    — fs.stat mtime (only when withMtime)
+//   }
+//
+// Design contract:
+//   - Read-only walk. Never writes anywhere in the vault.
+//   - Corrupt / unreadable files are skipped silently (matches existing readPageMeta behaviour).
+//   - Excluded dirs match existing kioku_list / health-metrics EXCLUDE set (.obsidian /
+//     .archive / .trash / templates / .cache) plus dotfile-prefix skip.
+//   - subDir nonexistent → returns [] (graceful: empty raw-sources/ in fresh vaults).
+
+import { readFile, readdir, stat } from 'node:fs/promises';
+import { basename, join, relative, sep } from 'node:path';
+
+import { parseFrontmatter } from './frontmatter.mjs';
+import { findWikilinks } from './wikilinks.mjs';
+
+export const DEFAULT_EXCLUDE_DIRS = Object.freeze(
+  new Set(['.obsidian', '.archive', '.trash', 'templates', '.cache']),
+);
+
+// wiki/ subdirectory naming convention. Used by inferPageType when frontmatter.type
+// is missing — keeps backwards compat with the previously duplicated DIR_TO_TYPE
+// (health-metrics.mjs) and PATH_TO_TYPE (visualizer-data.mjs).
+const SUBDIR_TO_TYPE = Object.freeze({
+  concepts: 'concept',
+  projects: 'project',
+  decisions: 'decision',
+  summaries: 'summary',
+  analyses: 'analysis',
+  patterns: 'pattern',
+  bugs: 'bug',
+  meta: 'meta',
+  viz: 'viz',
+  people: 'person',
+  sources: 'source',
+});
+
+// Resolve a wiki page type. Priority: special root files > frontmatter.type > subdir name > 'other'.
+// Pass null/undefined frontmatter for raw-source files (no frontmatter expected).
+export function inferPageType(rel, frontmatter) {
+  if (rel === 'index.md') return 'index';
+  if (rel === 'log.md') return 'log';
+  if (rel === 'hot.md') return 'hot';
+  const fmType = frontmatter && frontmatter.type;
+  if (typeof fmType === 'string' && fmType.trim()) return fmType.trim();
+  const top = rel.split('/')[0];
+  if (SUBDIR_TO_TYPE[top]) return SUBDIR_TO_TYPE[top];
+  return 'other';
+}
+
+// Title resolution: frontmatter.title → body first H1 → basename (sans extension).
+// Body is optional — when omitted the H1 step is skipped.
+export function resolvePageTitle(rel, frontmatter, body) {
+  const fmTitle = frontmatter && frontmatter.title;
+  if (typeof fmTitle === 'string' && fmTitle.trim()) return fmTitle.trim();
+  if (typeof body === 'string' && body.length > 0) {
+    const h1 = body.match(/^#\s+(.+?)\s*$/m);
+    if (h1) return h1[1].trim();
+  }
+  return stripExtension(basename(rel));
+}
+
+function stripExtension(name) {
+  const idx = name.lastIndexOf('.');
+  if (idx <= 0) return name; // no ext or dotfile only
+  return name.slice(0, idx);
+}
+
+// Walk a vault subdir recursively, returning page metadata.
+//
+// vault     — absolute vault path
+// options:
+//   subDir          — relative to vault (default 'wiki')
+//   excludeDirs     — Set of directory names to skip (default DEFAULT_EXCLUDE_DIRS)
+//   extensions      — file extensions to collect (default ['.md']); raw-sources lineage
+//                     call uses ['.md', '.pdf', '.epub', '.docx', '.txt']
+//   withFrontmatter — parse YAML frontmatter (default true; ignored for non-.md files)
+//   withWikilinks   — findWikilinks on text (default true; ignored for non-.md files)
+//   withBody        — include text + body fields (default false)
+//   withMtime       — include fs.stat mtime field (default false)
+export async function walkPages(vault, options = {}) {
+  if (typeof vault !== 'string' || !vault) return [];
+
+  const subDir = typeof options.subDir === 'string' ? options.subDir : 'wiki';
+  const excludeDirs = options.excludeDirs instanceof Set ? options.excludeDirs : DEFAULT_EXCLUDE_DIRS;
+  const extensions = Array.isArray(options.extensions) && options.extensions.length > 0
+    ? options.extensions
+    : ['.md'];
+  const extSet = new Set(extensions.map((e) => e.toLowerCase()));
+  const withFrontmatter = options.withFrontmatter !== false;
+  const withWikilinks = options.withWikilinks !== false;
+  const withBody = options.withBody === true;
+  const withMtime = options.withMtime === true;
+
+  const rootDir = join(vault, subDir);
+  let baseStat;
+  try {
+    baseStat = await stat(rootDir);
+  } catch (err) {
+    if (err && err.code === 'ENOENT') return [];
+    throw err;
+  }
+  if (!baseStat.isDirectory()) return [];
+
+  const out = [];
+  async function walk(absDir) {
+    let entries;
+    try {
+      entries = await readdir(absDir, { withFileTypes: true });
+    } catch (err) {
+      if (err && err.code === 'ENOENT') return;
+      throw err;
+    }
+    for (const ent of entries) {
+      if (ent.name.startsWith('.')) continue;
+      if (excludeDirs.has(ent.name)) continue;
+      const abs = join(absDir, ent.name);
+      if (ent.isDirectory()) {
+        await walk(abs);
+        continue;
+      }
+      if (!ent.isFile()) continue;
+
+      const lowerName = ent.name.toLowerCase();
+      const dotIdx = lowerName.lastIndexOf('.');
+      const ext = dotIdx > 0 ? lowerName.slice(dotIdx) : '';
+      if (!extSet.has(ext)) continue;
+      const isMarkdown = ext === '.md';
+
+      let text = null;
+      let st = null;
+      try {
+        if (isMarkdown && (withBody || withFrontmatter || withWikilinks)) {
+          text = await readFile(abs, 'utf8');
+        }
+        if (withMtime) {
+          st = await stat(abs);
+        }
+      } catch {
+        // Corrupt / unreadable → skip silently (preserves existing readPageMeta contract).
+        continue;
+      }
+
+      const rel = relative(rootDir, abs).split(sep).join('/');
+      const name = stripExtension(basename(rel));
+
+      let frontmatter = null;
+      let body = '';
+      if (text != null) {
+        const parsed = parseFrontmatter(text);
+        frontmatter = parsed.data || {};
+        body = parsed.body || '';
+      }
+      const type = inferPageType(rel, frontmatter);
+      const title = resolvePageTitle(rel, frontmatter, body);
+      const wikilinks = withWikilinks && isMarkdown && text != null ? findWikilinks(text) : null;
+
+      const page = { abs, rel, name, type, title };
+      if (withFrontmatter) page.frontmatter = frontmatter || {};
+      if (withWikilinks) page.wikilinks = wikilinks || [];
+      if (withBody) {
+        page.text = text != null ? text : '';
+        page.body = body;
+      }
+      if (withMtime && st) page.mtime = st.mtime;
+      out.push(page);
+    }
+  }
+  await walk(rootDir);
+  return out;
+}
+
+// Convenience: legacy-shape adapter used by health-metrics._internals for back-compat
+// (tests/health-metrics.test.mjs invokes healthInternals.listWikiPages).
+//
+// Returns: [{abs, rel}]  — no metadata, matches the prior listWikiPages signature.
+export async function listMarkdownRefs(vault, options = {}) {
+  const pages = await walkPages(vault, {
+    ...options,
+    withFrontmatter: false,
+    withWikilinks: false,
+    withBody: false,
+    withMtime: false,
+  });
+  return pages.map((p) => ({ abs: p.abs, rel: p.rel }));
+}
+
+export const _internals = {
+  SUBDIR_TO_TYPE,
+  stripExtension,
+};

--- a/mcp/manifest.json
+++ b/mcp/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "kioku-wiki",
   "display_name": "KIOKU Wiki",
-  "version": "0.7.5",
+  "version": "0.8.0",
   "description": "Read, search, and write your KIOKU Obsidian Wiki from Claude Desktop or Claude Code.",
   "long_description": "KIOKU is a personal knowledge base ('second brain') built on top of an Obsidian Vault. This MCP server exposes eleven tools (kioku_search, kioku_read, kioku_list, kioku_write_note, kioku_write_wiki, kioku_delete, kioku_ingest_pdf, kioku_ingest_url, kioku_ingest_document, kioku_generate_viz, kioku_health) so that Claude Desktop and Claude Code can browse and update the Wiki without leaving the chat. All operations are local stdio — nothing leaves your machine. See https://github.com/megaphone-tokyo/kioku for the full project.",
   "author": {

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kioku-mcp",
-  "version": "0.7.5",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kioku-mcp",
-      "version": "0.7.5",
+      "version": "0.8.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "~1.29.0",
         "@mozilla/readability": "^0.6.0",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kioku-mcp",
-  "version": "0.7.5",
+  "version": "0.8.0",
   "private": true,
   "type": "module",
   "description": "KIOKU local MCP server (Wiki read/list/search/write_note/write_wiki/delete) for Claude Desktop and Claude Code.",

--- a/mcp/templates/viz-template.html
+++ b/mcp/templates/viz-template.html
@@ -4,14 +4,17 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <!--
-  KIOKU Wiki Visualizer (Phase D α v0.7)
+  KIOKU Wiki Visualizer (Phase 1+2 v0.8 β / Phase D α v0.7)
   正典: tools/claude-brain/plan/claude/26042402_visualizer-concept-sketch.md
+       + tools/claude-brain/plan/codex/260512_v0-8-visualizer-beta-scope.md (Sprint 3 β scope)
 
   Security / Trust posture:
     - self-contained HTML (外部 network 呼び出し 0)
     - data は frontmatter + wikilink のみ、page body は含まない (plan P1 絶対契約)
     - innerHTML 一切使用しない (clearing は while-removeChild、追加は createElement + textContent)
     - data は <script type="application/json"> に inline、tool 側で </  / U+2028 / U+2029 escape 済
+    - Phase 2 で追加した bar chart / sparkline / warm zone gradient は全て CSS + DOM のみ
+      (svg / canvas / external chart lib 一切使わず HTML self-contained 性を担保)
 -->
 <title>KIOKU Wiki Visualizer</title>
 <style>
@@ -132,6 +135,493 @@
     font-size: 12px;
     color: #ffcc9a;
   }
+
+  /* ─── Overview (first view, Sprint 3 v0.8 β) ─── */
+  .overview-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 12px;
+  }
+  .overview-card {
+    background: var(--panel);
+    border: 1px solid var(--panel-edge);
+    border-radius: 8px;
+    padding: 14px 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    min-height: 200px;
+  }
+  .overview-card h2 {
+    margin: 0 0 4px 0;
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--accent);
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+  .overview-card .big-num {
+    font-size: 32px;
+    font-weight: 600;
+    color: var(--fg);
+    line-height: 1;
+    font-variant-numeric: tabular-nums;
+  }
+  .overview-card .sub-num { color: var(--muted); font-size: 12px; }
+  .overview-card .row {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 8px;
+    font-size: 13px;
+  }
+  .overview-card .row .label { color: var(--muted); font-size: 12px; }
+  .overview-card .row .value {
+    color: var(--fg);
+    font-weight: 500;
+    font-variant-numeric: tabular-nums;
+  }
+  .overview-card ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .overview-card li { font-size: 12px; color: var(--fg); }
+  .overview-card .chip {
+    display: inline-block;
+    padding: 2px 6px;
+    border-radius: 4px;
+    background: #22262f;
+    color: var(--muted);
+    font-size: 11px;
+    margin-right: 4px;
+    font-variant-numeric: tabular-nums;
+  }
+  .overview-card .chip.danger { background: #4a1c1c; color: #ffb3b3; }
+  .overview-card .chip.warn   { background: #4a3a18; color: #ffd9a3; }
+  .overview-card .chip.ok     { background: #1c4a2c; color: #b8f0c8; }
+  .overview-card .priority-P0 { color: var(--removed); font-weight: 600; }
+  .overview-card .priority-P1 { color: var(--modified); font-weight: 600; }
+  .overview-card .priority-P2 { color: var(--muted);   font-weight: 600; }
+  .overview-card .action-item {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 6px 0;
+    border-bottom: 1px solid var(--panel-edge);
+  }
+  .overview-card .action-item:last-child { border-bottom: none; }
+  .overview-card .action-reason { color: var(--fg); font-size: 12px; line-height: 1.4; }
+  .overview-card .action-next   { color: var(--muted); font-size: 11px; line-height: 1.4; }
+  .overview-card .action-cmd {
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", Monaco, Menlo, Consolas, monospace;
+    font-size: 11px;
+    color: var(--accent);
+    background: #161a22;
+    padding: 2px 6px;
+    border-radius: 3px;
+    display: inline-block;
+    word-break: break-all;
+  }
+  .overview-card .empty {
+    color: var(--muted);
+    font-size: 12px;
+    font-style: italic;
+  }
+
+  /* ─── Phase 2: Health overlay (status banner + bar chart + sparkline + warm gradient + cluster) ─── */
+  .status-banner {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    padding: 8px 12px;
+    background: var(--panel);
+    border: 1px solid var(--panel-edge);
+    border-radius: 8px;
+    margin-bottom: 12px;
+    font-size: 12px;
+  }
+  .status-banner .sb-chip {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 4px;
+    padding: 4px 8px;
+    border-radius: 6px;
+    background: #22262f;
+    border: 1px solid var(--panel-edge);
+    color: var(--muted);
+    font-variant-numeric: tabular-nums;
+  }
+  .status-banner .sb-chip .sb-label { font-size: 11px; }
+  .status-banner .sb-chip .sb-value { color: var(--fg); font-weight: 600; }
+  .status-banner .sb-chip.sev-ok      { border-color: #2a4a3a; color: #b8f0c8; }
+  .status-banner .sb-chip.sev-info    { border-color: #2a3a4a; color: #b8d4f0; }
+  .status-banner .sb-chip.sev-warn    { border-color: #4a3a18; background: #2a2218; color: #ffd9a3; }
+  .status-banner .sb-chip.sev-danger  { border-color: #4a1c1c; background: #2a1414; color: #ffb3b3; }
+
+  /* page_count_by_type compact bar chart */
+  .bar-chart { display: flex; flex-direction: column; gap: 3px; margin-top: 4px; }
+  .bar-chart .bc-row {
+    display: grid;
+    grid-template-columns: 70px 1fr 32px;
+    gap: 6px;
+    align-items: center;
+    font-size: 11px;
+  }
+  .bar-chart .bc-label { color: var(--muted); text-align: right; }
+  .bar-chart .bc-bar {
+    height: 10px;
+    background: #22262f;
+    border-radius: 3px;
+    overflow: hidden;
+    position: relative;
+  }
+  .bar-chart .bc-bar-fill {
+    height: 100%;
+    background: var(--accent);
+    border-radius: 3px;
+  }
+  .bar-chart .bc-value { color: var(--fg); font-variant-numeric: tabular-nums; text-align: right; }
+
+  /* summaries growth sparkline (7d / 30d simple bars) */
+  .sparkline { display: flex; gap: 6px; align-items: flex-end; height: 36px; padding: 4px 0; }
+  .sparkline .spark-col {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+    flex: 1;
+  }
+  .sparkline .spark-bar {
+    width: 100%;
+    max-width: 36px;
+    background: var(--accent);
+    border-radius: 2px 2px 0 0;
+    min-height: 2px;
+  }
+  .sparkline .spark-label { color: var(--muted); font-size: 10px; }
+  .sparkline .spark-value { color: var(--fg); font-size: 10px; font-variant-numeric: tabular-nums; }
+
+  /* warm zone gradient (fresh / warm / stale 3 bucket) */
+  .warm-gradient {
+    display: flex;
+    height: 16px;
+    border-radius: 4px;
+    overflow: hidden;
+    margin-top: 6px;
+    border: 1px solid var(--panel-edge);
+  }
+  .warm-gradient .wg-seg {
+    height: 100%;
+    transition: width 0.2s ease;
+  }
+  .warm-gradient .wg-seg.fresh { background: linear-gradient(to right, #4cd07d, #6ed09a); }
+  .warm-gradient .wg-seg.warm  { background: linear-gradient(to right, #ffcc5c, #ffb840); }
+  .warm-gradient .wg-seg.stale { background: linear-gradient(to right, #ff8a5c, #ff6b6b); }
+  .warm-gradient-legend {
+    display: flex;
+    justify-content: space-between;
+    margin-top: 4px;
+    font-size: 10px;
+    color: var(--muted);
+    font-variant-numeric: tabular-nums;
+  }
+  .warm-gradient-legend .wg-leg-fresh { color: #b8f0c8; }
+  .warm-gradient-legend .wg-leg-warm  { color: #ffd9a3; }
+  .warm-gradient-legend .wg-leg-stale { color: #ffb3b3; }
+
+  /* broken_wikilink cluster + sha256_dup merge candidate */
+  .cluster-list { display: flex; flex-direction: column; gap: 6px; margin-top: 4px; }
+  .cluster-list .cluster-item {
+    background: #161a22;
+    border: 1px solid var(--panel-edge);
+    border-radius: 4px;
+    padding: 5px 8px;
+    font-size: 11px;
+  }
+  .cluster-list .cluster-target {
+    color: var(--removed);
+    font-family: ui-monospace, SFMono-Regular, Monaco, monospace;
+    font-size: 11px;
+    word-break: break-all;
+  }
+  .cluster-list .cluster-meta { color: var(--muted); font-size: 10px; margin-top: 2px; }
+  .cluster-list .cluster-sources {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    margin-top: 3px;
+  }
+  .cluster-list .cluster-source {
+    color: var(--muted);
+    font-size: 10px;
+    font-family: ui-monospace, SFMono-Regular, Monaco, monospace;
+    word-break: break-all;
+  }
+
+  /* ─── Sprint 3 Phase 4: Quality notes drawer (auto-lint 4 観点 補助表示) ─── */
+  /* graph に断定表示せず "Quality notes" card で補助表示する設計 (PM 答え #3)。
+     report 不在時は "auto-lint 未実行" 案内、parse 成功時は 4 観点を mini-list で展示。 */
+  .qn-disclosure {
+    color: var(--muted);
+    font-size: 10px;
+    font-style: italic;
+    margin: 2px 0 6px 0;
+    line-height: 1.4;
+  }
+  .qn-meta {
+    color: var(--muted);
+    font-size: 10px;
+    margin-bottom: 4px;
+    font-variant-numeric: tabular-nums;
+  }
+  .qn-categories {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin-top: 4px;
+  }
+  .qn-cat {
+    background: #161a22;
+    border: 1px solid var(--panel-edge);
+    border-radius: 4px;
+    padding: 5px 8px;
+    font-size: 11px;
+  }
+  .qn-cat-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 6px;
+    color: var(--fg);
+    font-size: 11px;
+  }
+  .qn-cat-label {
+    color: var(--accent);
+    font-weight: 600;
+    letter-spacing: 0.02em;
+  }
+  .qn-cat-count {
+    color: var(--muted);
+    font-size: 10px;
+    font-variant-numeric: tabular-nums;
+  }
+  .qn-cat-count.qn-empty { color: #6e7c4a; }
+  .qn-samples {
+    list-style: disc;
+    padding-left: 16px;
+    margin: 4px 0 0 0;
+    color: var(--muted);
+    font-size: 10px;
+    line-height: 1.5;
+  }
+  .qn-samples li {
+    font-size: 10px;
+    color: var(--muted);
+    word-break: break-word;
+  }
+  .qn-truncated-note {
+    color: #8a8a8a;
+    font-size: 9px;
+    font-style: italic;
+    margin-top: 2px;
+  }
+  .qn-source-link {
+    display: inline-block;
+    margin-top: 6px;
+    font-size: 10px;
+    color: var(--accent);
+    text-decoration: none;
+    word-break: break-all;
+  }
+  .qn-source-link:hover { text-decoration: underline; }
+  .qn-missing {
+    color: var(--muted);
+    font-size: 11px;
+    line-height: 1.5;
+  }
+  .qn-missing code {
+    font-family: ui-monospace, SFMono-Regular, Monaco, monospace;
+    background: #161a22;
+    color: var(--accent);
+    padding: 1px 5px;
+    border-radius: 3px;
+    font-size: 10px;
+  }
+
+  /* ─── Sprint 3 Phase 3: Lineage tab (raw-sources → summaries → wiki best-effort graph) ─── */
+  .ln-banner {
+    margin: 0 0 12px 0;
+    padding: 8px 12px;
+    border: 1px solid #3a3a18;
+    background: #1f1f10;
+    color: #ffd9a3;
+    border-radius: 4px;
+    font-size: 12px;
+    line-height: 1.5;
+  }
+  .ln-banner b { color: #ffe9c0; }
+  .ln-controls {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+    margin-bottom: 8px;
+  }
+  .ln-controls label { font-size: 12px; color: var(--muted); }
+  .ln-controls input[type="search"],
+  .ln-controls select {
+    background: var(--panel);
+    color: var(--fg);
+    border: 1px solid var(--panel-edge);
+    padding: 4px 6px;
+    border-radius: 3px;
+    font-size: 12px;
+  }
+  .ln-summary {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+    margin-bottom: 10px;
+    font-size: 11px;
+  }
+  .ln-summary .ln-totals {
+    display: flex; gap: 8px;
+    padding: 4px 8px;
+    border: 1px solid var(--panel-edge);
+    background: var(--panel);
+    border-radius: 3px;
+  }
+  .ln-summary .ln-edge-counts { display: flex; gap: 6px; }
+  .ln-edge-chip {
+    padding: 2px 6px;
+    border-radius: 3px;
+    border: 1px solid var(--panel-edge);
+    background: #181818;
+    color: var(--muted);
+  }
+  .ln-edge-chip b { color: var(--fg); }
+  .ln-edge-chip.kind-sha256       { border-color: #2a4a3a; }
+  .ln-edge-chip.kind-derived_from { border-color: #2a4a3a; }
+  .ln-edge-chip.kind-wikilink     { border-color: #2a3a4a; }
+  .ln-edge-chip.kind-filename     { border-color: #4a3a18; }
+  .ln-edge-chip.kind-time         { border-color: #4a2a4a; }
+
+  .ln-layout {
+    display: grid;
+    grid-template-columns: minmax(220px, 30%) 1fr;
+    gap: 12px;
+    min-height: 300px;
+  }
+  .ln-node-list {
+    border: 1px solid var(--panel-edge);
+    background: var(--panel);
+    padding: 6px;
+    border-radius: 4px;
+    max-height: 480px;
+    overflow-y: auto;
+    font-size: 12px;
+  }
+  .ln-node-row {
+    display: flex;
+    gap: 6px;
+    align-items: center;
+    padding: 4px 6px;
+    border-radius: 3px;
+    cursor: pointer;
+  }
+  .ln-node-row:hover { background: #1f2530; }
+  .ln-node-row.selected { background: #2a3a4a; }
+  .ln-node-row .ln-layer-pill {
+    display: inline-block;
+    min-width: 56px;
+    padding: 1px 6px;
+    border-radius: 999px;
+    font-size: 10px;
+    text-align: center;
+    color: var(--fg);
+    border: 1px solid var(--panel-edge);
+  }
+  .ln-layer-raw     { background: #1f1f10; border-color: #4a3a18; color: #ffd9a3; }
+  .ln-layer-summary { background: #102018; border-color: #2a4a3a; color: #b8f0c8; }
+  .ln-layer-wiki    { background: #101820; border-color: #2a3a4a; color: #b8d4f0; }
+  .ln-node-row .ln-name {
+    font-family: ui-monospace, SFMono-Regular, Monaco, monospace;
+    color: var(--fg);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    flex: 1;
+  }
+  .ln-detail {
+    border: 1px solid var(--panel-edge);
+    background: var(--panel);
+    padding: 12px;
+    border-radius: 4px;
+    font-size: 12px;
+    overflow-y: auto;
+    max-height: 480px;
+  }
+  .ln-detail h3 {
+    margin: 0 0 6px 0;
+    font-size: 14px;
+    color: var(--fg);
+  }
+  .ln-detail .ln-path {
+    font-family: ui-monospace, SFMono-Regular, Monaco, monospace;
+    color: var(--muted);
+    font-size: 11px;
+    margin-bottom: 8px;
+    word-break: break-all;
+  }
+  .ln-detail .ln-edge-list {
+    list-style: none;
+    padding: 0;
+    margin: 4px 0 8px 0;
+  }
+  .ln-detail .ln-edge-row {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    padding: 3px 0;
+    border-bottom: 1px dotted #2a2a2a;
+  }
+  .ln-detail .ln-edge-kind {
+    display: inline-block;
+    min-width: 90px;
+    padding: 1px 6px;
+    border-radius: 3px;
+    font-size: 10px;
+    text-align: center;
+    color: var(--muted);
+    border: 1px solid var(--panel-edge);
+    background: #181818;
+  }
+  .ln-detail .ln-edge-conf {
+    font-family: ui-monospace, SFMono-Regular, Monaco, monospace;
+    color: var(--muted);
+    font-size: 11px;
+  }
+  .ln-detail .ln-edge-target {
+    font-family: ui-monospace, SFMono-Regular, Monaco, monospace;
+    color: var(--fg);
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .ln-detail .ln-edge-hint {
+    color: var(--muted);
+    font-size: 11px;
+  }
+  .ln-detail .ln-empty {
+    color: var(--muted);
+    font-style: italic;
+    padding: 8px 0;
+  }
 </style>
 </head>
 <body>
@@ -142,15 +632,41 @@
 </header>
 
 <nav class="tabs">
-  <button id="tab-timeline" class="active" data-view="view-timeline">Timeline Player</button>
+  <button id="tab-overview" class="active" data-view="view-overview">Overview</button>
+  <button id="tab-timeline" data-view="view-timeline">Timeline Player</button>
   <button id="tab-diff" data-view="view-diff">Diff Viewer</button>
+  <button id="tab-lineage" data-view="view-lineage">Lineage</button>
 </nav>
 
 <main>
   <div id="warnings"></div>
 
+  <!-- View 0: Overview (Sprint 3 v0.8 β default, codex doc Axis 3 §First view 4 layer + Phase 2 overlay) -->
+  <section id="view-overview" class="view active">
+    <!-- Phase 2: P1 metrics status banner (6 chip) -->
+    <div class="status-banner" id="ov-status-banner"></div>
+    <div class="overview-grid">
+      <div class="overview-card" id="ov-vault-overview">
+        <h2>Vault overview</h2>
+      </div>
+      <div class="overview-card" id="ov-health-focus">
+        <h2>Health focus</h2>
+      </div>
+      <div class="overview-card" id="ov-graph-preview">
+        <h2>Graph preview</h2>
+      </div>
+      <div class="overview-card" id="ov-action-queue">
+        <h2>Action queue</h2>
+      </div>
+      <!-- Sprint 3 v0.8 β Phase 4: Quality notes drawer (auto-lint 4 観点、graph 上断定なし) -->
+      <div class="overview-card" id="ov-quality-notes">
+        <h2>Quality notes (auto-lint)</h2>
+      </div>
+    </div>
+  </section>
+
   <!-- View 1: Timeline Player -->
-  <section id="view-timeline" class="view active">
+  <section id="view-timeline" class="view">
     <div class="controls">
       <button id="tp-prev" title="1 つ前の snapshot へ">← Prev</button>
       <button id="tp-play">▶ Play</button>
@@ -181,6 +697,41 @@
       <svg class="graph" id="dv-svg" viewBox="0 0 800 520" preserveAspectRatio="xMidYMid meet"></svg>
     </div>
     <div class="detail" id="dv-detail"></div>
+  </section>
+
+  <!-- View 3: Lineage (Sprint 3 v0.8 β Phase 3, codex doc Axis 4)
+       raw-sources → summaries → wiki pages の 3 layer best-effort 推定。
+       confidence 階層化 (sha256=1.0 ≥ derived_from=0.95 ≥ wikilink=0.85 ≥ filename=0.7 ≥ time=0.4) で
+       UI 上 transparency を担保。"estimated lineage" disclosure banner で user trust を保護。 -->
+  <section id="view-lineage" class="view">
+    <div id="ln-banner" class="ln-banner"></div>
+    <div class="ln-controls">
+      <label>Layer filter
+        <select id="ln-layer">
+          <option value="all">All</option>
+          <option value="raw">Raw sources</option>
+          <option value="summary">Summaries</option>
+          <option value="wiki">Wiki pages</option>
+        </select>
+      </label>
+      <label>Search
+        <input type="search" id="ln-search" placeholder="name / path 部分一致" />
+      </label>
+      <label>Hops
+        <select id="ln-hops">
+          <option value="1">1-hop</option>
+          <option value="2" selected>2-hop</option>
+        </select>
+      </label>
+      <span class="counter" id="ln-counter"></span>
+    </div>
+    <div class="ln-summary" id="ln-summary"></div>
+    <div class="ln-layout">
+      <aside class="ln-node-list" id="ln-node-list"></aside>
+      <div class="ln-detail" id="ln-detail">
+        <p class="muted">左の node 一覧から 1 つ選ぶと、その node を中心に 1-2 hop の lineage が表示されます。</p>
+      </div>
+    </div>
   </section>
 </main>
 
@@ -252,6 +803,737 @@
     w.className = "warning";
     w.textContent = "git history が 16MiB cap で truncate されました。古い commit は一部欠落している可能性があります。";
     document.getElementById("warnings").appendChild(w);
+  }
+  if (data.first_view_error) {
+    const w = document.createElement("div");
+    w.className = "warning";
+    w.textContent = "first view 計算失敗 (Timeline / Diff は引き続き利用可): " + data.first_view_error;
+    document.getElementById("warnings").appendChild(w);
+  }
+
+  // ───────────────────────── View 0: Overview (Sprint 3 v0.8 β Phase 1+2) ─────────────────────────
+  // codex strategic doc Axis 3 §First view 4 layer ordering:
+  //   status_banner (Phase 2) → vault overview → health focus → graph preview → action queue
+  renderOverview(data.first_view || null, data.first_view_error || null);
+
+  function renderOverview(firstView, firstViewError) {
+    const ovBanner  = document.getElementById("ov-status-banner");
+    const ovVault   = document.getElementById("ov-vault-overview");
+    const ovHealth  = document.getElementById("ov-health-focus");
+    const ovGraph   = document.getElementById("ov-graph-preview");
+    const ovAction  = document.getElementById("ov-action-queue");
+    const ovQuality = document.getElementById("ov-quality-notes");
+
+    if (firstViewError) {
+      [ovBanner, ovVault, ovHealth, ovGraph, ovAction, ovQuality].forEach(function (el) {
+        const div = document.createElement("div");
+        div.className = "empty";
+        div.textContent = "first view 計算に失敗 (詳細は上の warning banner): " + firstViewError;
+        el.appendChild(div);
+      });
+      return;
+    }
+    if (!firstView) {
+      [ovBanner, ovVault, ovHealth, ovGraph, ovAction, ovQuality].forEach(function (el) {
+        const div = document.createElement("div");
+        div.className = "empty";
+        div.textContent = "first view データ未注入 (この HTML は古い visualizer.mjs で生成された可能性あり)";
+        el.appendChild(div);
+      });
+      return;
+    }
+
+    // ── Phase 2: Status banner (P1 metrics 6 件、severity 付き chip) ──
+    (function renderStatusBanner() {
+      const sb = firstView.status_banner || {};
+      const items = [
+        { key: "orphan",            label: "orphan",      get: function (m) { return m.count; } },
+        { key: "stale",             label: "stale",       get: function (m) { return m.count; } },
+        { key: "duplicate_title",   label: "dup-title",   get: function (m) { return m.count; } },
+        { key: "hot_md_age",        label: "hot.md",      get: function (m) { return m.age_human || "—"; } },
+        { key: "last_ingest",       label: "last-ingest", get: function (m) { return m.age_human || "—"; } },
+        { key: "unprocessed_logs",  label: "unprocessed", get: function (m) { return m.count; } },
+      ];
+      items.forEach(function (it) {
+        const m = sb[it.key];
+        if (!m) return;
+        const chip = document.createElement("span");
+        chip.className = "sb-chip sev-" + (m.severity || "ok");
+        const lbl = document.createElement("span");
+        lbl.className = "sb-label";
+        lbl.textContent = it.label + ":";
+        const val = document.createElement("span");
+        val.className = "sb-value";
+        val.textContent = String(it.get(m));
+        chip.appendChild(lbl);
+        chip.appendChild(val);
+        ovBanner.appendChild(chip);
+      });
+    })();
+
+    // ── Layer 1: Vault overview (Phase 2 で sparkline + bar chart 追加) ──
+    (function renderVaultOverview() {
+      const vo = firstView.vault_overview || {};
+      const totalDiv = document.createElement("div");
+      totalDiv.className = "big-num";
+      totalDiv.textContent = String(vo.pages_total != null ? vo.pages_total : 0);
+      ovVault.appendChild(totalDiv);
+      const totalSub = document.createElement("div");
+      totalSub.className = "sub-num";
+      totalSub.textContent = "pages total in wiki/";
+      ovVault.appendChild(totalSub);
+
+      // Phase 2: summaries growth + sparkline
+      const g = vo.summaries_growth;
+      if (g) {
+        const row = document.createElement("div");
+        row.className = "row";
+        const lbl = document.createElement("span");
+        lbl.className = "label";
+        lbl.textContent = "summaries growth";
+        const val = document.createElement("span");
+        val.className = "value";
+        if (g.vault_is_git) {
+          val.textContent = "+" + ((g.day_7 && g.day_7.added) || 0)
+            + "/7d, +" + ((g.day_30 && g.day_30.added) || 0) + "/30d";
+        } else {
+          val.textContent = "n/a (not a git vault)";
+        }
+        row.appendChild(lbl);
+        row.appendChild(val);
+        ovVault.appendChild(row);
+
+        if (g.vault_is_git) {
+          const spark = document.createElement("div");
+          spark.className = "sparkline";
+          const r7 = (g.day_7 && g.day_7.per_day) || 0;
+          const r30 = (g.day_30 && g.day_30.per_day) || 0;
+          const maxRate = Math.max(r7, r30, 0.1); // div by zero 回避
+          const cols = [
+            { lbl: "7d", val: (g.day_7 && g.day_7.added) || 0, rate: r7 },
+            { lbl: "30d", val: (g.day_30 && g.day_30.added) || 0, rate: r30 },
+          ];
+          cols.forEach(function (c) {
+            const col = document.createElement("div");
+            col.className = "spark-col";
+            const v = document.createElement("div");
+            v.className = "spark-value";
+            v.textContent = "+" + c.val;
+            col.appendChild(v);
+            const bar = document.createElement("div");
+            bar.className = "spark-bar";
+            bar.style.height = Math.round((c.rate / maxRate) * 24) + "px";
+            col.appendChild(bar);
+            const l = document.createElement("div");
+            l.className = "spark-label";
+            l.textContent = c.lbl;
+            col.appendChild(l);
+            spark.appendChild(col);
+          });
+          ovVault.appendChild(spark);
+        }
+      }
+
+      // Phase 2: page_count_by_type compact bar chart (sorted_entries 経由)
+      const pct = vo.page_count_by_type;
+      if (pct && Array.isArray(pct.sorted_entries) && pct.sorted_entries.length > 0) {
+        const lblDiv = document.createElement("div");
+        lblDiv.className = "row";
+        const lblSpan = document.createElement("span");
+        lblSpan.className = "label";
+        lblSpan.textContent = "type distribution (top 6)";
+        lblDiv.appendChild(lblSpan);
+        ovVault.appendChild(lblDiv);
+
+        const chart = document.createElement("div");
+        chart.className = "bar-chart";
+        const entries = pct.sorted_entries.slice(0, 6);
+        const maxCount = entries.reduce(function (m, e) { return Math.max(m, e[1]); }, 0) || 1;
+        entries.forEach(function (e) {
+          const r = document.createElement("div");
+          r.className = "bc-row";
+          const lblEl = document.createElement("span");
+          lblEl.className = "bc-label";
+          lblEl.textContent = e[0];
+          const barWrap = document.createElement("span");
+          barWrap.className = "bc-bar";
+          const barFill = document.createElement("span");
+          barFill.className = "bc-bar-fill";
+          barFill.style.width = Math.round((e[1] / maxCount) * 100) + "%";
+          barWrap.appendChild(barFill);
+          const valEl = document.createElement("span");
+          valEl.className = "bc-value";
+          valEl.textContent = String(e[1]);
+          r.appendChild(lblEl);
+          r.appendChild(barWrap);
+          r.appendChild(valEl);
+          chart.appendChild(r);
+        });
+        ovVault.appendChild(chart);
+      }
+    })();
+
+    // ── Layer 2: Health focus (Phase 2 で warm gradient + broken cluster + sha256 cluster 追加) ──
+    (function renderHealthFocus() {
+      const hf = firstView.health_focus || {};
+      function row(label, count, severityClass) {
+        const r = document.createElement("div");
+        r.className = "row";
+        const lbl = document.createElement("span");
+        lbl.className = "label";
+        lbl.textContent = label;
+        const chip = document.createElement("span");
+        chip.className = "chip " + (count > 0 ? severityClass : "ok");
+        chip.textContent = String(count);
+        r.appendChild(lbl);
+        r.appendChild(chip);
+        return r;
+      }
+      const broken = hf.broken_wikilink || { count: 0, samples: [], clusters: [] };
+      const sha    = hf.source_sha256_duplicate || { count: 0, groups: [] };
+      const warm   = hf.pages_warm_zone || { count: 0, lower_days: 7, upper_days: 30, distribution: null };
+      ovHealth.appendChild(row("broken wikilinks", broken.count, "danger"));
+      ovHealth.appendChild(row("source_sha256 duplicates", sha.count, "danger"));
+      ovHealth.appendChild(
+        row("warm zone (" + warm.lower_days + "-" + warm.upper_days + "d)", warm.count, "warn"),
+      );
+
+      // Phase 2: warm zone gradient bar (fresh / warm / stale 3 bucket)
+      if (warm.distribution && warm.distribution.total_classified > 0) {
+        const dist = warm.distribution;
+        const grad = document.createElement("div");
+        grad.className = "warm-gradient";
+        const total = dist.total_classified;
+        const segs = [
+          { cls: "fresh", val: dist.fresh },
+          { cls: "warm", val: dist.warm },
+          { cls: "stale", val: dist.stale },
+        ];
+        segs.forEach(function (s) {
+          if (s.val <= 0) return;
+          const seg = document.createElement("div");
+          seg.className = "wg-seg " + s.cls;
+          seg.style.width = ((s.val / total) * 100).toFixed(1) + "%";
+          seg.setAttribute("title", s.cls + ": " + s.val + " pages");
+          grad.appendChild(seg);
+        });
+        ovHealth.appendChild(grad);
+
+        const legend = document.createElement("div");
+        legend.className = "warm-gradient-legend";
+        const lf = document.createElement("span");
+        lf.className = "wg-leg-fresh";
+        lf.textContent = "fresh " + dist.fresh;
+        const lw = document.createElement("span");
+        lw.className = "wg-leg-warm";
+        lw.textContent = "warm " + dist.warm;
+        const ls = document.createElement("span");
+        ls.className = "wg-leg-stale";
+        ls.textContent = "stale " + dist.stale;
+        legend.appendChild(lf);
+        legend.appendChild(lw);
+        legend.appendChild(ls);
+        ovHealth.appendChild(legend);
+      }
+
+      // Phase 2: broken_wikilink cluster (target でグループ化、merge target view)
+      if (broken.clusters && broken.clusters.length > 0) {
+        const clusterHeader = document.createElement("div");
+        clusterHeader.className = "row";
+        const clusterLbl = document.createElement("span");
+        clusterLbl.className = "label";
+        clusterLbl.textContent = "broken targets (top "
+          + Math.min(broken.clusters.length, 3) + ")";
+        clusterHeader.appendChild(clusterLbl);
+        ovHealth.appendChild(clusterHeader);
+
+        const list = document.createElement("div");
+        list.className = "cluster-list";
+        broken.clusters.slice(0, 3).forEach(function (c) {
+          const item = document.createElement("div");
+          item.className = "cluster-item";
+          const target = document.createElement("div");
+          target.className = "cluster-target";
+          target.textContent = "[[" + c.target + "]]";
+          item.appendChild(target);
+          const meta = document.createElement("div");
+          meta.className = "cluster-meta";
+          meta.textContent = c.inbound_broken_count + " broken inbound link"
+            + (c.inbound_broken_count > 1 ? "s" : "");
+          item.appendChild(meta);
+          const sources = document.createElement("div");
+          sources.className = "cluster-sources";
+          c.sources.slice(0, 3).forEach(function (s) {
+            const src = document.createElement("div");
+            src.className = "cluster-source";
+            src.textContent = "← " + s;
+            sources.appendChild(src);
+          });
+          if (c.sources.length > 3) {
+            const more = document.createElement("div");
+            more.className = "cluster-source";
+            more.textContent = "  +" + (c.sources.length - 3) + " more";
+            sources.appendChild(more);
+          }
+          item.appendChild(sources);
+          list.appendChild(item);
+        });
+        ovHealth.appendChild(list);
+      }
+
+      // Phase 2: source_sha256_duplicate cluster (merge candidate)
+      if (sha.groups && sha.groups.length > 0) {
+        const shaHeader = document.createElement("div");
+        shaHeader.className = "row";
+        const shaLbl = document.createElement("span");
+        shaLbl.className = "label";
+        shaLbl.textContent = "merge candidates (sha256)";
+        shaHeader.appendChild(shaLbl);
+        ovHealth.appendChild(shaHeader);
+
+        const shaList = document.createElement("div");
+        shaList.className = "cluster-list";
+        sha.groups.slice(0, 3).forEach(function (gr) {
+          const item = document.createElement("div");
+          item.className = "cluster-item";
+          const target = document.createElement("div");
+          target.className = "cluster-target";
+          target.textContent = gr.source_sha256.slice(0, 16) + "…";
+          item.appendChild(target);
+          const meta = document.createElement("div");
+          meta.className = "cluster-meta";
+          meta.textContent = gr.paths.length + " pages share this source";
+          item.appendChild(meta);
+          const sources = document.createElement("div");
+          sources.className = "cluster-sources";
+          gr.paths.slice(0, 4).forEach(function (p) {
+            const src = document.createElement("div");
+            src.className = "cluster-source";
+            src.textContent = p;
+            sources.appendChild(src);
+          });
+          item.appendChild(sources);
+          shaList.appendChild(item);
+        });
+        ovHealth.appendChild(shaList);
+      }
+    })();
+
+    // ── Layer 3: Graph preview ──
+    (function renderGraphPreview() {
+      const gp = firstView.graph_preview || {};
+      function section(title, items, formatter) {
+        if (!items || items.length === 0) return false;
+        const header = document.createElement("div");
+        header.className = "row";
+        const lbl = document.createElement("span");
+        lbl.className = "label";
+        lbl.textContent = title + " (" + items.length + ")";
+        header.appendChild(lbl);
+        ovGraph.appendChild(header);
+        const ul = document.createElement("ul");
+        items.slice(0, 5).forEach(function (it) {
+          const li = document.createElement("li");
+          li.textContent = formatter(it);
+          ul.appendChild(li);
+        });
+        ovGraph.appendChild(ul);
+        return true;
+      }
+      const hasHot     = section("hot pages", gp.hot_pages,
+        function (p) { return p.name + "  · links=" + (p.degree || 0); });
+      const hasProj    = section("active projects", gp.active_projects,
+        function (p) { return p.title || p.name; });
+      const hasDecis   = section("recent decisions", gp.recent_decisions,
+        function (p) { return p.title || p.name; });
+      if (!hasHot && !hasProj && !hasDecis) {
+        const e = document.createElement("div");
+        e.className = "empty";
+        e.textContent = "snapshot がないため preview なし (まず Vault を git commit してください)";
+        ovGraph.appendChild(e);
+      }
+    })();
+
+    // ── Layer 4: Action queue ──
+    (function renderActionQueue() {
+      const aq = Array.isArray(firstView.action_queue) ? firstView.action_queue : [];
+      if (aq.length === 0) {
+        const e = document.createElement("div");
+        e.className = "empty";
+        e.textContent = "健全な状態です — action 不要 (P0 / P1 metric が全てゼロ)";
+        ovAction.appendChild(e);
+        return;
+      }
+      aq.forEach(function (item) {
+        const div = document.createElement("div");
+        div.className = "action-item";
+
+        const reason = document.createElement("div");
+        reason.className = "action-reason";
+        const pr = document.createElement("span");
+        pr.className = "priority-" + item.priority;
+        pr.textContent = "[" + item.priority + "] ";
+        reason.appendChild(pr);
+        const txt = document.createElement("span");
+        txt.textContent = item.reason;
+        reason.appendChild(txt);
+        div.appendChild(reason);
+
+        const next = document.createElement("div");
+        next.className = "action-next";
+        next.textContent = "→ " + item.next_action;
+        div.appendChild(next);
+
+        if (item.command) {
+          const cmd = document.createElement("div");
+          cmd.className = "action-cmd";
+          cmd.textContent = item.command;
+          div.appendChild(cmd);
+        }
+        ovAction.appendChild(div);
+      });
+    })();
+
+    // ── Phase 4: Quality notes drawer (auto-lint 4 観点、補助表示) ──
+    // graph に断定表示せず "estimated" 性質を明示 (PM 答え #3「user trust 落とさない」)。
+    // report 不在時は "auto-lint 未実行" 案内、parse 成功時は 4 観点を mini-list で表示。
+    (function renderQualityNotes() {
+      const al = firstView.auto_lint || null;
+      if (!al || !al.report_exists) {
+        const wrap = document.createElement("div");
+        wrap.className = "qn-missing";
+        const p1 = document.createElement("div");
+        p1.textContent = "auto-lint 未実行 — wiki/lint-report.md がまだ生成されていません。";
+        const p2 = document.createElement("div");
+        p2.style.marginTop = "6px";
+        const cmd = document.createElement("code");
+        cmd.textContent = "bash scripts/auto-lint.sh";
+        p2.appendChild(document.createTextNode("実行コマンド: "));
+        p2.appendChild(cmd);
+        wrap.appendChild(p1);
+        wrap.appendChild(p2);
+        ovQuality.appendChild(wrap);
+        return;
+      }
+
+      const disclosure = document.createElement("div");
+      disclosure.className = "qn-disclosure";
+      disclosure.textContent = "LLM 推定 (deterministic ではない) — 詳細は wiki/lint-report.md を参照";
+      ovQuality.appendChild(disclosure);
+
+      const meta = document.createElement("div");
+      meta.className = "qn-meta";
+      const metaBits = [];
+      if (al.generated_at) metaBits.push("updated " + al.generated_at);
+      metaBits.push("total " + (typeof al.total_findings === "number" ? al.total_findings : "—") + " findings");
+      if (al.source_truncated) metaBits.push("source truncated");
+      meta.textContent = metaBits.join("  ·  ");
+      ovQuality.appendChild(meta);
+
+      const list = document.createElement("div");
+      list.className = "qn-categories";
+      const categories = Array.isArray(al.categories) ? al.categories : [];
+      categories.forEach(function (cat) {
+        const wrap = document.createElement("div");
+        wrap.className = "qn-cat";
+        const head = document.createElement("div");
+        head.className = "qn-cat-head";
+        const label = document.createElement("span");
+        label.className = "qn-cat-label";
+        label.textContent = cat.label || cat.key || "(unknown)";
+        const count = document.createElement("span");
+        const isEmpty = !cat.count || cat.count === 0;
+        count.className = "qn-cat-count" + (isEmpty ? " qn-empty" : "");
+        const suffix = cat.count_estimated ? " (推定)" : "";
+        count.textContent = (cat.count || 0) + " findings" + suffix;
+        head.appendChild(label);
+        head.appendChild(count);
+        wrap.appendChild(head);
+
+        const samples = Array.isArray(cat.samples) ? cat.samples : [];
+        if (samples.length > 0) {
+          const ul = document.createElement("ul");
+          ul.className = "qn-samples";
+          samples.forEach(function (s) {
+            const li = document.createElement("li");
+            li.textContent = s;
+            ul.appendChild(li);
+          });
+          wrap.appendChild(ul);
+          if (cat.sample_truncated) {
+            const trunc = document.createElement("div");
+            trunc.className = "qn-truncated-note";
+            trunc.textContent = "(showing top " + samples.length + " — see lint-report.md for full list)";
+            wrap.appendChild(trunc);
+          }
+        }
+        list.appendChild(wrap);
+      });
+      ovQuality.appendChild(list);
+
+      const link = document.createElement("a");
+      link.className = "qn-source-link";
+      link.href = "../../" + (al.source_path || "wiki/lint-report.md");
+      link.target = "_blank";
+      link.rel = "noopener";
+      link.textContent = "Open full report → " + (al.source_path || "wiki/lint-report.md");
+      ovQuality.appendChild(link);
+    })();
+  }
+
+  // ───────────────────────── View 3: Lineage (Sprint 3 v0.8 β Phase 3) ─────────────────────────
+  renderLineage(data.lineage || null, data.lineage_error || null);
+
+  function renderLineage(lineage, lineageError) {
+    const banner = document.getElementById("ln-banner");
+    const counter = document.getElementById("ln-counter");
+    const summary = document.getElementById("ln-summary");
+    const nodeList = document.getElementById("ln-node-list");
+    const detail = document.getElementById("ln-detail");
+    const layerSel = document.getElementById("ln-layer");
+    const searchInput = document.getElementById("ln-search");
+    const hopsSel = document.getElementById("ln-hops");
+
+    if (lineageError) {
+      const div = document.createElement("div");
+      div.className = "warning";
+      div.textContent = "lineage 計算失敗 (他 view は引き続き利用可): " + lineageError;
+      banner.appendChild(div);
+      return;
+    }
+    if (!lineage) {
+      const p = document.createElement("p");
+      p.className = "muted";
+      p.textContent = "lineage データ未注入 (古い visualizer.mjs で生成された HTML の可能性あり)";
+      banner.appendChild(p);
+      return;
+    }
+
+    // ★ estimated lineage disclosure (best-effort hint shape、user trust 保護)
+    const note = document.createElement("div");
+    const star = document.createElement("b"); star.textContent = "★ estimated lineage";
+    const text = document.createTextNode(
+      " — " + (lineage.hint_note || "best-effort heuristics") +
+      ". 100% 再現ではなく、heuristic に基づく「説明可能な lineage 推測」を表示しています。"
+    );
+    note.appendChild(star);
+    note.appendChild(text);
+    banner.appendChild(note);
+
+    // Summary chips (totals + per-edge-kind counts)
+    (function renderSummary() {
+      const totals = lineage.totals || { nodes: 0, raw: 0, summary: 0, wiki: 0, edges: 0 };
+      const totalsDiv = document.createElement("div");
+      totalsDiv.className = "ln-totals";
+      function addTotal(label, val) {
+        const span = document.createElement("span");
+        const b = document.createElement("b"); b.textContent = String(val);
+        const t = document.createTextNode(" " + label);
+        span.appendChild(b); span.appendChild(t);
+        totalsDiv.appendChild(span);
+      }
+      addTotal("nodes", totals.nodes);
+      addTotal("raw", totals.raw);
+      addTotal("summary", totals.summary);
+      addTotal("wiki", totals.wiki);
+      addTotal("edges", totals.edges);
+      summary.appendChild(totalsDiv);
+
+      const edgeCounts = document.createElement("div");
+      edgeCounts.className = "ln-edge-counts";
+      const kinds = ["sha256", "derived_from", "wikilink", "filename", "time"];
+      const hintSummary = lineage.hint_summary || {};
+      kinds.forEach(function (k) {
+        const chip = document.createElement("span");
+        chip.className = "ln-edge-chip kind-" + k;
+        const b = document.createElement("b"); b.textContent = String(hintSummary[k] || 0);
+        const t = document.createTextNode(" " + k);
+        chip.appendChild(b); chip.appendChild(t);
+        edgeCounts.appendChild(chip);
+      });
+      summary.appendChild(edgeCounts);
+
+      if (lineage.truncated) {
+        const trunc = document.createElement("span");
+        trunc.className = "ln-edge-chip";
+        trunc.textContent = "truncated to " + (lineage.node_cap || 300) + " nodes";
+        summary.appendChild(trunc);
+      }
+    })();
+
+    // Build adjacency for runtime 1-2 hop subgraph
+    const nodes = Array.isArray(lineage.nodes) ? lineage.nodes : [];
+    const edges = Array.isArray(lineage.edges) ? lineage.edges : [];
+    const nodeById = {};
+    nodes.forEach(function (n) { nodeById[n.id] = n; });
+    const adj = {};
+    edges.forEach(function (e) {
+      (adj[e.source] = adj[e.source] || []).push(e);
+      (adj[e.target] = adj[e.target] || []).push(e);
+    });
+
+    let selectedId = null;
+
+    function renderNodeList() {
+      clearNode(nodeList);
+      const layerFilter = layerSel.value;
+      const q = (searchInput.value || "").trim().toLowerCase();
+      let visible = nodes;
+      if (layerFilter !== "all") visible = visible.filter(function (n) { return n.layer === layerFilter; });
+      if (q) {
+        visible = visible.filter(function (n) {
+          return n.name.toLowerCase().indexOf(q) !== -1 ||
+                 (n.path || "").toLowerCase().indexOf(q) !== -1;
+        });
+      }
+      counter.textContent = visible.length + " / " + nodes.length + " nodes";
+      visible.slice(0, 200).forEach(function (n) {
+        const row = document.createElement("div");
+        row.className = "ln-node-row";
+        if (n.id === selectedId) row.classList.add("selected");
+        const pill = document.createElement("span");
+        pill.className = "ln-layer-pill ln-layer-" + n.layer;
+        pill.textContent = n.layer;
+        const name = document.createElement("span");
+        name.className = "ln-name";
+        name.textContent = n.name;
+        name.title = n.path || n.id;
+        row.appendChild(pill);
+        row.appendChild(name);
+        row.addEventListener("click", function () { selectNode(n.id); });
+        nodeList.appendChild(row);
+      });
+      if (visible.length > 200) {
+        const more = document.createElement("div");
+        more.className = "muted";
+        more.style.padding = "4px 6px";
+        more.textContent = "(" + (visible.length - 200) + " more — refine the search)";
+        nodeList.appendChild(more);
+      }
+    }
+
+    function selectNode(id) {
+      selectedId = id;
+      renderNodeList();
+      renderDetail(id);
+    }
+
+    function subgraph(centerId, hops) {
+      const visited = {}; visited[centerId] = 0;
+      const queue = [[centerId, 0]];
+      while (queue.length > 0) {
+        const head = queue.shift();
+        const cid = head[0]; const depth = head[1];
+        if (depth >= hops) continue;
+        const neighbors = adj[cid] || [];
+        for (let i = 0; i < neighbors.length; i += 1) {
+          const e = neighbors[i];
+          const next = e.source === cid ? e.target : e.source;
+          if (next in visited) continue;
+          visited[next] = depth + 1;
+          queue.push([next, depth + 1]);
+        }
+      }
+      return visited;
+    }
+
+    function renderDetail(centerId) {
+      clearNode(detail);
+      const center = nodeById[centerId];
+      if (!center) {
+        const p = document.createElement("p"); p.className = "muted";
+        p.textContent = "node not found"; detail.appendChild(p);
+        return;
+      }
+      const hops = parseInt(hopsSel.value, 10) || 1;
+      const visited = subgraph(centerId, hops);
+      const visitedIds = Object.keys(visited);
+      const sub = edges.filter(function (e) {
+        return (e.source in visited) && (e.target in visited);
+      });
+
+      const h3 = document.createElement("h3"); h3.textContent = center.title || center.name;
+      detail.appendChild(h3);
+      const pathDiv = document.createElement("div");
+      pathDiv.className = "ln-path";
+      pathDiv.textContent = center.path || center.id;
+      detail.appendChild(pathDiv);
+
+      const meta = document.createElement("p");
+      meta.className = "muted";
+      meta.textContent =
+        "layer: " + center.layer +
+        " · type: " + (center.type || "—") +
+        " · " + (hops === 2 ? "2-hop" : "1-hop") +
+        " subgraph: " + visitedIds.length + " nodes, " + sub.length + " edges";
+      detail.appendChild(meta);
+
+      // Group edges by kind
+      const byKind = {};
+      sub.forEach(function (e) {
+        if (e.source !== centerId && e.target !== centerId && hops < 2) return;
+        (byKind[e.kind] = byKind[e.kind] || []).push(e);
+      });
+      const kindOrder = ["sha256", "derived_from", "wikilink", "filename", "time"];
+      let any = false;
+      kindOrder.forEach(function (k) {
+        const list = byKind[k];
+        if (!list || list.length === 0) return;
+        any = true;
+        const h4 = document.createElement("h4");
+        h4.textContent = k + "  (" + list.length + " edge" + (list.length > 1 ? "s" : "") + ")";
+        h4.style.fontSize = "12px";
+        h4.style.marginTop = "10px";
+        h4.style.marginBottom = "4px";
+        h4.style.color = "var(--muted)";
+        detail.appendChild(h4);
+        const ul = document.createElement("ul");
+        ul.className = "ln-edge-list";
+        list.forEach(function (e) {
+          const li = document.createElement("li");
+          li.className = "ln-edge-row";
+          const kind = document.createElement("span");
+          kind.className = "ln-edge-kind";
+          kind.textContent = k;
+          const conf = document.createElement("span");
+          conf.className = "ln-edge-conf";
+          conf.textContent = "conf " + (Math.round((e.confidence || 0) * 100) / 100).toFixed(2);
+          const otherId = e.source === centerId ? e.target : e.source;
+          const arrow = e.source === centerId ? "→" : "←";
+          const targetSpan = document.createElement("span");
+          targetSpan.className = "ln-edge-target";
+          const otherNode = nodeById[otherId];
+          targetSpan.textContent = arrow + " " + (otherNode ? (otherNode.path || otherNode.name) : otherId);
+          targetSpan.title = otherId;
+          targetSpan.style.cursor = "pointer";
+          targetSpan.addEventListener("click", function () { selectNode(otherId); });
+          const hint = document.createElement("span");
+          hint.className = "ln-edge-hint";
+          hint.textContent = e.hint || "";
+          li.appendChild(kind);
+          li.appendChild(conf);
+          li.appendChild(targetSpan);
+          li.appendChild(hint);
+          ul.appendChild(li);
+        });
+        detail.appendChild(ul);
+      });
+      if (!any) {
+        const p = document.createElement("p");
+        p.className = "ln-empty";
+        p.textContent = "この node には 1-2 hop の lineage hint が見つかりません (孤立 node)。";
+        detail.appendChild(p);
+      }
+
+      addObsidianLink(detail, data.vault_name, center.path);
+    }
+
+    layerSel.addEventListener("change", renderNodeList);
+    searchInput.addEventListener("input", renderNodeList);
+    hopsSel.addEventListener("change", function () {
+      if (selectedId) renderDetail(selectedId);
+    });
+    renderNodeList();
   }
 
   // ───────────────────────── tab switch ─────────────────────────

--- a/mcp/tools/visualizer.mjs
+++ b/mcp/tools/visualizer.mjs
@@ -21,6 +21,9 @@ import { fileURLToPath } from 'node:url';
 import { assertInsideBase, PathBoundaryError } from '../lib/vault-path.mjs';
 import { getFileHistory } from '../lib/git-history.mjs';
 import { buildWikiSnapshot, diffSnapshots } from '../lib/wiki-snapshot.mjs';
+import { collectHealthMetrics } from '../lib/health-metrics.mjs';
+import { collectFirstViewData } from '../lib/visualizer-data.mjs';
+import { buildLineageGraph } from '../lib/lineage-graph.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const TEMPLATE_PATH = join(__dirname, '..', 'templates', 'viz-template.html');
@@ -41,7 +44,7 @@ export const VISUALIZER_TOOL_DEF = {
   name: 'kioku_generate_viz',
   title: 'Generate KIOKU wiki visualizer (local HTML)',
   description:
-    'Generates a self-contained HTML visualizer of the wiki showing Timeline Player (View 1, temporal evolution) and Diff Viewer (View 2, 2 時点の差分). Data is embedded as inline JSON — only frontmatter and wikilinks, never page body. Output is written to the vault .cache/viz/ directory and opened directly in a browser (no external network). Does NOT modify wiki/. Requires the vault to be a git repository.',
+    'Generates a self-contained HTML visualizer of the wiki with 4 views: Overview (first view = vault overview + health focus + graph preview + action queue), Timeline Player (temporal evolution), Diff Viewer (2 時点の差分), and Lineage (raw-sources → summaries → wiki best-effort 3 layer lineage graph, Sprint 3 v0.8 β). Data is embedded as inline JSON — only frontmatter and wikilinks, never page body. Output is written to the vault .cache/viz/ directory and opened directly in a browser (no external network). Does NOT modify wiki/. Requires the vault to be a git repository.',
   inputShape: {
     output_path: z
       .string()
@@ -148,15 +151,44 @@ export async function handleGenerateViz(vault, args = {}) {
   }
 
   // 4. data embed
+  //   Phase 1 v0.8 Visualizer β: first_view を top-level に追加。
+  //   既存 Timeline / Diff が依存する snapshots / since / commits_total 等は
+  //   schema を破壊しないよう保持 (BLUE-VIZ-FIRSTVIEW-5 schema isolation 担保)。
+  //   health metrics 取得失敗時 (orphan health module deps 等) は warnings に積み、
+  //   first_view を null とし既存 view は維持 (LEARN#6 graceful degrade)。
+  const now = new Date();
+  let firstView = null;
+  let firstViewError = null;
+  try {
+    const health = await collectHealthMetrics(vault, { now });
+    firstView = await collectFirstViewData(vault, { now, snapshots, health });
+  } catch (err) {
+    firstViewError = err instanceof Error ? err.message : String(err);
+  }
+  // Phase 3 v0.8 β: best-effort 3 layer lineage graph (raw-sources → summaries → wiki).
+  // Failure is non-fatal — Overview/Timeline/Diff continue working with lineage=null.
+  let lineage = null;
+  let lineageError = null;
+  try {
+    lineage = await buildLineageGraph(vault, { now });
+  } catch (err) {
+    lineageError = err instanceof Error ? err.message : String(err);
+  }
   const data = {
-    schema_version: 1,
-    generated_at: new Date().toISOString(),
+    // schema_version 履歴: 1 (V-1 base) / 2 (Phase 1 first_view) / 3 (Phase 3 lineage) /
+    //                      4 (Phase 4 auto-lint drawer in first_view.auto_lint)
+    schema_version: 4,
+    generated_at: now.toISOString(),
     vault_name: basename(vault),
     since,
     max_commits: maxCommits,
     commits_total: histRes.commits.length,
     history_truncated: Boolean(histRes.truncated),
     snapshots, // 新しい順 (git log --max-count)
+    first_view: firstView, // Sprint 3 v0.8 β Phase 1/2、null の場合は Overview tab で degraded UI 表示
+    first_view_error: firstViewError, // null / string、warning banner 用
+    lineage,           // Sprint 3 v0.8 β Phase 3、null は Lineage tab で degraded UI 表示
+    lineage_error: lineageError,
   };
   const dataJson = safeJsonForScript(data);
   const html = template.replace(DATA_PLACEHOLDER, dataJson);
@@ -188,7 +220,13 @@ export async function handleGenerateViz(vault, args = {}) {
     latest_pages: latestPagesCount,
     since,
     history_truncated: Boolean(histRes.truncated),
-    views: ['timeline-player', 'diff-viewer'],
+    views: ['overview', 'timeline-player', 'diff-viewer', 'lineage'],
+    first_view_present: firstView !== null,
+    first_view_error: firstViewError,
+    auto_lint_present: Boolean(firstView && firstView.auto_lint && firstView.auto_lint.report_exists),
+    lineage_present: lineage !== null,
+    lineage_error: lineageError,
+    lineage_totals: lineage ? lineage.totals : null,
     note: 'Open the generated HTML file in a browser. No external network required.',
   };
 }

--- a/skills/kioku-delegation-handoff/SKILL.md
+++ b/skills/kioku-delegation-handoff/SKILL.md
@@ -167,10 +167,38 @@ ls {{target-files}} 2>&1
 # 3. LEARN#10 逆方向: main にも該当 commit が無いか
 git log -10 origin/main --oneline | grep -iE "{{keyword}}"
 
-# 4. {{additional precheck commands}}
+# 4. LEARN#12 Rule 2: PM main hygiene
+git log --oneline origin/main..main
+# (empty=clean)
+
+# 5. {{additional precheck commands}}
+
+# 6. LEARN#15 mandatory: session current-branch verify (parallel session contention 防御)
+git symbolic-ref HEAD
+# 期待: refs/heads/{{expected-branch}} (例: feature/<scope-topic>)
+# 想定 branch と異なれば parallel session contention の可能性 → abort + escalate
+# 加えて作業 milestones 毎 (file edit 前 / commit 直前 / push 直前) に再 verify 推奨
 ```
 
 discrepancy 発見時 → PM session に escalate、本 handoff の更新依頼。**着手前停止が原則**。
+
+## LEARN#15 milestone 毎 branch verify (mandatory pattern、commit / push 直前)
+
+```bash
+EXPECTED_BRANCH="feature/{{scope-topic}}"
+
+# commit 直前 chained assert
+git symbolic-ref HEAD | grep -q "refs/heads/${EXPECTED_BRANCH}" \
+  && git commit -m "..." \
+  || (echo "ABORT: expected ${EXPECTED_BRANCH}, got $(git symbolic-ref HEAD)"; exit 1)
+
+# push 直前 chained assert
+git symbolic-ref HEAD | grep -q "refs/heads/${EXPECTED_BRANCH}" \
+  && git push -u origin "${EXPECTED_BRANCH}" \
+  || (echo "ABORT: expected ${EXPECTED_BRANCH}, got $(git symbolic-ref HEAD)"; exit 1)
+```
+
+→ 誤 branch flip があれば commit / push 前に abort、recovery flow (branch 戻し + working tree 保持) へ
 
 ---
 
@@ -284,6 +312,14 @@ PR #90 URL test 安定化 (N=5): scope = quick/full suite 分離、target = 10 �
 
 PR #96 README mode-based (N=6): scope = Mode A/B/C onboarding + doctor mode detection、target = README.md + README.ja.md + `scripts/doctor.sh` + `tests/doctor.test.sh`、TEST-PREFIX = `BLUE-DOCTOR-MODE-`、想定工数 1-2h、5 点セット
 
+PR #103 health metrics core (N=7): scope = Sprint 2 着手 (`kioku_health` MCP tool + 6 core metrics + `generate-health.mjs` + dashboard view)、target = `mcp/lib/health-metrics.mjs` + `mcp/tools/health.mjs` + `scripts/generate-health.mjs` + `templates/wiki/meta/dashboard.base` + `tests/health-metrics.test.mjs` + `tests/mcp/tools-health.test.mjs`、TEST-PREFIX = `BLUE-HEALTH-` + `MCP-HEALTH-`、想定工数 8-12h、6 点セット (real Vault dogfood 数値を完了報告に含める)。**skill 初使用 cycle**
+
+PR #109 stretch metrics + auto-lint refactor (N=8): scope = Sprint 2 完走 (stretch 5 metrics + LINT_PROMPT 6→4 観点 refactor)、target = N=7 と同 file 拡張 + `scripts/auto-lint.sh` + `tests/auto-lint.test.sh`、TEST-PREFIX = `BLUE-HEALTH-STRETCH-` + `BLUE-LINT-PROMPT-`、想定工数 8-15h、6 点セット (LEARN#5 grep audit が 2 箇所 hardcoded "6 metric" drift catch、LEARN#6 5 layer boundary table を完了報告に組み込み)
+
+### マーケ系 retrospect article 制作 (N=2 マーケ系)
+
+PR #115 v0.7.2-v0.7.5 Sprint 1+2 retrospect (マーケ N=2): scope = 4 release 集約 retrospect article × 2 媒体 (dev.to + Zenn)、target = `marketing/article/dev.to/26050X_*-devto.md` + `marketing/article/zen/26050X_*-zenn.md`、想定工数 4-6h、5 点セット (Zenn 英語混入 audit + dev.to technical depth + Sprint 3 narrative boundary check 含む)
+
 ## 関連 (本 skill が参照する正典)
 
 - `.claude/rules/workflow.md` LEARN#5 (cross-suite test) / LEARN#6 (cross-boundary integration review) / LEARN#10 (双方向 PM precheck) / LEARN#11 (release cycle sync boundary) / LEARN#12 (delegation = branch + PR mandatory)
@@ -295,4 +331,39 @@ PR #96 README mode-based (N=6): scope = Mode A/B/C onboarding + doctor mode dete
 
 - **新 N cycle で本 skill 利用** = N counter / Metadata 更新
 - **8 cycle 以上経過時に本 skill 自体を refactor**: 共通要素の更なる抽出 / scope-specific 入力の自動推論強化
-- **session type 別の specialized variant**: 制作 Claude / codex / マーケ で handoff 内容が大きく異なる場合は別 skill 化検討 (現状は 1 skill で 3 type cover、N=6 cycle 中は 制作 N=6 / codex N=0 / マーケ N=1 で 制作 偏重、要 observe)
+- **session type 別の specialized variant**: 制作 Claude / codex / マーケ で handoff 内容が大きく異なる場合は別 skill 化検討
+
+### N=8 retrospect (2026-05-08、PM session 振り返り)
+
+skill 化 (PR #101、N=6 codify) → N=7 (PR #103、初使用) → N=8 (PR #109) で 2 cycle 完走後の retrospect:
+
+**結論**: **light refactor のみ実施、heavy refactor は N=10 (Sprint 3 完走 = 6月) まで defer**
+
+#### 観察された pattern
+
+- **impl 系 (制作 Claude) handoff は stable**: N=7 (268 行) と N=8 (277 行) で構造的 mutation 少ない、template が固定化されている。boilerplate 部分 (`Workflow requirements` / `LEARN#10 precheck` / `Test requirements regression list` / `Metadata`) は そのまま再利用可能
+- **scope-specific section (`Scope` / `file 構成` / `per-axis unit test`) は task ごとに完全書き換え** = これは設計通り、handoff 価値の core 部分
+- **マーケ系 N=2 で template に **「Quality requirements (article 制作特有)」 section を後付け追加**** が必要だった (Zenn 英語混入 audit / dev.to technical depth / boundary check)、impl 系 boilerplate そのままでは article 制作 task type に対応できない
+- **codex 系 (strategic doc 委譲) はまだ N=0**、本 SKILL.md 起動例には書いてあるが実例なし → variant 不足を確認できる data 不足
+
+#### 累積 cycle 分布 (N=8 時点)
+
+| session type | N | example PRs |
+|---|---|---|
+| 制作 Claude (impl) | 8 | #70/#74/#84/#89/#90/#96/#103/#109 |
+| マーケ Claude (article) | 2 | #115 (本 retrospect 起票)、kickoff resource list (4/23) |
+| codex CLI (strategic) | 0 | (未実例、Sprint 3 = v0.8 Visualizer β scope 検討で N=1 to be) |
+
+→ **制作 偏重 8:2:0**、これは予想通りの分布 (release engineering の主軸が impl)
+
+#### N=8 で実施した light refactor
+
+1. ✅ §「過去 handoff 例」 section に N=7 (PR #103) + N=8 (PR #109) + マーケ N=2 (PR #115) entry 追加
+2. ✅ §メタ運用 に本 retrospect note 追加 (将来の N=10 retrospect での比較 baseline)
+
+#### N=10 で trigger される heavy refactor candidate
+
+- **`--to=マーケ` variant boilerplate**: 「Quality requirements (article 制作特有)」section を skill template に組み込み、マーケ retrospect 起票時に self-include
+- **`--to=codex` variant boilerplate**: codex strategic doc 委譲が N=2 以上累積した時点で、scope 検討 / 競合分析 / roadmap 執筆向けの section template を抽出
+- **共通 boilerplate の prompt 自動推論強化**: scope-topic から TEST-PREFIX / target file path を heuristic 推論する rule 追加 (現状は user 入力)
+- **boilerplate の monolithic SKILL.md → 分割 file 化**: SKILL.md 298 行 + `templates/<session-type>.md.tmpl` 化で reading cost 削減

--- a/tests/fixtures/visualizer-empty-vault/README.md
+++ b/tests/fixtures/visualizer-empty-vault/README.md
@@ -1,0 +1,14 @@
+# visualizer-empty-vault fixture
+
+Sprint 3 v0.8 β Phase 4 — CI screenshot regression test 用の "empty Vault" 再現 fixture。
+
+意図的に **ファイルが README.md だけ**。 `tests/fixtures/visualizer-vaults.mjs` の
+`cloneEmptyVault(tmpDir)` でこのディレクトリ構造をコピーし、`git init` + initial commit
+を tmpDir 上で行うことで「育っていない Vault」状態を再現する。
+
+acceptance criteria (handoff §Phase 4):
+- ✅ empty Vault state で「まだ育っていない」を丁寧表示 (破綻しない)
+- ✅ first_view = null OR 全 layer empty で graceful render
+- ✅ auto-lint drawer は "未実行" 案内のみ表示
+
+このディレクトリには `wiki/` 配下を含めない (本物の empty を表現)。

--- a/tests/fixtures/visualizer-small-vault/README.md
+++ b/tests/fixtures/visualizer-small-vault/README.md
@@ -1,0 +1,33 @@
+# visualizer-small-vault fixture
+
+Sprint 3 v0.8 β Phase 4 — CI screenshot regression test 用の "small Vault" 再現 fixture。
+
+3-5 wiki page + 1 auto-lint report (4 観点 完備) の最小構成。Phase 1-4 で実装した
+全 view (Overview / Timeline / Diff / Lineage) + auto-lint drawer が動作する最小入力。
+
+`tests/fixtures/visualizer-vaults.mjs` の `cloneSmallVault(tmpDir)` がこの directory を
+tmpDir にコピーし、`git init` + 2 commit (初期 ingest + concept 追加) を作って snapshot
+時系列を作る。
+
+## 構成
+
+- `wiki/index.md` — entrance page (wikilink to concepts)
+- `wiki/concepts/jwt.md` — concept page
+- `wiki/concepts/oauth.md` — concept page (relates to jwt)
+- `wiki/projects/kioku-mini.md` — project page
+- `wiki/decisions/use-edge-runtime.md` — decision page
+- `wiki/lint-report.md` — auto-lint report (4 観点全部に 1 件ずつ finding)
+
+## acceptance criteria (handoff §Phase 4)
+
+- ✅ small Vault state で各 view が動作 (破綻しない)
+- ✅ 5 page で graph_preview hot_pages / active_projects / recent_decisions が non-empty
+- ✅ auto-lint drawer 4 観点全部に finding 表示
+- ✅ Timeline 2 snapshot 切替可
+- ✅ Diff 2 snapshot 間の差分表示可
+
+## 編集時の注意
+
+このディレクトリは **screenshot regression test の固定入力**。
+意図的な内容変更 (新 view 追加で fixture も拡張する等) 以外で wiki/ 配下を変えると
+BLUE-VIZ-SCREENSHOT-* の期待値が drift するため CI fail する。

--- a/tests/fixtures/visualizer-small-vault/wiki/concepts/jwt.md
+++ b/tests/fixtures/visualizer-small-vault/wiki/concepts/jwt.md
@@ -1,0 +1,11 @@
+---
+type: concept
+title: JWT (JSON Web Token)
+tags: [auth, session]
+updated: 2026-05-12
+---
+
+# JWT
+
+Compact, URL-safe means of representing claims to be transferred between two parties.
+Often used together with [[oauth]] flows for delegated authorization.

--- a/tests/fixtures/visualizer-small-vault/wiki/concepts/oauth.md
+++ b/tests/fixtures/visualizer-small-vault/wiki/concepts/oauth.md
@@ -1,0 +1,11 @@
+---
+type: concept
+title: OAuth 2.0
+tags: [auth, delegation]
+updated: 2026-05-12
+---
+
+# OAuth 2.0
+
+Authorization framework that enables third-party applications to obtain limited
+access to a user's account. Commonly issues [[jwt]] as access tokens.

--- a/tests/fixtures/visualizer-small-vault/wiki/decisions/use-edge-runtime.md
+++ b/tests/fixtures/visualizer-small-vault/wiki/decisions/use-edge-runtime.md
@@ -1,0 +1,12 @@
+---
+type: decision
+title: Use Edge Runtime for API routes
+date: 2026-05-12
+status: adopted
+updated: 2026-05-12
+---
+
+# Use Edge Runtime
+
+Decided to default to Edge Runtime for new API routes to reduce cold-start time.
+Trade-offs and constraints documented in [[kioku-mini]].

--- a/tests/fixtures/visualizer-small-vault/wiki/index.md
+++ b/tests/fixtures/visualizer-small-vault/wiki/index.md
@@ -1,0 +1,13 @@
+---
+type: index
+title: Small Vault Index
+updated: 2026-05-12
+---
+
+# Index
+
+This is a minimal fixture vault for visualizer screenshot regression tests.
+
+- [[jwt]] / [[oauth]] — auth concepts
+- [[kioku-mini]] — fixture project
+- [[use-edge-runtime]] — fixture decision

--- a/tests/fixtures/visualizer-small-vault/wiki/lint-report.md
+++ b/tests/fixtures/visualizer-small-vault/wiki/lint-report.md
@@ -1,0 +1,34 @@
+---
+title: Lint Report (fixture)
+date: 2026-05-12
+---
+
+# Wiki Lint Report (2026-05-12)
+
+## 要約
+
+- 検出した問題の総数: 4
+- カテゴリ別の内訳: 矛盾 1 / splinter 1 / 専用ページ候補 1 / link gap 1
+
+## 概念の矛盾
+
+- [[jwt]] は "compact URL-safe" と書かれているが、[[oauth]] では "access token として
+  発行される" としか書かれておらず JWT 自体の構造説明が分散している。要 consolidate。
+
+## 概念の splinter
+
+- "session" 概念が [[jwt]] と [[oauth]] の両方で軽く触れられているが専用ページなし。
+  概念 page として独立させる候補。
+
+## 専用ページ候補
+
+- "access token" が 2 ページで言及されているが wiki/concepts/ に専用ページ未昇格。
+
+## 意味的な相互リンク欠落
+
+- [[kioku-mini]] と [[use-edge-runtime]] は依存関係を持つが、後者から前者への
+  back-link が片方向しか張られていない。
+
+## R1: Unicode 不可視文字 (prompt injection 監査)
+
+(該当なし — wiki/ 内のどの .md にも ZWSP / RTLO / SHY / BOM 等は検出されませんでした)

--- a/tests/fixtures/visualizer-small-vault/wiki/projects/kioku-mini.md
+++ b/tests/fixtures/visualizer-small-vault/wiki/projects/kioku-mini.md
@@ -1,0 +1,13 @@
+---
+type: project
+title: KIOKU Mini (fixture project)
+status: active
+updated: 2026-05-12
+---
+
+# KIOKU Mini
+
+Fixture project page for visualizer regression tests. Demonstrates that the
+graph preview correctly classifies project-typed pages into `active_projects`.
+
+Related: [[jwt]] [[oauth]] [[use-edge-runtime]]

--- a/tests/fixtures/visualizer-vaults.mjs
+++ b/tests/fixtures/visualizer-vaults.mjs
@@ -1,0 +1,139 @@
+// visualizer-vaults.mjs — Sprint 3 v0.8 β Phase 4 fixture vault builder
+//
+// 「screenshot regression test を deterministic に走らせる」目的の helper。
+// CLAUDE.md `テスト方針: 実 Vault を絶対に汚染しない` に従い、本物の Vault には触らず
+// tmpdir に static fixture (tests/fixtures/visualizer-{empty,small}-vault/) を copy → git init →
+// initial commit、必要なら 2nd commit (Timeline 切替確認用) を作って path を返す。
+//
+// 設計方針:
+//   - 親 repo の .git に nested git repo を作れないので、static fixture には .git を含めない。
+//     test 実行時に builder が tmp 上で git init する。
+//   - visualizer.mjs は `git log` で commit 履歴を集めるので、初回 commit は必須。
+//     small Vault は 2 commit 用意し snapshot 切替が機能することを確認できる。
+//   - SAFE_CONFIG (visualizer の RCE hardening) を尊重: builder は user-level git config を
+//     使うが、init.defaultBranch / user.name / user.email を inline 指定して reproducible に。
+//   - LEARN#6 cross-boundary drift 回避: builder の output path は absolute、消費側は
+//     `await rm(vault, { recursive: true, force: true })` で必ず cleanup する責務。
+
+import { cp, mkdir, mkdtemp, readdir, writeFile, rm } from 'node:fs/promises';
+import { spawn } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const EMPTY_FIXTURE_DIR = join(__dirname, 'visualizer-empty-vault');
+const SMALL_FIXTURE_DIR = join(__dirname, 'visualizer-small-vault');
+
+// SAFE_CONFIG と同等の "侵害された .git/config を読まない" git 呼び出し。
+// builder は user vault 内で動かないので fsmonitor 脅威は低いが、CI / reviewer 安心のため
+// 同じ pattern を踏襲する。
+const GIT_SAFE_ARGS = ['-c', 'core.fsmonitor=false', '-c', 'core.hooksPath=/dev/null', '-c', 'protocol.version=2'];
+const GIT_SAFE_ENV = {
+  GIT_CONFIG_NOSYSTEM: '1',
+  GIT_TERMINAL_PROMPT: '0',
+  GIT_OPTIONAL_LOCKS: '0',
+  // identity を inline で固定: user vault の global config (RYU AI) を継承しない reproducibility
+  GIT_AUTHOR_NAME: 'visualizer-fixture',
+  GIT_AUTHOR_EMAIL: 'fixture@test.local',
+  GIT_COMMITTER_NAME: 'visualizer-fixture',
+  GIT_COMMITTER_EMAIL: 'fixture@test.local',
+};
+
+async function git(cwd, args) {
+  return new Promise((resolve, reject) => {
+    const proc = spawn('git', [...GIT_SAFE_ARGS, ...args], {
+      cwd,
+      env: { ...process.env, ...GIT_SAFE_ENV },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stderr = '';
+    proc.stderr.on('data', (chunk) => { stderr += chunk.toString(); });
+    proc.on('error', reject);
+    proc.on('close', (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`git ${args.join(' ')} failed (code ${code}): ${stderr.trim()}`));
+    });
+  });
+}
+
+// Recursively copy a fixture directory into the destination. Skips README files at
+// the fixture root so the test vault doesn't get polluted with fixture meta docs.
+async function copyFixture(src, dst) {
+  await mkdir(dst, { recursive: true });
+  const entries = await readdir(src, { withFileTypes: true });
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      await cp(join(src, entry.name), join(dst, entry.name), { recursive: true });
+    } else if (entry.name === 'README.md') {
+      // fixture meta は vault に持ち込まない
+      continue;
+    } else {
+      await cp(join(src, entry.name), join(dst, entry.name));
+    }
+  }
+}
+
+// 共通: tmp に fixture を展開 + git init + initial commit
+async function bootstrapTmpVault(fixtureDir, prefix) {
+  const tmp = await mkdtemp(join(tmpdir(), prefix));
+  try {
+    await copyFixture(fixtureDir, tmp);
+    await git(tmp, ['init', '-q', '-b', 'main']);
+    // empty vault には commit する file が無いので allow-empty
+    await git(tmp, ['add', '-A']);
+    await git(tmp, ['commit', '-q', '--allow-empty', '-m', 'fixture: initial vault state']);
+    return tmp;
+  } catch (err) {
+    await rm(tmp, { recursive: true, force: true }).catch(() => {});
+    throw err;
+  }
+}
+
+// Empty vault: README しか無い (= wiki/ も無い) → "まだ育っていない Vault" の正典再現。
+// 返り値は absolute path、消費側は rm で cleanup する。
+export async function cloneEmptyVault() {
+  return bootstrapTmpVault(EMPTY_FIXTURE_DIR, 'kioku-viz-fixture-empty-');
+}
+
+// Small vault: 5 wiki page + auto-lint report、2 commit (snapshot 切替確認可)。
+// 2nd commit は "concept の追記" として小さな update を加える (Diff view が空にならないため)。
+export async function cloneSmallVault() {
+  const vault = await bootstrapTmpVault(SMALL_FIXTURE_DIR, 'kioku-viz-fixture-small-');
+  try {
+    // 2nd commit: jwt.md に小さい追記を加える (Diff 用)
+    const jwtPath = join(vault, 'wiki', 'concepts', 'jwt.md');
+    const updated = [
+      '---',
+      'type: concept',
+      'title: JWT (JSON Web Token)',
+      'tags: [auth, session]',
+      'updated: 2026-05-13',
+      '---',
+      '',
+      '# JWT',
+      '',
+      'Compact, URL-safe means of representing claims to be transferred between two parties.',
+      'Often used together with [[oauth]] flows for delegated authorization.',
+      '',
+      '## Use cases',
+      '',
+      '- Stateless session tokens',
+      '- Service-to-service authorization',
+      '',
+    ].join('\n');
+    await writeFile(jwtPath, updated, 'utf8');
+    await git(vault, ['add', 'wiki/concepts/jwt.md']);
+    await git(vault, ['commit', '-q', '-m', 'fixture: expand jwt concept with use cases']);
+    return vault;
+  } catch (err) {
+    await rm(vault, { recursive: true, force: true }).catch(() => {});
+    throw err;
+  }
+}
+
+// 任意の vault を rm。test の finally 句で使う安全な wrapper。
+export async function disposeFixtureVault(vault) {
+  if (typeof vault !== 'string' || vault.length === 0) return;
+  await rm(vault, { recursive: true, force: true }).catch(() => {});
+}

--- a/tests/lineage-graph.test.mjs
+++ b/tests/lineage-graph.test.mjs
@@ -1,0 +1,374 @@
+// lineage-graph.test.mjs — Sprint 3 Phase 3 Raw-source lineage graph tests.
+//
+// Coverage map (handoff §Test requirements Phase 3):
+//   BLUE-VIZ-LINEAGE-1: sha256 edge 構築 (summary 同士、raw → summary 推移)
+//   BLUE-VIZ-LINEAGE-2: derived_from frontmatter edge
+//   BLUE-VIZ-LINEAGE-3: filename / slug similarity edge
+//   BLUE-VIZ-LINEAGE-4: wikilink edge (concept 間)
+//   BLUE-VIZ-LINEAGE-5: time proximity edge (cross-layer only)
+//   BLUE-VIZ-LINEAGE-6: 1-2 hop selectSubgraph (巨大 graph 回避)
+//   BLUE-VIZ-LINEAGE-7: best-effort hint shape (estimated lineage 表記 + confidence ordering)
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, mkdir, writeFile, utimes } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  buildLineageGraph,
+  selectSubgraph,
+  LINEAGE_SCHEMA_VERSION,
+  DEFAULT_NODE_CAP,
+  EDGE_KINDS,
+  EDGE_CONFIDENCE,
+  _internals,
+} from '../mcp/lib/lineage-graph.mjs';
+
+const SHA_A = 'a'.repeat(64); // 64-char sha256 placeholder
+const SHA_B = 'b'.repeat(64);
+
+async function setMtime(path, dateIso) {
+  const d = new Date(dateIso);
+  await utimes(path, d, d);
+}
+
+async function makeLineageVault(opts = {}) {
+  const root = await mkdtemp(join(tmpdir(), 'kioku-lineage-test-'));
+  await mkdir(join(root, 'wiki', 'concepts'), { recursive: true });
+  await mkdir(join(root, 'wiki', 'summaries'), { recursive: true });
+  await mkdir(join(root, 'raw-sources', 'pdf'), { recursive: true });
+  await mkdir(join(root, 'raw-sources', 'url'), { recursive: true });
+
+  // ── Raw sources ──
+  await writeFile(join(root, 'raw-sources', 'pdf', 'rag-pipeline.pdf'), '%PDF rag fake');
+  await writeFile(join(root, 'raw-sources', 'pdf', 'rag-pipeline.md'), '# extracted rag md');
+  await writeFile(join(root, 'raw-sources', 'url', 'jwt-rfc.md'), '# jwt rfc html→md');
+
+  // ── Wiki summaries (have source_sha256 + derived_from) ──
+  await writeFile(
+    join(root, 'wiki', 'summaries', 'rag-pipeline-summary.md'),
+    [
+      '---',
+      `source_sha256: ${SHA_A}`,
+      'source: raw-sources/pdf/rag-pipeline.pdf',
+      'derived_from: raw-sources/pdf/rag-pipeline.pdf',
+      'ingest_at: 2026-04-01T10:00:00Z',
+      '---',
+      '',
+      '# RAG pipeline summary',
+    ].join('\n'),
+  );
+  await writeFile(
+    join(root, 'wiki', 'summaries', 'rag-pipeline-notes.md'),
+    [
+      '---',
+      `source_sha256: ${SHA_A}`,
+      '---',
+      '',
+      '# RAG pipeline notes (same source, different angle)',
+    ].join('\n'),
+  );
+  // frontmatter.mjs uses an inline YAML subset (no multi-line array syntax),
+  // so derived_from is intentionally written as an inline list here.
+  await writeFile(
+    join(root, 'wiki', 'summaries', 'jwt-rfc-summary.md'),
+    [
+      '---',
+      `source_sha256: ${SHA_B}`,
+      'derived_from: ["raw-sources/url/jwt-rfc.md", "concepts/jwt.md"]',
+      '---',
+      '',
+      '# JWT RFC summary',
+    ].join('\n'),
+  );
+
+  // ── Wiki concept pages (wikilinks each other) ──
+  await writeFile(
+    join(root, 'wiki', 'concepts', 'jwt.md'),
+    '---\ntype: concept\n---\n\n# JWT\n\nSee [[oauth]].\nAlso [[rag-pipeline-summary]].\n',
+  );
+  await writeFile(
+    join(root, 'wiki', 'concepts', 'oauth.md'),
+    '---\ntype: concept\n---\n\n# OAuth\n\nRelated: [[jwt]].\n',
+  );
+
+  if (opts.applyMtimes) {
+    // Engineer a known mtime sequence so time edges are deterministic:
+    //   rag pdf (raw)               → 2026-03-01T09:00:00Z
+    //   rag md (raw)                → 2026-03-01T09:00:30Z
+    //   rag-pipeline-summary (sum)  → 2026-03-01T09:10:00Z  (within 1h of raw)
+    //   rag-pipeline-notes (sum)    → 2026-03-01T09:20:00Z
+    //   concepts/jwt (wiki)         → 2026-03-01T15:00:00Z  (>1h gap — no time edge)
+    await setMtime(join(root, 'raw-sources', 'pdf', 'rag-pipeline.pdf'), '2026-03-01T09:00:00Z');
+    await setMtime(join(root, 'raw-sources', 'pdf', 'rag-pipeline.md'), '2026-03-01T09:00:30Z');
+    await setMtime(join(root, 'wiki', 'summaries', 'rag-pipeline-summary.md'), '2026-03-01T09:10:00Z');
+    await setMtime(join(root, 'wiki', 'summaries', 'rag-pipeline-notes.md'), '2026-03-01T09:20:00Z');
+    await setMtime(join(root, 'wiki', 'concepts', 'jwt.md'), '2026-03-01T15:00:00Z');
+    await setMtime(join(root, 'wiki', 'concepts', 'oauth.md'), '2026-03-01T15:10:00Z');
+    await setMtime(join(root, 'raw-sources', 'url', 'jwt-rfc.md'), '2026-04-01T08:00:00Z');
+    await setMtime(join(root, 'wiki', 'summaries', 'jwt-rfc-summary.md'), '2026-04-01T08:20:00Z');
+  }
+  return root;
+}
+
+describe('lineage-graph.mjs (Phase 3 raw-source lineage)', () => {
+  test('BLUE-VIZ-LINEAGE-1: sha256 edge connects summaries with same source_sha256', async () => {
+    const root = await makeLineageVault();
+    try {
+      const graph = await buildLineageGraph(root);
+      const sha256Edges = graph.edges.filter((e) => e.kind === 'sha256');
+      // rag-pipeline-summary <-> rag-pipeline-notes (SHA_A)
+      // jwt-rfc-summary is alone with SHA_B → no edge
+      const ragPair = sha256Edges.find((e) =>
+        (e.source.includes('rag-pipeline-summary') && e.target.includes('rag-pipeline-notes')) ||
+        (e.source.includes('rag-pipeline-notes') && e.target.includes('rag-pipeline-summary')),
+      );
+      assert.ok(ragPair, 'rag-pipeline-summary ↔ rag-pipeline-notes sha256 edge expected');
+      assert.equal(ragPair.confidence, EDGE_CONFIDENCE.sha256);
+      assert.match(ragPair.hint, /source_sha256/);
+      // jwt-rfc-summary alone → no sha256 edge with another node
+      const jwtSha256 = sha256Edges.find((e) =>
+        e.source.includes('jwt-rfc-summary') || e.target.includes('jwt-rfc-summary'),
+      );
+      assert.equal(jwtSha256, undefined, 'singleton sha256 group must not emit an edge');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('BLUE-VIZ-LINEAGE-2: derived_from frontmatter edges resolve to raw + wiki nodes', async () => {
+    const root = await makeLineageVault();
+    try {
+      const graph = await buildLineageGraph(root);
+      const derived = graph.edges.filter((e) => e.kind === 'derived_from');
+      // rag-pipeline-summary → raw-sources/pdf/rag-pipeline.pdf
+      // jwt-rfc-summary → raw-sources/url/jwt-rfc.md AND → concepts/jwt.md
+      const ragRaw = derived.find((e) =>
+        e.source.includes('rag-pipeline-summary') && e.target === 'raw:pdf/rag-pipeline.pdf',
+      );
+      assert.ok(ragRaw, 'rag-pipeline-summary → raw pdf derived_from edge expected');
+      assert.equal(ragRaw.confidence, EDGE_CONFIDENCE.derived_from);
+
+      const jwtToRawHtml = derived.find((e) =>
+        e.source.includes('jwt-rfc-summary') && e.target === 'raw:url/jwt-rfc.md',
+      );
+      assert.ok(jwtToRawHtml, 'jwt-rfc-summary → raw url md derived_from edge expected');
+
+      const jwtToConcept = derived.find((e) =>
+        e.source.includes('jwt-rfc-summary') && e.target === 'wiki:concepts/jwt.md',
+      );
+      assert.ok(jwtToConcept, 'jwt-rfc-summary → concepts/jwt.md derived_from edge expected');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('BLUE-VIZ-LINEAGE-3: filename slug similarity edges connect summary ↔ raw', async () => {
+    const root = await makeLineageVault();
+    try {
+      const graph = await buildLineageGraph(root);
+      const filenameEdges = graph.edges.filter((e) => e.kind === 'filename');
+      // rag-pipeline-summary slug stem "rag-pipeline" should hit both raw rag files
+      const ragSrc = filenameEdges.filter((e) => e.source === 'wiki:summaries/rag-pipeline-summary.md');
+      assert.ok(ragSrc.length >= 2,
+        `expected ≥2 filename edges from rag summary to raw rag files, got ${ragSrc.length}`);
+      for (const e of ragSrc) {
+        assert.ok(e.target.startsWith('raw:pdf/rag-pipeline.'));
+        assert.equal(e.confidence, EDGE_CONFIDENCE.filename);
+        assert.match(e.hint, /slug match/);
+      }
+      // notes file ends in -notes; the suffix-strip helper should handle it
+      const notesSrc = filenameEdges.filter((e) => e.source === 'wiki:summaries/rag-pipeline-notes.md');
+      assert.ok(notesSrc.length >= 1, 'rag-pipeline-notes slug stem must match raw rag files');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('BLUE-VIZ-LINEAGE-4: wikilink edges connect concept pages bidirectionally observed', async () => {
+    const root = await makeLineageVault();
+    try {
+      const graph = await buildLineageGraph(root);
+      const wikilinks = graph.edges.filter((e) => e.kind === 'wikilink');
+      // jwt → oauth (from concepts/jwt.md), oauth → jwt (from concepts/oauth.md)
+      const jwtToOauth = wikilinks.find((e) =>
+        e.source === 'wiki:concepts/jwt.md' && e.target === 'wiki:concepts/oauth.md',
+      );
+      assert.ok(jwtToOauth, 'jwt → oauth wikilink edge expected');
+      assert.equal(jwtToOauth.confidence, EDGE_CONFIDENCE.wikilink);
+      assert.equal(jwtToOauth.hint, '[[oauth]]');
+      const oauthToJwt = wikilinks.find((e) =>
+        e.source === 'wiki:concepts/oauth.md' && e.target === 'wiki:concepts/jwt.md',
+      );
+      assert.ok(oauthToJwt, 'oauth → jwt wikilink edge expected');
+      // jwt → rag-pipeline-summary (basename resolution via summaries/)
+      const jwtToRag = wikilinks.find((e) =>
+        e.source === 'wiki:concepts/jwt.md' && e.target === 'wiki:summaries/rag-pipeline-summary.md',
+      );
+      assert.ok(jwtToRag, 'jwt → rag-pipeline-summary wikilink edge expected via basename match');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('BLUE-VIZ-LINEAGE-5: time proximity edges only cross-layer within window', async () => {
+    const root = await makeLineageVault({ applyMtimes: true });
+    try {
+      const graph = await buildLineageGraph(root, { timeProximitySeconds: 3600 });
+      const timeEdges = graph.edges.filter((e) => e.kind === 'time');
+      // Raw pdf (09:00) → summary (09:10), notes (09:20), raw md (09:00:30) are all in 1h window.
+      // All raw↔summary pairs and raw↔raw (same layer, dropped) etc.
+      assert.ok(timeEdges.length > 0, 'expected at least one cross-layer time edge');
+      // Confidence is lowest among edge kinds
+      for (const e of timeEdges) {
+        assert.equal(e.confidence, EDGE_CONFIDENCE.time);
+        assert.match(e.hint, /mtime proximity/);
+      }
+      // Same-layer pair (rag-pipeline-summary ↔ rag-pipeline-notes are both summary)
+      // must NOT be in time edges (sha256 covers it, time would be noise)
+      const sameLayer = timeEdges.find((e) => {
+        const layerOf = (id) => {
+          if (id.startsWith('raw:')) return 'raw';
+          if (id.includes(':summaries/')) return 'summary';
+          return 'wiki';
+        };
+        return layerOf(e.source) === layerOf(e.target);
+      });
+      assert.equal(sameLayer, undefined, 'time edges must be cross-layer only');
+      // jwt concept (15:00) is far outside the rag cluster (09:xx) — no time edge to rag
+      const farPair = timeEdges.find((e) =>
+        (e.source === 'wiki:concepts/jwt.md' && e.target.includes('rag-pipeline')) ||
+        (e.target === 'wiki:concepts/jwt.md' && e.source.includes('rag-pipeline')),
+      );
+      assert.equal(farPair, undefined, '6-hour-apart pair must not produce a time edge');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('BLUE-VIZ-LINEAGE-6: selectSubgraph respects 1-hop and 2-hop limits', async () => {
+    const root = await makeLineageVault();
+    try {
+      const graph = await buildLineageGraph(root);
+      const center = 'wiki:summaries/rag-pipeline-summary.md';
+      const oneHop = selectSubgraph(graph, center, 1);
+      const twoHop = selectSubgraph(graph, center, 2);
+      assert.ok(oneHop.nodes.length >= 2, 'center + at least one neighbor');
+      assert.ok(oneHop.nodes.find((n) => n.id === center), 'center included in 1-hop');
+      // 2-hop must be ≥ 1-hop and ≤ full graph
+      assert.ok(twoHop.nodes.length >= oneHop.nodes.length);
+      assert.ok(twoHop.nodes.length <= graph.nodes.length);
+      // Edges restricted to included nodes
+      const ids = new Set(twoHop.nodes.map((n) => n.id));
+      for (const e of twoHop.edges) {
+        assert.ok(ids.has(e.source) && ids.has(e.target),
+          `edge ${e.source}→${e.target} outside subgraph node set`);
+      }
+      // Unknown center → empty
+      const empty = selectSubgraph(graph, 'wiki:does/not/exist.md', 1);
+      assert.deepEqual(empty, { nodes: [], edges: [] });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('BLUE-VIZ-LINEAGE-7: best-effort hint shape + confidence ordering', async () => {
+    const root = await makeLineageVault();
+    try {
+      const graph = await buildLineageGraph(root);
+      // top-level shape
+      assert.equal(graph.schema_version, LINEAGE_SCHEMA_VERSION);
+      assert.match(graph.hint_note, /estimated lineage/i, 'estimated lineage 注釈 required');
+      assert.match(graph.hint_note, /best-effort/i);
+      // 5 edge kinds counted in hint_summary
+      assert.deepEqual(Object.keys(graph.hint_summary).sort(), EDGE_KINDS.slice().sort());
+      // Confidence ordering invariant: sha256 ≥ derived_from ≥ wikilink ≥ filename ≥ time
+      assert.ok(EDGE_CONFIDENCE.sha256 >= EDGE_CONFIDENCE.derived_from);
+      assert.ok(EDGE_CONFIDENCE.derived_from >= EDGE_CONFIDENCE.wikilink);
+      assert.ok(EDGE_CONFIDENCE.wikilink >= EDGE_CONFIDENCE.filename);
+      assert.ok(EDGE_CONFIDENCE.filename >= EDGE_CONFIDENCE.time);
+      // Every edge carries the 4 required fields
+      for (const e of graph.edges) {
+        assert.equal(typeof e.source, 'string');
+        assert.equal(typeof e.target, 'string');
+        assert.ok(EDGE_KINDS.includes(e.kind));
+        assert.equal(typeof e.confidence, 'number');
+        assert.equal(typeof e.hint, 'string');
+        assert.ok(e.hint.length > 0);
+      }
+      // node body / text never leaks into lineage output (P1 absolute contract continues)
+      const serialized = JSON.stringify(graph);
+      assert.ok(!serialized.includes('"body"'), 'page body must not leak into lineage graph');
+      assert.ok(!serialized.includes('"text"'), 'raw text must not leak into lineage graph');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('BLUE-VIZ-LINEAGE-cap: node_cap drops oldest, sets truncated=true', async () => {
+    const root = await makeLineageVault();
+    try {
+      const graph = await buildLineageGraph(root, { nodeCap: 3 });
+      assert.equal(graph.nodes.length, 3);
+      assert.equal(graph.truncated, true);
+      assert.equal(graph.node_cap, 3);
+      assert.ok(graph.totals.nodes === 3);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('BLUE-VIZ-LINEAGE-empty: vault with no raw-sources / wiki returns empty totals', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'kioku-lineage-empty-'));
+    try {
+      // No wiki/ or raw-sources/
+      const graph = await buildLineageGraph(root);
+      assert.deepEqual(graph.totals, { nodes: 0, raw: 0, summary: 0, wiki: 0, edges: 0 });
+      assert.equal(graph.truncated, false);
+      assert.equal(graph.nodes.length, 0);
+      assert.equal(graph.edges.length, 0);
+      // Hint summary still has all 5 kinds with 0 counts
+      assert.deepEqual(graph.hint_summary, { sha256: 0, derived_from: 0, filename: 0, wikilink: 0, time: 0 });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('BLUE-VIZ-LINEAGE-perf: 300 node sythetic vault stays under 1s', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'kioku-lineage-perf-'));
+    try {
+      await mkdir(join(root, 'wiki', 'concepts'), { recursive: true });
+      await mkdir(join(root, 'wiki', 'summaries'), { recursive: true });
+      await mkdir(join(root, 'raw-sources'), { recursive: true });
+      // 100 concepts + 100 summaries + 100 raw sources = 300 nodes
+      for (let i = 0; i < 100; i++) {
+        await writeFile(
+          join(root, 'wiki', 'concepts', `concept-${i}.md`),
+          `---\ntype: concept\n---\n\n# Concept ${i}\n\n[[concept-${(i + 1) % 100}]]\n`,
+        );
+        await writeFile(
+          join(root, 'wiki', 'summaries', `summary-${i}.md`),
+          `---\nsource_sha256: ${'a'.repeat(60)}${i.toString().padStart(4, '0')}\n---\n\n# Summary ${i}\n`,
+        );
+        await writeFile(join(root, 'raw-sources', `raw-${i}.pdf`), `fake pdf ${i}`);
+      }
+      const t0 = Date.now();
+      const graph = await buildLineageGraph(root, { nodeCap: DEFAULT_NODE_CAP });
+      const elapsed = Date.now() - t0;
+      assert.equal(graph.totals.nodes, 300);
+      assert.ok(elapsed < 1500, `300 node graph build took ${elapsed}ms (expected < 1500ms)`);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('BLUE-VIZ-LINEAGE-internals: _internals exports are stable', () => {
+    assert.ok(typeof _internals.slugify === 'function');
+    assert.equal(_internals.slugify('RAG Pipeline Notes'), 'rag-pipeline-notes');
+    assert.equal(_internals.summarySlugStem('rag-pipeline-summary'), 'rag-pipeline');
+    assert.equal(_internals.summarySlugStem('rag-pipeline-notes'), 'rag-pipeline');
+    assert.equal(_internals.layerForWikiPage('summaries/x.md'), 'summary');
+    assert.equal(_internals.layerForWikiPage('concepts/x.md'), 'wiki');
+  });
+});

--- a/tests/mcp/tools-visualizer-screenshot.test.mjs
+++ b/tests/mcp/tools-visualizer-screenshot.test.mjs
@@ -1,0 +1,183 @@
+// tools-visualizer-screenshot.test.mjs — Sprint 3 v0.8 β Phase 4
+//
+// CI screenshot regression test: empty / small fixture Vault で kioku_generate_viz が
+// 破綻なく動き、screenshot 撮影に必要な DOM containers / data shape / drawer 要素が揃って
+// いることを assert する。実 screenshot は撮らない (headless browser 依存を持ち込まない
+// = Node 18+ stdlib only 原則 §「Hook スクリプトは外部依存を入れない」を test にも適用)
+// が、screenshot 担保すべき要素を DOM / JSON shape として固定する。
+//
+// 実行: node --test tools/claude-brain/tests/mcp/tools-visualizer-screenshot.test.mjs
+//
+// ケース:
+//   BLUE-VIZ-SCREENSHOT-1: empty Vault state 破綻なし (auto-lint drawer "未実行" 案内)
+//   BLUE-VIZ-SCREENSHOT-2: small Vault で全 view 動作 (Overview/Timeline/Diff/Lineage)
+//   BLUE-VIZ-SCREENSHOT-3: auto-lint drawer 4 観点表示 (small Vault fixture lint-report.md)
+//   BLUE-VIZ-SCREENSHOT-4: 既存 Timeline Player / Diff Viewer regression (Phase D α 維持)
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { spawnSync } from 'node:child_process';
+
+import { handleGenerateViz } from '../../mcp/tools/visualizer.mjs';
+import { cloneEmptyVault, cloneSmallVault, disposeFixtureVault } from '../fixtures/visualizer-vaults.mjs';
+
+// git が利用可能でなければ skip — visualizer は git log で commit を集めるので git 必須。
+const gitAvailable = spawnSync('git', ['--version']).status === 0;
+
+function parseDataBlob(html) {
+  const m = html.match(/<script type="application\/json" id="kioku-data">([^<]*)<\/script>/);
+  assert.ok(m, 'data JSON script tag exists in HTML');
+  return JSON.parse(m[1]);
+}
+
+describe('kioku_generate_viz — Sprint 3 v0.8 β Phase 4 screenshot regression', () => {
+
+  test('BLUE-VIZ-SCREENSHOT-1: empty Vault state 破綻なし (drawer は "未実行" 案内のみ)', async () => {
+    if (!gitAvailable) return;
+    const vault = await cloneEmptyVault();
+    try {
+      const res = await handleGenerateViz(vault, {});
+      // 生成自体は成功するはず (commit はある = git log 集計可)
+      assert.equal(typeof res.path, 'string');
+      assert.equal(res.first_view_error, null,
+        'empty Vault でも first_view 計算は成功する (健全な状態の表現として first_view を返す)');
+      assert.equal(res.auto_lint_present, false,
+        'empty Vault には wiki/lint-report.md が無いので auto_lint_present は false');
+
+      const html = await readFile(res.path, 'utf8');
+      const data = parseDataBlob(html);
+      // schema_version 確認 (Phase 4 で 4 に bump 済)
+      assert.equal(data.schema_version, 4);
+      // first_view present, auto_lint null (graceful)
+      assert.ok(data.first_view, 'first_view object present');
+      assert.equal(data.first_view.auto_lint, null,
+        'no lint-report.md → auto_lint is null (graceful)');
+      // graph_preview は空でも構わない (wiki/ が無い)
+      assert.ok(data.first_view.graph_preview, 'graph_preview key exists');
+
+      // HTML 側: 5 枚目 card markup が存在する (drawer 容器)
+      assert.match(html, /id="ov-quality-notes"/);
+      // "auto-lint 未実行" 案内のためのコマンド表記が HTML JS render path に含まれる
+      assert.match(html, /bash scripts\/auto-lint\.sh/,
+        'renderQualityNotes JS has command suggestion for empty state');
+    } finally {
+      await disposeFixtureVault(vault);
+    }
+  });
+
+  test('BLUE-VIZ-SCREENSHOT-2: small Vault で全 view 動作 (Overview/Timeline/Diff/Lineage)', async () => {
+    if (!gitAvailable) return;
+    const vault = await cloneSmallVault();
+    try {
+      const res = await handleGenerateViz(vault, {});
+      assert.equal(res.first_view_present, true);
+      assert.equal(res.lineage_present, true,
+        'small Vault でも lineage は計算成功 (raw-sources 0 でも summaries / wiki layer は存在)');
+      assert.deepEqual(res.views, ['overview', 'timeline-player', 'diff-viewer', 'lineage']);
+      assert.ok(res.snapshots >= 2,
+        'small Vault は 2 commit ある → snapshot 2 以上で Timeline 切替テスト可');
+
+      const html = await readFile(res.path, 'utf8');
+      const data = parseDataBlob(html);
+      assert.equal(data.first_view.schema_version, 2,
+        'first_view schema_version は Phase 4 で 2 に bump');
+      assert.ok(data.snapshots.length >= 2, 'snapshots array carries 2+ entries');
+
+      // graph_preview: 5 page の中で hot_pages / active_projects / recent_decisions が
+      // それぞれ classified されることを軽く確認 (validates fixture content)
+      const gp = data.first_view.graph_preview;
+      assert.ok(Array.isArray(gp.hot_pages) && gp.hot_pages.length > 0,
+        'hot_pages non-empty for small vault');
+      assert.ok(gp.active_projects.some((p) => p.name === 'kioku-mini'),
+        'fixture project page kioku-mini classified into active_projects');
+      assert.ok(gp.recent_decisions.some((p) => p.name === 'use-edge-runtime'),
+        'fixture decision page use-edge-runtime classified into recent_decisions');
+    } finally {
+      await disposeFixtureVault(vault);
+    }
+  });
+
+  test('BLUE-VIZ-SCREENSHOT-3: auto-lint drawer 4 観点表示 (small Vault lint-report.md 経由)', async () => {
+    if (!gitAvailable) return;
+    const vault = await cloneSmallVault();
+    try {
+      const res = await handleGenerateViz(vault, {});
+      assert.equal(res.auto_lint_present, true,
+        'small Vault は wiki/lint-report.md を持つので auto_lint_present=true');
+
+      const html = await readFile(res.path, 'utf8');
+      const data = parseDataBlob(html);
+      const al = data.first_view.auto_lint;
+      assert.ok(al, 'auto_lint object embedded in first_view');
+      assert.equal(al.report_exists, true);
+      assert.equal(al.source_path, 'wiki/lint-report.md');
+      assert.equal(al.categories.length, 4, '4 観点 categories');
+
+      const byKey = Object.fromEntries(al.categories.map((c) => [c.key, c]));
+      // fixture lint-report.md は 4 観点各 1 finding
+      assert.equal(byKey.contradiction.count, 1);
+      assert.equal(byKey.splinter.count, 1);
+      assert.equal(byKey.promotion_candidate.count, 1);
+      assert.equal(byKey.link_gap.count, 1);
+      assert.equal(al.total_findings, 4);
+
+      // sample text are non-empty (fixture lint-report の本文がそのまま入っている)
+      for (const cat of al.categories) {
+        assert.ok(cat.samples.length === 1, `${cat.key} has 1 sample`);
+        assert.ok(typeof cat.samples[0] === 'string' && cat.samples[0].length > 0,
+          `${cat.key} sample is non-empty string`);
+      }
+
+      // HTML 側: drawer card + 4 観点 CSS + heading
+      assert.match(html, /Quality notes \(auto-lint\)/);
+      assert.match(html, /\.qn-cat\s*\{/);
+      assert.match(html, /\.qn-samples\s*\{/);
+      assert.match(html, /\.qn-disclosure\s*\{/);
+    } finally {
+      await disposeFixtureVault(vault);
+    }
+  });
+
+  test('BLUE-VIZ-SCREENSHOT-4: 既存 Timeline / Diff regression (Phase D α 維持)', async () => {
+    if (!gitAvailable) return;
+    const vault = await cloneSmallVault();
+    try {
+      const res = await handleGenerateViz(vault, {});
+      const html = await readFile(res.path, 'utf8');
+      const data = parseDataBlob(html);
+
+      // Timeline tab markup + JS path (V-2 で既に存在、Phase 4 で壊さない契約)
+      assert.match(html, /id="tab-timeline"/);
+      assert.match(html, /id="tp-slider"/);
+      assert.match(html, /id="tp-play"/);
+
+      // Diff tab markup + JS path
+      assert.match(html, /id="tab-diff"/);
+      assert.match(html, /id="dv-from"/);
+      assert.match(html, /id="dv-to"/);
+      assert.match(html, /id="dv-diff"/);
+
+      // snapshots data structure 不変 (Timeline / Diff の入力)
+      assert.ok(Array.isArray(data.snapshots), 'snapshots is array');
+      for (const snap of data.snapshots) {
+        assert.equal(typeof snap.sha, 'string');
+        assert.equal(typeof snap.timestamp, 'number');
+        assert.ok(Array.isArray(snap.pages), 'snapshot.pages is array');
+        assert.ok(Array.isArray(snap.links), 'snapshot.links is array');
+        // P1 security 契約: body フィールドは snapshot に含めない (VIZ-T3 と同じ assertion)
+        for (const p of snap.pages) {
+          assert.ok(!('body' in p), 'snapshot page must not include body');
+          assert.ok(!('content' in p), 'snapshot page must not include content');
+        }
+      }
+
+      // generation summary に既存 user 互換性のため必要な field が引き続き存在
+      assert.equal(typeof res.commits, 'number');
+      assert.equal(typeof res.latest_pages, 'number');
+      assert.equal(typeof res.since, 'string');
+    } finally {
+      await disposeFixtureVault(vault);
+    }
+  });
+});

--- a/tests/mcp/visualizer.test.mjs
+++ b/tests/mcp/visualizer.test.mjs
@@ -2,14 +2,17 @@
 //
 // 実行: node --test tools/claude-brain/tests/mcp/visualizer.test.mjs
 //
-// ケース (VIZ-T1 〜 VIZ-T7):
+// ケース (VIZ-T1 〜 VIZ-T9):
 //   VIZ-T1: TOOL_DEF shape (name / title / description / inputShape)
 //   VIZ-T2: 非 git vault → helpful error
-//   VIZ-T3: 正常パス — git fixture で生成、HTML 内に data JSON 埋め込み確認
+//   VIZ-T3: 正常パス — git fixture で生成、HTML 内に data JSON 埋め込み確認 (schema_version=4 含む、Phase 4 で bump)
 //   VIZ-T4: output_path validation — `.cache/viz/` prefix 以外は reject
 //   VIZ-T5: embeddings=true は "deferred to v0.8" で reject
 //   VIZ-T6: path traversal in output_path → boundary error
 //   VIZ-T7: XSS hardening — script close tag が HTML 内で escape される
+//   VIZ-T8: first_view 4 layer が data blob に埋め込まれる (Phase 1 v0.8 β)
+//   VIZ-T9: Phase 2 health overlay elements (status banner + bar chart + sparkline + warm gradient + cluster) が HTML に存在 + Phase 4 で auto-lint drawer presence へ flip (旧 negative→positive)
+//   VIZ-T10: Phase 3 lineage graph が data blob + HTML tab に embed される (Sprint 3 v0.8 β Phase 3)
 
 import { test, describe, before } from 'node:test';
 import assert from 'node:assert/strict';
@@ -132,9 +135,15 @@ describe('kioku_generate_viz (Phase D α V-2)', () => {
       const m = html.match(/<script type="application\/json" id="kioku-data">([^<]*)<\/script>/);
       assert.ok(m, 'kioku-data script block missing');
       const parsed = JSON.parse(m[1]);
-      assert.equal(parsed.schema_version, 1);
+      assert.equal(parsed.schema_version, 4, 'schema_version bumped to 4 with Phase 4 auto-lint drawer');
       assert.ok(Array.isArray(parsed.snapshots));
       assert.ok(parsed.snapshots.length >= 2);
+      // first_view field が存在 (Phase 1 v0.8 β、null 許容だが key 自体は present)
+      assert.ok('first_view' in parsed, 'first_view top-level field missing');
+      assert.ok('first_view_error' in parsed, 'first_view_error top-level field missing');
+      // lineage field が存在 (Phase 3、null 許容だが key 自体は present)
+      assert.ok('lineage' in parsed, 'lineage top-level field missing');
+      assert.ok('lineage_error' in parsed, 'lineage_error top-level field missing');
       // snapshot に body が含まれていないこと (plan P1 絶対契約)
       for (const s of parsed.snapshots) {
         for (const p of s.pages) {
@@ -212,5 +221,185 @@ describe('kioku_generate_viz (Phase D α V-2)', () => {
     assert.ok(out.includes('\\u003c/script>'), 'closing tag not escaped');
     // JSON.parse しても元データに戻ること (escape 後も valid JSON)
     assert.deepEqual(JSON.parse(out), malicious);
+  });
+
+  test('VIZ-T9: Phase 2 health overlay elements (banner + chart + sparkline + warm gradient + cluster) + Phase 4 auto-lint drawer presence (flipped)', async () => {
+    if (!gitAvailable) return;
+    const root = await makeFixtureVault();
+    try {
+      const res = await handleGenerateViz(root, {});
+      const html = await readFile(res.path, 'utf8');
+      const m = html.match(/<script type="application\/json" id="kioku-data">([^<]*)<\/script>/);
+      const parsed = JSON.parse(m[1]);
+
+      // Phase 2 data shapes in first_view
+      assert.ok(parsed.first_view.status_banner, 'status_banner field present');
+      assert.ok(parsed.first_view.status_banner.orphan, 'status_banner.orphan present');
+      assert.ok(parsed.first_view.status_banner.stale, 'status_banner.stale present');
+      assert.ok(parsed.first_view.status_banner.duplicate_title, 'status_banner.duplicate_title present');
+      assert.ok(parsed.first_view.status_banner.hot_md_age, 'status_banner.hot_md_age present');
+      assert.ok(parsed.first_view.status_banner.last_ingest, 'status_banner.last_ingest present');
+      assert.ok(parsed.first_view.status_banner.unprocessed_logs, 'status_banner.unprocessed_logs present');
+
+      assert.ok(Array.isArray(parsed.first_view.vault_overview.page_count_by_type.sorted_entries),
+        'sorted_entries field present for bar chart');
+      assert.ok(parsed.first_view.health_focus.pages_warm_zone.distribution,
+        'pages_warm_zone.distribution present for gradient');
+      assert.ok(Array.isArray(parsed.first_view.health_focus.broken_wikilink.clusters),
+        'broken_wikilink.clusters present for cluster view');
+
+      // Phase 2 HTML elements:
+      //   - DOM container (status banner) は static HTML 上に存在
+      //   - bar chart / sparkline / warm gradient / cluster は JS で動的生成、
+      //     CSS class 定義の存在で render path が用意されていることを確認
+      assert.match(html, /id="ov-status-banner"/, 'status banner container in HTML');
+      // CSS class definitions (verify render path 用意済)
+      assert.match(html, /\.status-banner\s*\{/, 'status-banner CSS rule defined');
+      assert.match(html, /\.sb-chip\s*\{/, 'sb-chip CSS rule defined (JS が runtime に append)');
+      assert.match(html, /\.bar-chart\s*\{/, 'bar-chart CSS rule defined for type distribution');
+      assert.match(html, /\.sparkline\s*\{/, 'sparkline CSS rule defined for growth');
+      assert.match(html, /\.warm-gradient\s*\{/, 'warm-gradient CSS rule defined for fresh/warm/stale');
+      assert.match(html, /\.cluster-list\s*\{/, 'cluster-list CSS rule defined for broken/sha256');
+      // severity class definitions (各 severity が CSS rule で配色定義済)
+      assert.match(html, /\.sev-ok\b/, 'sev-ok CSS defined');
+      assert.match(html, /\.sev-info\b/, 'sev-info CSS defined');
+      assert.match(html, /\.sev-warn\b/, 'sev-warn CSS defined');
+      assert.match(html, /\.sev-danger\b/, 'sev-danger CSS defined');
+      // JS render path mentions (chip creation, growth sparkline, gradient segment)
+      assert.match(html, /createElement\("div"\)/, 'render path uses createElement');
+      assert.match(html, /sb-chip sev-/, 'JS appends sb-chip with severity class');
+      assert.match(html, /wg-seg /, 'JS creates warm gradient segments');
+      assert.match(html, /cluster-item/, 'JS creates cluster items');
+
+      // Phase 4 flip: auto-lint drawer is now present (was negative in Phase 2)
+      // - first_view contains auto_lint field (graceful null when no wiki/lint-report.md)
+      // - HTML contains the 5th card container (ov-quality-notes) + CSS rules for drawer
+      // - fixture vault has no lint-report.md → auto_lint === null, renders "未実行" message
+      assert.ok('auto_lint' in parsed.first_view,
+        'auto_lint field is present in first_view (Phase 4 drawer)');
+      assert.equal(parsed.first_view.auto_lint, null,
+        'fixture vault has no wiki/lint-report.md → auto_lint is null (graceful)');
+
+      // HTML side: drawer card + CSS rules for renderQualityNotes
+      assert.match(html, /id="ov-quality-notes"/, 'quality-notes card container in HTML');
+      assert.match(html, /\.qn-cat\s*\{/, 'qn-cat CSS rule defined');
+      assert.match(html, /\.qn-samples\s*\{/, 'qn-samples CSS rule defined');
+      assert.match(html, /\.qn-missing\s*\{/, 'qn-missing CSS rule defined for empty state');
+      assert.match(html, /Quality notes \(auto-lint\)/, 'card heading text in template');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('VIZ-T8: first_view 4 layer ordering が data blob に埋め込まれる (Phase 1 v0.8 β)', async () => {
+    if (!gitAvailable) return;
+    const root = await makeFixtureVault();
+    try {
+      const res = await handleGenerateViz(root, {});
+      // 返り値 shape — Phase 1 で追加された field + Phase 3 で lineage tab 追加
+      assert.ok(Array.isArray(res.views));
+      assert.deepEqual(res.views, ['overview', 'timeline-player', 'diff-viewer', 'lineage'],
+        'overview + lineage を含む 4 view が宣言される (Phase 3)');
+      assert.equal(typeof res.first_view_present, 'boolean');
+      assert.ok(res.first_view_present, 'fixture vault でも first_view は計算成功するはず');
+      assert.equal(res.first_view_error, null);
+
+      // HTML 内 first_view 4 layer
+      const html = await readFile(res.path, 'utf8');
+      const m = html.match(/<script type="application\/json" id="kioku-data">([^<]*)<\/script>/);
+      const parsed = JSON.parse(m[1]);
+      assert.ok(parsed.first_view, 'first_view must be populated');
+      assert.equal(parsed.first_view.schema_version, 2,
+        'first_view schema_version bumped to 2 in Phase 4 (auto_lint field added)');
+      // 4 layer 順序 (codex doc Axis 3)
+      assert.ok(parsed.first_view.vault_overview, 'layer 1 vault_overview');
+      assert.ok(parsed.first_view.health_focus, 'layer 2 health_focus');
+      assert.ok(parsed.first_view.graph_preview, 'layer 3 graph_preview');
+      assert.ok(Array.isArray(parsed.first_view.action_queue), 'layer 4 action_queue');
+
+      // vault_overview: pages_total が fixture の page 数 (≥ 3) と整合
+      assert.ok(parsed.first_view.vault_overview.pages_total >= 3,
+        `expected ≥ 3 pages in fixture, got ${parsed.first_view.vault_overview.pages_total}`);
+      // page_count_by_type は concept type を含む (fixture に concepts/ あり)
+      assert.ok(parsed.first_view.vault_overview.page_count_by_type.by_type.concept >= 2,
+        'fixture has 2+ concept pages');
+
+      // HTML 自体に Overview tab が存在 (default active)
+      assert.match(html, /id="tab-overview"[^>]*class="active"/);
+      assert.match(html, /id="view-overview"[^>]*class="view active"/);
+
+      // body 漏洩防止契約は first_view でも継承 (snapshot.pages も pages_total も body を含まない)
+      // — health metrics は frontmatter 経由なので body は触らない設計
+      assert.ok(!JSON.stringify(parsed.first_view).includes('"body"'),
+        'first_view must not leak page body');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('VIZ-T10: Phase 3 lineage graph embeds 3-layer nodes + 5 edge kinds + HTML tab/CSS', async () => {
+    if (!gitAvailable) return;
+    const root = await makeFixtureVault();
+    try {
+      // Add raw-sources + a summary referencing them so the fixture exercises lineage paths.
+      await mkdir(join(root, 'raw-sources', 'pdf'), { recursive: true });
+      await mkdir(join(root, 'wiki', 'summaries'), { recursive: true });
+      await writeFile(join(root, 'raw-sources', 'pdf', 'jwt.pdf'), '%PDF fake');
+      await writeFile(
+        join(root, 'wiki', 'summaries', 'jwt-summary.md'),
+        '---\nsource_sha256: ' + 'a'.repeat(64) + '\nderived_from: raw-sources/pdf/jwt.pdf\n---\n\n# jwt summary\n',
+      );
+
+      const res = await handleGenerateViz(root, {});
+      // Return value shape
+      assert.equal(res.lineage_present, true, 'lineage_present=true for non-empty vault');
+      assert.equal(res.lineage_error, null);
+      assert.ok(res.lineage_totals);
+      assert.ok(res.lineage_totals.nodes >= 4, 'wiki + summary + raw nodes >= 4');
+
+      const html = await readFile(res.path, 'utf8');
+      const m = html.match(/<script type="application\/json" id="kioku-data">([^<]*)<\/script>/);
+      const parsed = JSON.parse(m[1]);
+      assert.ok(parsed.lineage, 'lineage embedded in inline JSON');
+      assert.equal(parsed.lineage.schema_version, 1);
+      assert.match(parsed.lineage.hint_note, /estimated lineage/i);
+      // 3 layer classification on nodes
+      const layers = new Set((parsed.lineage.nodes || []).map((n) => n.layer));
+      assert.ok(layers.has('raw'), 'raw layer present');
+      assert.ok(layers.has('summary'), 'summary layer present');
+      assert.ok(layers.has('wiki'), 'wiki layer present');
+      // hint_summary has 5 edge kinds
+      assert.deepEqual(
+        Object.keys(parsed.lineage.hint_summary).sort(),
+        ['derived_from', 'filename', 'sha256', 'time', 'wikilink'],
+      );
+      // derived_from + filename edges expected for jwt-summary fixture
+      const edges = parsed.lineage.edges || [];
+      const derivedHit = edges.find((e) => e.kind === 'derived_from'
+        && e.source === 'wiki:summaries/jwt-summary.md'
+        && e.target === 'raw:pdf/jwt.pdf');
+      assert.ok(derivedHit, 'derived_from edge from summary to raw pdf expected');
+
+      // body 漏洩契約継承
+      assert.ok(!JSON.stringify(parsed.lineage).includes('"body"'),
+        'lineage must not leak page body');
+      assert.ok(!JSON.stringify(parsed.lineage).includes('"text"'),
+        'lineage must not leak raw text');
+
+      // HTML side: Lineage tab + view section + CSS hooks
+      assert.match(html, /id="tab-lineage"/, 'Lineage tab button in HTML');
+      assert.match(html, /id="view-lineage"/, 'Lineage view section in HTML');
+      assert.match(html, /\.ln-banner\s*\{/, 'ln-banner CSS rule defined');
+      assert.match(html, /\.ln-node-row\s*\{/, 'ln-node-row CSS rule defined');
+      assert.match(html, /\.ln-edge-chip\s*\{/, 'ln-edge-chip CSS rule defined');
+      assert.match(html, /\.ln-layer-raw\b/, 'raw layer pill style defined');
+      assert.match(html, /\.ln-layer-summary\b/, 'summary layer pill style defined');
+      assert.match(html, /\.ln-layer-wiki\b/, 'wiki layer pill style defined');
+      // JS render path
+      assert.match(html, /renderLineage\s*\(/, 'renderLineage JS function called');
+      assert.match(html, /estimated lineage/, 'best-effort disclosure text in JS');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/visualizer-data.test.mjs
+++ b/tests/visualizer-data.test.mjs
@@ -1,0 +1,799 @@
+// visualizer-data.test.mjs — Phase 1+2 v0.8 Visualizer β First view data tests
+//
+// 実行: node --test tools/claude-brain/tests/visualizer-data.test.mjs
+//
+// codex strategic doc 260512_v0-8-visualizer-beta-scope.md §Axis 3 First view
+// = 4 layer ordering (Vault overview / Health focus / Graph preview / Action queue)
+//
+// Phase 1 ケース:
+//   BLUE-VIZ-FIRSTVIEW-1: Vault overview data shape
+//   BLUE-VIZ-FIRSTVIEW-2: Health focus data shape (broken / sha256 dup / warm zone)
+//   BLUE-VIZ-FIRSTVIEW-3: Graph preview data (hot pages / active projects / recent decisions)
+//   BLUE-VIZ-FIRSTVIEW-4: Action queue 3-5 件 (priority + next_action 必須)
+//   BLUE-VIZ-FIRSTVIEW-5: Schema isolation — first_view が既存 snapshots schema を壊さない
+//
+// Phase 2 ケース (Health overlay integration):
+//   BLUE-VIZ-HEALTH-OVERLAY-1: broken_wikilink.clusters (target でグループ化、merge target view)
+//   BLUE-VIZ-HEALTH-OVERLAY-2: source_sha256_duplicate.groups merge candidate context
+//   BLUE-VIZ-HEALTH-OVERLAY-3: pages_warm_zone.distribution (fresh/warm/stale 3 bucket gradient)
+//   BLUE-VIZ-HEALTH-OVERLAY-4: page_count_by_type chart-friendly (sorted entries 計算)
+//   BLUE-VIZ-HEALTH-OVERLAY-5: summaries_growth_rate sparkline data (7d/30d + per_day)
+//   BLUE-VIZ-HEALTH-OVERLAY-6: status_banner with 6 P1 metrics + severity (ok/info/warn/danger)
+//   BLUE-VIZ-HEALTH-OVERLAY-7: (Phase 4 で flip) auto_lint field is now present in first_view,
+//                              graceful null when no report file
+//
+// Phase 4 ケース (Auto-lint drawer):
+//   BLUE-VIZ-AUTOLINT-DRAWER-1: loadAutoLintReport returns null when no wiki/lint-report.md
+//   BLUE-VIZ-AUTOLINT-DRAWER-2: 4 観点 sections are correctly extracted with samples + counts
+//   BLUE-VIZ-AUTOLINT-DRAWER-3: sample text is collapsed + truncated to 240 chars
+//   BLUE-VIZ-AUTOLINT-DRAWER-4: sample_limit caps per-category at 3 samples
+//   BLUE-VIZ-AUTOLINT-DRAWER-5: "(検出なし)" / "none" markers produce count=0
+//   BLUE-VIZ-AUTOLINT-DRAWER-6: frontmatter date is extracted as generated_at
+//   BLUE-VIZ-AUTOLINT-DRAWER-7: malformed markdown doesn't crash (paragraph fallback)
+//   BLUE-VIZ-AUTOLINT-DRAWER-8: source_truncated flag set when file exceeds 256KB
+//   BLUE-VIZ-AUTOLINT-DRAWER-9: collectFirstViewData embeds auto_lint into first_view
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  collectFirstViewData,
+  walkLiveWikiPages,
+  loadAutoLintReport,
+  FIRST_VIEW_SCHEMA_VERSION,
+  AUTO_LINT_SCHEMA_VERSION,
+  _internals,
+} from '../mcp/lib/visualizer-data.mjs';
+
+// ───────────── mock health data ─────────────
+// collectHealthMetrics(vault) が返す shape を最小限再現
+function makeMockHealth(overrides = {}) {
+  const base = {
+    schema_version: 2,
+    generated_at: '2026-05-12T00:00:00.000Z',
+    vault_pages_total: 155,
+    metrics: {
+      orphan: { count: 3, pages: ['concepts/foo.md', 'concepts/bar.md', 'analyses/baz.md'] },
+      stale: { count: 8, threshold_days: 30, pages: [] },
+      duplicate_title: { count: 1, groups: [] },
+      hot_md_age: { exists: true, mtime_iso: '2026-05-11T00:00:00.000Z', age_seconds: 86400, age_human: '1d' },
+      last_ingest: { exists: true, log_count: 200, mtime_iso: '2026-05-11T20:00:00.000Z', age_seconds: 14400, age_human: '4h' },
+      unprocessed_logs: { count: 7, sample_paths: [], sample_truncated: false },
+      broken_wikilink: {
+        count: 21,
+        samples: [
+          { source: 'concepts/a.md', target: 'missing-1' },
+          { source: 'concepts/b.md', target: 'missing-2' },
+        ],
+        sample_truncated: false,
+      },
+      source_sha256_duplicate: {
+        count: 2,
+        groups: [
+          { source_sha256: 'aaaa', paths: ['summaries/x.md', 'summaries/y.md'] },
+          { source_sha256: 'bbbb', paths: ['summaries/z.md', 'summaries/w.md'] },
+        ],
+      },
+      pages_warm_zone: {
+        count: 12,
+        lower_days: 7,
+        upper_days: 30,
+        pages: [{ rel: 'concepts/warm1.md', age_days: 14, updated: '2026-04-28' }],
+      },
+      page_count_by_type: {
+        total: 155,
+        by_type: { concept: 40, project: 8, decision: 12, summary: 70, analysis: 15, other: 10 },
+      },
+      summaries_growth_rate: {
+        vault_is_git: true,
+        day_7: { added: 14, per_day: 2.0 },
+        day_30: { added: 45, per_day: 1.5 },
+      },
+    },
+    next_actions: [],
+  };
+  return { ...base, ...overrides };
+}
+
+// snapshots: visualizer.mjs が build した shape を最小限再現 (newest first)。
+// 各 page には wikilinks (outgoing target 名 array) を持たせる — buildGraphPreview の
+// degree 計算が page.wikilinks 経由になったため必須 (snapshot 経由でも live walk 経由でも同形)。
+function makeMockSnapshots() {
+  return [
+    {
+      sha: 'a'.repeat(40),
+      shortSha: 'aaaaaaa',
+      timestamp: 1715472000000,
+      author: 'tester',
+      subject: 'latest commit',
+      pages: [
+        { name: 'index', type: 'index', tags: [], title: 'Index', path: 'wiki/index.md', wikilinks: ['jwt', 'oauth'] },
+        { name: 'jwt', type: 'concept', tags: ['auth'], title: 'JWT', path: 'wiki/concepts/jwt.md', wikilinks: ['oauth'] },
+        { name: 'oauth', type: 'concept', tags: ['auth'], title: 'OAuth', path: 'wiki/concepts/oauth.md', wikilinks: ['jwt'] },
+        { name: 'kioku', type: 'project', tags: [], title: 'KIOKU', path: 'wiki/projects/kioku.md', wikilinks: [] },
+        { name: 'use-postgres', type: 'decision', tags: [], title: 'Use Postgres', path: 'wiki/decisions/use-postgres.md', wikilinks: [] },
+      ],
+      links: [
+        { from: 'index', to: 'jwt' },
+        { from: 'index', to: 'oauth' },
+        { from: 'jwt', to: 'oauth' },
+        { from: 'oauth', to: 'jwt' },
+      ],
+      truncated: false,
+      error: null,
+    },
+  ];
+}
+
+describe('visualizer-data.mjs — Phase 1 v0.8 first view', () => {
+  test('BLUE-VIZ-FIRSTVIEW-1: vault_overview data shape', async () => {
+    const result = await collectFirstViewData('/dummy', {
+      health: makeMockHealth(),
+      snapshots: makeMockSnapshots(),
+      now: new Date('2026-05-12T00:00:00.000Z'),
+    });
+    assert.equal(result.schema_version, FIRST_VIEW_SCHEMA_VERSION);
+    assert.ok(result.vault_overview, 'vault_overview missing');
+    assert.equal(result.vault_overview.pages_total, 155);
+    assert.ok(result.vault_overview.summaries_growth, 'summaries_growth missing');
+    assert.equal(result.vault_overview.summaries_growth.vault_is_git, true);
+    assert.equal(result.vault_overview.summaries_growth.day_7.added, 14);
+    assert.equal(result.vault_overview.summaries_growth.day_30.added, 45);
+    assert.ok(result.vault_overview.page_count_by_type, 'page_count_by_type missing');
+    assert.equal(result.vault_overview.page_count_by_type.total, 155);
+    assert.equal(result.vault_overview.page_count_by_type.by_type.concept, 40);
+    assert.equal(result.vault_overview.page_count_by_type.by_type.summary, 70);
+  });
+
+  test('BLUE-VIZ-FIRSTVIEW-2: health_focus data shape', async () => {
+    const result = await collectFirstViewData('/dummy', {
+      health: makeMockHealth(),
+      snapshots: makeMockSnapshots(),
+      now: new Date('2026-05-12T00:00:00.000Z'),
+    });
+    assert.ok(result.health_focus, 'health_focus missing');
+    // broken_wikilink: count + samples (件数制限あり)
+    assert.equal(result.health_focus.broken_wikilink.count, 21);
+    assert.ok(Array.isArray(result.health_focus.broken_wikilink.samples));
+    assert.ok(result.health_focus.broken_wikilink.samples.length <= 5,
+      'broken_wikilink.samples should be capped to first 5 for compact display');
+    // source_sha256_duplicate: count + groups
+    assert.equal(result.health_focus.source_sha256_duplicate.count, 2);
+    assert.ok(Array.isArray(result.health_focus.source_sha256_duplicate.groups));
+    assert.ok(result.health_focus.source_sha256_duplicate.groups.length <= 5);
+    // pages_warm_zone: count + lower_days + upper_days + pages
+    assert.equal(result.health_focus.pages_warm_zone.count, 12);
+    assert.equal(result.health_focus.pages_warm_zone.lower_days, 7);
+    assert.equal(result.health_focus.pages_warm_zone.upper_days, 30);
+    assert.ok(Array.isArray(result.health_focus.pages_warm_zone.pages));
+  });
+
+  test('BLUE-VIZ-FIRSTVIEW-3: graph_preview data (hot pages / active projects / recent decisions)', async () => {
+    const result = await collectFirstViewData('/dummy', {
+      health: makeMockHealth(),
+      snapshots: makeMockSnapshots(),
+      now: new Date('2026-05-12T00:00:00.000Z'),
+    });
+    assert.ok(result.graph_preview, 'graph_preview missing');
+    assert.ok(Array.isArray(result.graph_preview.hot_pages), 'hot_pages should be array');
+    assert.ok(Array.isArray(result.graph_preview.active_projects), 'active_projects should be array');
+    assert.ok(Array.isArray(result.graph_preview.recent_decisions), 'recent_decisions should be array');
+
+    // hot_pages: 最新 snapshot から wikilink degree でソートされた page
+    // mock では oauth と jwt が degree=3 で最も hot
+    assert.ok(result.graph_preview.hot_pages.length > 0, 'hot_pages should have entries when snapshots exist');
+    const top = result.graph_preview.hot_pages[0];
+    assert.ok(typeof top.name === 'string');
+    assert.ok(typeof top.degree === 'number');
+
+    // active_projects: type=project の page だけが入る
+    for (const p of result.graph_preview.active_projects) {
+      assert.equal(p.type ?? 'project', 'project',
+        'active_projects must contain only type=project pages');
+    }
+    assert.ok(result.graph_preview.active_projects.some((p) => p.name === 'kioku'));
+
+    // recent_decisions: type=decision の page だけが入る
+    for (const p of result.graph_preview.recent_decisions) {
+      assert.equal(p.type ?? 'decision', 'decision',
+        'recent_decisions must contain only type=decision pages');
+    }
+    assert.ok(result.graph_preview.recent_decisions.some((p) => p.name === 'use-postgres'));
+  });
+
+  test('BLUE-VIZ-FIRSTVIEW-4: action_queue with priority + next_action (cap 5)', async () => {
+    const result = await collectFirstViewData('/dummy', {
+      health: makeMockHealth(),
+      snapshots: makeMockSnapshots(),
+      now: new Date('2026-05-12T00:00:00.000Z'),
+    });
+    assert.ok(Array.isArray(result.action_queue), 'action_queue must be an array');
+    assert.ok(result.action_queue.length >= 3, 'mock has 21 broken + 2 sha256dup + 12 warm + 8 stale + 7 unprocessed_logs + 3 orphan + 1 dup_title → expect ≥ 3 items');
+    assert.ok(result.action_queue.length <= 5, 'action_queue must be capped at 5');
+
+    // 各 item の必須 field
+    for (const item of result.action_queue) {
+      assert.ok(typeof item.priority === 'string', `priority missing: ${JSON.stringify(item)}`);
+      assert.match(item.priority, /^P[0-2]$/, `priority must be P0/P1/P2: ${item.priority}`);
+      assert.ok(typeof item.reason === 'string' && item.reason.length > 0, 'reason required');
+      assert.ok(typeof item.next_action === 'string' && item.next_action.length > 0, 'next_action required');
+    }
+
+    // P0 (broken_wikilink + source_sha256_duplicate) が先頭に来る
+    assert.equal(result.action_queue[0].priority, 'P0', 'highest priority item should be P0');
+
+    // 健全な vault (mock to have 0 issues) → action_queue は空配列
+    const healthyResult = await collectFirstViewData('/dummy', {
+      health: makeMockHealth({
+        metrics: {
+          orphan: { count: 0, pages: [] },
+          stale: { count: 0, threshold_days: 30, pages: [] },
+          duplicate_title: { count: 0, groups: [] },
+          hot_md_age: { exists: true, mtime_iso: '2026-05-12T00:00:00.000Z', age_seconds: 60, age_human: '1m' },
+          last_ingest: { exists: true, log_count: 200, mtime_iso: '2026-05-12T00:00:00.000Z', age_seconds: 60, age_human: '1m' },
+          unprocessed_logs: { count: 0, sample_paths: [], sample_truncated: false },
+          broken_wikilink: { count: 0, samples: [], sample_truncated: false },
+          source_sha256_duplicate: { count: 0, groups: [] },
+          pages_warm_zone: { count: 0, lower_days: 7, upper_days: 30, pages: [] },
+          page_count_by_type: { total: 155, by_type: { concept: 40 } },
+          summaries_growth_rate: { vault_is_git: true, day_7: { added: 5, per_day: 0.7 }, day_30: { added: 20, per_day: 0.67 } },
+        },
+      }),
+      snapshots: makeMockSnapshots(),
+      now: new Date('2026-05-12T00:00:00.000Z'),
+    });
+    assert.equal(healthyResult.action_queue.length, 0, 'healthy vault → empty action queue');
+  });
+
+  test('BLUE-VIZ-FIRSTVIEW-5: first_view schema is isolated from existing snapshot top-level fields', async () => {
+    const result = await collectFirstViewData('/dummy', {
+      health: makeMockHealth(),
+      snapshots: makeMockSnapshots(),
+      now: new Date('2026-05-12T00:00:00.000Z'),
+    });
+    // visualizer.mjs の data blob top-level field (Timeline/Diff が依存する) と
+    // 衝突しないことを保証
+    assert.ok(!('snapshots' in result), 'first_view must not include top-level "snapshots"');
+    assert.ok(!('commits_total' in result), 'first_view must not include top-level "commits_total"');
+    assert.ok(!('since' in result), 'first_view must not include top-level "since"');
+    assert.ok(!('vault_name' in result), 'first_view must not include top-level "vault_name"');
+    assert.ok(!('history_truncated' in result), 'first_view must not include top-level "history_truncated"');
+
+    // first_view 内 field は 4 layer ordering で並ぶ
+    const keys = Object.keys(result);
+    const layerKeys = keys.filter((k) => ['vault_overview', 'health_focus', 'graph_preview', 'action_queue'].includes(k));
+    assert.deepEqual(layerKeys, ['vault_overview', 'health_focus', 'graph_preview', 'action_queue'],
+      '4 layer must appear in spec ordering: overview → health → graph → action');
+  });
+
+  test('BLUE-VIZ-FIRSTVIEW-empty-snapshots: graph_preview gracefully empty when no snapshots', async () => {
+    const result = await collectFirstViewData('/dummy', {
+      health: makeMockHealth(),
+      snapshots: [],
+      now: new Date('2026-05-12T00:00:00.000Z'),
+    });
+    assert.deepEqual(result.graph_preview.hot_pages, []);
+    assert.deepEqual(result.graph_preview.active_projects, []);
+    assert.deepEqual(result.graph_preview.recent_decisions, []);
+  });
+
+  test('BLUE-VIZ-FIRSTVIEW-internals: cap constants exported for downstream tests', () => {
+    assert.ok(typeof _internals === 'object' && _internals !== null);
+    assert.ok(typeof _internals.HOT_PAGES_LIMIT === 'number');
+    assert.ok(typeof _internals.ACTION_QUEUE_MAX === 'number');
+    assert.equal(_internals.ACTION_QUEUE_MAX, 5);
+  });
+
+  // ───────────────────────── Phase 2: Health overlay integration ─────────────────────────
+
+  test('BLUE-VIZ-HEALTH-OVERLAY-1: broken_wikilink.clusters group sources by target', async () => {
+    const result = await collectFirstViewData('/dummy', {
+      health: makeMockHealth({
+        metrics: {
+          ...makeMockHealth().metrics,
+          broken_wikilink: {
+            count: 5,
+            samples: [
+              { source: 'concepts/a.md', target: 'missing-x' },
+              { source: 'concepts/b.md', target: 'missing-x' }, // same target
+              { source: 'concepts/c.md', target: 'missing-y' },
+              { source: 'analyses/d.md', target: 'missing-x' }, // again same target
+              { source: 'bugs/e.md', target: 'missing-z' },
+            ],
+            sample_truncated: false,
+          },
+        },
+      }),
+      snapshots: makeMockSnapshots(),
+      now: new Date('2026-05-12T00:00:00.000Z'),
+    });
+    assert.ok(result.health_focus.broken_wikilink.clusters,
+      'broken_wikilink.clusters field required for Phase 2 merge candidate view');
+    const clusters = result.health_focus.broken_wikilink.clusters;
+    assert.ok(Array.isArray(clusters));
+    // target 'missing-x' は 3 source、'missing-y' は 1、'missing-z' は 1 → 3 cluster
+    assert.equal(clusters.length, 3);
+    const missingX = clusters.find((c) => c.target === 'missing-x');
+    assert.ok(missingX, 'missing-x cluster present');
+    assert.equal(missingX.sources.length, 3, 'missing-x has 3 source pages');
+    assert.equal(missingX.inbound_broken_count, 3, 'inbound_broken_count = sources.length');
+    // sort 順は inbound_broken_count desc → missing-x が先頭
+    assert.equal(clusters[0].target, 'missing-x', 'most-referenced broken target sorted first');
+  });
+
+  test('BLUE-VIZ-HEALTH-OVERLAY-2: source_sha256_duplicate.groups expose merge candidate paths', async () => {
+    const result = await collectFirstViewData('/dummy', {
+      health: makeMockHealth(),
+      snapshots: makeMockSnapshots(),
+      now: new Date('2026-05-12T00:00:00.000Z'),
+    });
+    const groups = result.health_focus.source_sha256_duplicate.groups;
+    assert.ok(Array.isArray(groups));
+    for (const g of groups) {
+      assert.ok(typeof g.source_sha256 === 'string' && g.source_sha256.length > 0);
+      assert.ok(Array.isArray(g.paths) && g.paths.length >= 2, '同一 sha256 で 2+ path = merge candidate');
+    }
+    assert.equal(result.health_focus.source_sha256_duplicate.count, 2);
+  });
+
+  test('BLUE-VIZ-HEALTH-OVERLAY-3: pages_warm_zone.distribution exposes fresh/warm/stale 3 bucket', async () => {
+    const result = await collectFirstViewData('/dummy', {
+      health: makeMockHealth(),
+      snapshots: makeMockSnapshots(),
+      now: new Date('2026-05-12T00:00:00.000Z'),
+    });
+    const dist = result.health_focus.pages_warm_zone.distribution;
+    assert.ok(dist, 'pages_warm_zone.distribution required for gradient bar');
+    // mock: total=155, stale=8, warm=12
+    //   fresh ≈ total - stale - warm = 135 (approximation since system pages を排除し切れない)
+    assert.equal(dist.warm, 12, 'warm = pages_warm_zone.count');
+    assert.equal(dist.stale, 8, 'stale = stale.count');
+    assert.equal(typeof dist.fresh, 'number', 'fresh は number');
+    assert.ok(dist.fresh >= 0, 'fresh は non-negative');
+    assert.equal(dist.fresh + dist.warm + dist.stale, dist.total_classified,
+      'fresh + warm + stale must equal total_classified');
+  });
+
+  test('BLUE-VIZ-HEALTH-OVERLAY-4: page_count_by_type chart-friendly sorted_entries', async () => {
+    const result = await collectFirstViewData('/dummy', {
+      health: makeMockHealth(),
+      snapshots: makeMockSnapshots(),
+      now: new Date('2026-05-12T00:00:00.000Z'),
+    });
+    const pct = result.vault_overview.page_count_by_type;
+    // existing fields: total, by_type
+    assert.equal(pct.total, 155);
+    assert.ok(pct.by_type.summary === 70);
+    // Phase 2: sorted_entries で chart rendering 側が再 sort せずに済む
+    assert.ok(Array.isArray(pct.sorted_entries), 'sorted_entries field required for compact bar chart');
+    assert.ok(pct.sorted_entries.length > 0);
+    for (const e of pct.sorted_entries) {
+      assert.ok(Array.isArray(e) && e.length === 2);
+      assert.equal(typeof e[0], 'string');
+      assert.equal(typeof e[1], 'number');
+    }
+    // descending order
+    for (let i = 1; i < pct.sorted_entries.length; i += 1) {
+      assert.ok(pct.sorted_entries[i - 1][1] >= pct.sorted_entries[i][1],
+        `sorted_entries should be descending by count: ${JSON.stringify(pct.sorted_entries)}`);
+    }
+    // sum of values must equal total
+    const sumVal = pct.sorted_entries.reduce((s, e) => s + e[1], 0);
+    assert.equal(sumVal, pct.total, 'sum(sorted_entries) === total');
+  });
+
+  test('BLUE-VIZ-HEALTH-OVERLAY-5: summaries_growth_rate sparkline data preserved', async () => {
+    const result = await collectFirstViewData('/dummy', {
+      health: makeMockHealth(),
+      snapshots: makeMockSnapshots(),
+      now: new Date('2026-05-12T00:00:00.000Z'),
+    });
+    const g = result.vault_overview.summaries_growth;
+    assert.equal(g.vault_is_git, true);
+    assert.equal(g.day_7.added, 14);
+    assert.equal(g.day_7.per_day, 2.0);
+    assert.equal(g.day_30.added, 45);
+    assert.equal(g.day_30.per_day, 1.5);
+    // non-git vault では vault_is_git=false で graceful (sparkline 側で「n/a」表示)
+    const ngResult = await collectFirstViewData('/dummy', {
+      health: makeMockHealth({
+        metrics: {
+          ...makeMockHealth().metrics,
+          summaries_growth_rate: { vault_is_git: false, day_7: { added: 0, per_day: 0 }, day_30: { added: 0, per_day: 0 }, error: 'not_a_git_repo' },
+        },
+      }),
+      snapshots: makeMockSnapshots(),
+      now: new Date('2026-05-12T00:00:00.000Z'),
+    });
+    assert.equal(ngResult.vault_overview.summaries_growth.vault_is_git, false);
+    assert.equal(ngResult.vault_overview.summaries_growth.error, 'not_a_git_repo');
+  });
+
+  test('BLUE-VIZ-HEALTH-OVERLAY-6: status_banner with 6 P1 metrics + severity classification', async () => {
+    const result = await collectFirstViewData('/dummy', {
+      health: makeMockHealth(),
+      snapshots: makeMockSnapshots(),
+      now: new Date('2026-05-12T00:00:00.000Z'),
+    });
+    const sb = result.status_banner;
+    assert.ok(sb, 'status_banner field required for Phase 2');
+    // 6 P1 metrics 全部 present
+    assert.ok(sb.orphan);
+    assert.ok(sb.stale);
+    assert.ok(sb.duplicate_title);
+    assert.ok(sb.hot_md_age);
+    assert.ok(sb.last_ingest);
+    assert.ok(sb.unprocessed_logs);
+
+    // 各 metric は count or 相当 + severity
+    for (const key of ['orphan', 'stale', 'duplicate_title', 'unprocessed_logs']) {
+      assert.equal(typeof sb[key].count, 'number', `${key}.count should be number`);
+      assert.match(sb[key].severity, /^(ok|info|warn|danger)$/);
+    }
+
+    // mock values: orphan=3 → info, stale=8 → warn (>5), duplicate_title=1 → warn,
+    //   hot_md_age age_seconds=86400 (1d) → ok (under 7d), last_ingest age_seconds=14400 (4h) → ok (under 24h),
+    //   unprocessed_logs=7 → warn (>5)
+    assert.equal(sb.orphan.severity, 'info', 'orphan count=3 > 0 → info');
+    assert.equal(sb.stale.severity, 'warn', 'stale count=8 > 5 → warn');
+    assert.equal(sb.duplicate_title.severity, 'warn', 'duplicate_title count>0 → warn');
+    assert.equal(sb.hot_md_age.severity, 'ok', 'hot_md_age 1d < 7d threshold → ok');
+    assert.equal(sb.last_ingest.severity, 'ok', 'last_ingest 4h < 24h threshold → ok');
+    assert.equal(sb.unprocessed_logs.severity, 'warn', 'unprocessed_logs 7 > 5 → warn');
+
+    // healthy vault test
+    const healthyResult = await collectFirstViewData('/dummy', {
+      health: makeMockHealth({
+        metrics: {
+          orphan: { count: 0, pages: [] },
+          stale: { count: 0, threshold_days: 30, pages: [] },
+          duplicate_title: { count: 0, groups: [] },
+          hot_md_age: { exists: true, mtime_iso: '2026-05-12T00:00:00.000Z', age_seconds: 60, age_human: '1m' },
+          last_ingest: { exists: true, log_count: 200, mtime_iso: '2026-05-12T00:00:00.000Z', age_seconds: 60, age_human: '1m' },
+          unprocessed_logs: { count: 0, sample_paths: [], sample_truncated: false },
+          broken_wikilink: { count: 0, samples: [], sample_truncated: false },
+          source_sha256_duplicate: { count: 0, groups: [] },
+          pages_warm_zone: { count: 0, lower_days: 7, upper_days: 30, pages: [] },
+          page_count_by_type: { total: 100, by_type: { concept: 100 } },
+          summaries_growth_rate: { vault_is_git: true, day_7: { added: 1, per_day: 0.14 }, day_30: { added: 5, per_day: 0.17 } },
+        },
+      }),
+      snapshots: makeMockSnapshots(),
+      now: new Date('2026-05-12T00:00:00.000Z'),
+    });
+    for (const key of ['orphan', 'stale', 'duplicate_title', 'hot_md_age', 'last_ingest', 'unprocessed_logs']) {
+      assert.equal(healthyResult.status_banner[key].severity, 'ok',
+        `healthy vault: ${key} should be ok`);
+    }
+  });
+
+  test('BLUE-VIZ-HEALTH-OVERLAY-7: auto_lint field is present in first_view (Phase 4 flip — was negative in Phase 2)', async () => {
+    // Phase 2 では auto-lint output が first_view に含まれないことを negative assertion で固定していた。
+    // Phase 4 で drawer 化したため契約を flip:
+    //   - auto_lint field は first_view に必ず存在する (presence 契約)
+    //   - report 不在 vault では auto_lint === null (graceful degrade)
+    //   - report 存在 vault では object shape (BLUE-VIZ-AUTOLINT-DRAWER-* で検証)
+    const result = await collectFirstViewData('/dummy', {
+      health: makeMockHealth(),
+      snapshots: makeMockSnapshots(),
+      now: new Date('2026-05-12T00:00:00.000Z'),
+    });
+    assert.ok('auto_lint' in result, 'top-level auto_lint field must be present (Phase 4 drawer)');
+    assert.equal(result.auto_lint, null,
+      '/dummy vault has no wiki/lint-report.md → auto_lint must be null (graceful degrade)');
+    // schema_version も Phase 4 で bump 済
+    assert.equal(result.schema_version, FIRST_VIEW_SCHEMA_VERSION,
+      'first_view schema_version reflects the Phase 4 const bump');
+    assert.ok(FIRST_VIEW_SCHEMA_VERSION >= 2, 'Phase 4 bumps to schema 2');
+  });
+
+  // ───────────────────────── Phase 4 BLUE-VIZ-AUTOLINT-DRAWER-* (auto-lint drawer) ─────────────────────────
+
+  // section 1-3 で 4 観点それぞれが 1 件以上 finding を持つ完全 report fixture
+  function writeFullLintReport(vault) {
+    const body = [
+      '---',
+      'title: Lint Report',
+      'date: 2026-05-09',
+      '---',
+      '',
+      '# Wiki Lint Report (2026-05-09)',
+      '',
+      '## 要約',
+      '- 検出した問題の総数: 8',
+      '- カテゴリ別の内訳: 矛盾 2 / splinter 1 / 専用ページ候補 2 / link gap 3',
+      '',
+      '## 概念の矛盾',
+      '- hot.md TTL: concepts/hot-cache.md は 24h と書かれているが analyses/cache-rotation.md では 12h と記述、source が異なる',
+      '- ingest schedule: cron で 1h と書かれているが scripts/auto-ingest.sh の実装は 30 min',
+      '',
+      '## 概念の splinter',
+      '- agent の役割定義が wiki/concepts/agent-role.md と wiki/projects/multi-agent.md の両方に重複しているため merge 候補',
+      '',
+      '## 専用ページ候補',
+      '- "prompt cache" が summaries/ 配下 4 ファイルで言及されているが wiki/concepts/ に専用ページ未昇格',
+      '- "MCP transport" が source 3 件で繰り返されているが分散している',
+      '',
+      '## 意味的な相互リンク欠落',
+      '- wiki/concepts/jwt.md と wiki/concepts/oauth.md は深く関連するが wikilink なし',
+      '- wiki/decisions/use-postgres.md と wiki/analyses/db-perf.md は意味的に隣接するが link なし',
+      '- wiki/concepts/cron.md と wiki/projects/auto-ingest.md は依存関係があるが片方向しか link なし',
+      '',
+      '## R1: Unicode 不可視文字 (prompt injection 監査)',
+      '(該当なし — wiki/ 内のどの .md にも ZWSP / RTLO / SHY / BOM 等は検出されませんでした)',
+      '',
+    ].join('\n');
+    return writeFile(join(vault, 'wiki', 'lint-report.md'), body);
+  }
+
+  test('BLUE-VIZ-AUTOLINT-DRAWER-1: loadAutoLintReport returns null when wiki/lint-report.md is missing', async () => {
+    const vault = await mkdtemp(join(tmpdir(), 'kioku-autolint-missing-'));
+    try {
+      await mkdir(join(vault, 'wiki'), { recursive: true });
+      const result = await loadAutoLintReport(vault);
+      assert.equal(result, null, 'no report file → null');
+    } finally {
+      await rm(vault, { recursive: true, force: true });
+    }
+  });
+
+  test('BLUE-VIZ-AUTOLINT-DRAWER-2: 4 観点 sections are extracted with counts + samples', async () => {
+    const vault = await mkdtemp(join(tmpdir(), 'kioku-autolint-full-'));
+    try {
+      await mkdir(join(vault, 'wiki'), { recursive: true });
+      await writeFullLintReport(vault);
+      const result = await loadAutoLintReport(vault);
+      assert.ok(result, 'parsed report returned');
+      assert.equal(result.schema_version, AUTO_LINT_SCHEMA_VERSION);
+      assert.equal(result.report_exists, true);
+      assert.equal(result.source_path, 'wiki/lint-report.md');
+      assert.equal(result.generated_at, '2026-05-09');
+
+      const byKey = Object.fromEntries(result.categories.map((c) => [c.key, c]));
+      // 4 観点全て present
+      assert.ok(byKey.contradiction, 'contradiction category present');
+      assert.ok(byKey.splinter, 'splinter category present');
+      assert.ok(byKey.promotion_candidate, 'promotion_candidate category present');
+      assert.ok(byKey.link_gap, 'link_gap category present');
+      // count
+      assert.equal(byKey.contradiction.count, 2);
+      assert.equal(byKey.splinter.count, 1);
+      assert.equal(byKey.promotion_candidate.count, 2);
+      assert.equal(byKey.link_gap.count, 3);
+      // total = 8
+      assert.equal(result.total_findings, 8);
+      // samples non-empty
+      assert.ok(byKey.contradiction.samples[0].includes('hot.md TTL'),
+        'contradiction first sample matches');
+      assert.ok(byKey.link_gap.samples[0].includes('jwt.md'),
+        'link_gap first sample matches');
+      // count_estimated flag is true (LLM heuristic)
+      assert.equal(byKey.contradiction.count_estimated, true);
+    } finally {
+      await rm(vault, { recursive: true, force: true });
+    }
+  });
+
+  test('BLUE-VIZ-AUTOLINT-DRAWER-3: sample text is collapsed + truncated to 240 chars', async () => {
+    const limit = _internals.AUTO_LINT_SAMPLE_MAX_CHARS;
+    const longBullet = 'A'.repeat(limit + 50);
+    const body = [
+      '---', 'title: Lint Report', 'date: 2026-05-09', '---',
+      '', '## 概念の矛盾',
+      `- ${longBullet}`,
+      '',
+    ].join('\n');
+    const vault = await mkdtemp(join(tmpdir(), 'kioku-autolint-trunc-'));
+    try {
+      await mkdir(join(vault, 'wiki'), { recursive: true });
+      await writeFile(join(vault, 'wiki', 'lint-report.md'), body);
+      const result = await loadAutoLintReport(vault);
+      const sample = result.categories.find((c) => c.key === 'contradiction').samples[0];
+      assert.equal(sample.length, limit, `sample length capped to ${limit}`);
+      assert.ok(sample.endsWith('…'), 'truncation suffix added');
+    } finally {
+      await rm(vault, { recursive: true, force: true });
+    }
+  });
+
+  test('BLUE-VIZ-AUTOLINT-DRAWER-4: sample_limit caps per-category at 3 samples', async () => {
+    const limit = _internals.AUTO_LINT_SAMPLE_LIMIT;
+    const bullets = Array.from({ length: limit + 4 }, (_, i) => `- finding #${i + 1}: detail`).join('\n');
+    const body = [
+      '---', 'title: Lint Report', 'date: 2026-05-09', '---',
+      '', '## 意味的な相互リンク欠落',
+      bullets,
+      '',
+    ].join('\n');
+    const vault = await mkdtemp(join(tmpdir(), 'kioku-autolint-cap-'));
+    try {
+      await mkdir(join(vault, 'wiki'), { recursive: true });
+      await writeFile(join(vault, 'wiki', 'lint-report.md'), body);
+      const result = await loadAutoLintReport(vault);
+      const cat = result.categories.find((c) => c.key === 'link_gap');
+      assert.equal(cat.count, limit + 4, 'count reflects total findings');
+      assert.equal(cat.samples.length, limit, 'samples capped at limit');
+      assert.equal(cat.sample_truncated, true, 'sample_truncated flag set');
+    } finally {
+      await rm(vault, { recursive: true, force: true });
+    }
+  });
+
+  test('BLUE-VIZ-AUTOLINT-DRAWER-5: "(検出なし)" markers produce count=0 + empty samples', async () => {
+    const body = [
+      '---', 'title: Lint Report', 'date: 2026-05-09', '---',
+      '', '## 概念の矛盾',
+      '(検出なし)',
+      '',
+      '## 概念の splinter',
+      '該当なし',
+      '',
+      '## 専用ページ候補',
+      'None',
+      '',
+      '## 意味的な相互リンク欠落',
+      'n/a',
+      '',
+    ].join('\n');
+    const vault = await mkdtemp(join(tmpdir(), 'kioku-autolint-nomarker-'));
+    try {
+      await mkdir(join(vault, 'wiki'), { recursive: true });
+      await writeFile(join(vault, 'wiki', 'lint-report.md'), body);
+      const result = await loadAutoLintReport(vault);
+      assert.equal(result.total_findings, 0, '"検出なし" markers → no findings');
+      for (const cat of result.categories) {
+        assert.equal(cat.count, 0, `${cat.key} count is 0`);
+        assert.deepEqual(cat.samples, [], `${cat.key} samples is empty array`);
+      }
+    } finally {
+      await rm(vault, { recursive: true, force: true });
+    }
+  });
+
+  test('BLUE-VIZ-AUTOLINT-DRAWER-6: frontmatter date is extracted as generated_at (fallback to null when missing)', async () => {
+    const body = [
+      '# No frontmatter report',
+      '',
+      '## 概念の矛盾',
+      '- some finding',
+      '',
+    ].join('\n');
+    const vault = await mkdtemp(join(tmpdir(), 'kioku-autolint-nofront-'));
+    try {
+      await mkdir(join(vault, 'wiki'), { recursive: true });
+      await writeFile(join(vault, 'wiki', 'lint-report.md'), body);
+      const result = await loadAutoLintReport(vault);
+      assert.equal(result.generated_at, null, 'no frontmatter → generated_at is null');
+    } finally {
+      await rm(vault, { recursive: true, force: true });
+    }
+  });
+
+  test('BLUE-VIZ-AUTOLINT-DRAWER-7: malformed markdown without bullets falls back to paragraph parsing', async () => {
+    const body = [
+      '---', 'date: 2026-05-09', '---',
+      '',
+      '## 概念の矛盾',
+      'paragraph 1: this is a free-form judgment finding without bullet syntax.',
+      '',
+      'paragraph 2: another finding, separated by blank line.',
+      '',
+    ].join('\n');
+    const vault = await mkdtemp(join(tmpdir(), 'kioku-autolint-paragraph-'));
+    try {
+      await mkdir(join(vault, 'wiki'), { recursive: true });
+      await writeFile(join(vault, 'wiki', 'lint-report.md'), body);
+      const result = await loadAutoLintReport(vault);
+      const cat = result.categories.find((c) => c.key === 'contradiction');
+      assert.equal(cat.count, 2, 'paragraph fallback produces 2 findings');
+      assert.ok(cat.samples[0].includes('paragraph 1'), 'first paragraph captured');
+      assert.ok(cat.samples[1].includes('paragraph 2'), 'second paragraph captured');
+    } finally {
+      await rm(vault, { recursive: true, force: true });
+    }
+  });
+
+  test('BLUE-VIZ-AUTOLINT-DRAWER-8: source_truncated flag is set when file exceeds AUTO_LINT_MAX_BYTES', async () => {
+    const max = _internals.AUTO_LINT_MAX_BYTES;
+    const padding = 'x'.repeat(max + 1024);
+    const body = [
+      '---', 'date: 2026-05-09', '---',
+      '',
+      '## 概念の矛盾',
+      '- short finding',
+      '',
+      padding,
+    ].join('\n');
+    const vault = await mkdtemp(join(tmpdir(), 'kioku-autolint-trunc-bytes-'));
+    try {
+      await mkdir(join(vault, 'wiki'), { recursive: true });
+      await writeFile(join(vault, 'wiki', 'lint-report.md'), body);
+      const result = await loadAutoLintReport(vault);
+      assert.equal(result.source_truncated, true, 'file > max → source_truncated true');
+      // 早期セクションは引き続き parse できているはず
+      const cat = result.categories.find((c) => c.key === 'contradiction');
+      assert.ok(cat.count > 0, 'contradiction section is parsed before truncation cap');
+    } finally {
+      await rm(vault, { recursive: true, force: true });
+    }
+  });
+
+  test('BLUE-VIZ-AUTOLINT-DRAWER-9: collectFirstViewData embeds auto_lint into first_view (positive contract)', async () => {
+    const vault = await mkdtemp(join(tmpdir(), 'kioku-autolint-embed-'));
+    try {
+      await mkdir(join(vault, 'wiki'), { recursive: true });
+      await writeFullLintReport(vault);
+      const result = await collectFirstViewData(vault, {
+        health: makeMockHealth(),
+        snapshots: makeMockSnapshots(),
+        now: new Date('2026-05-12T00:00:00.000Z'),
+      });
+      assert.ok(result.auto_lint, 'auto_lint embedded');
+      assert.equal(result.auto_lint.report_exists, true);
+      assert.equal(result.auto_lint.categories.length, 4, '4 観点 categories');
+      assert.ok(result.auto_lint.total_findings >= 8, 'total_findings reflects full report');
+    } finally {
+      await rm(vault, { recursive: true, force: true });
+    }
+  });
+
+  // ───────────────────────── Phase 1 livewalk fallback test (placed after Phase 2) ─────────────────────────
+
+  test('BLUE-VIZ-FIRSTVIEW-livewalk: live filesystem walk fallback for graph_preview', async () => {
+    // real Vault が parent git repo の subdirectory にあると snapshot[0].pages が空に
+    // なる pre-existing issue を補う fallback path。snapshot 空でも live walk で graph_preview
+    // が機能する事を保証する。
+    const tmpVault = await mkdtemp(join(tmpdir(), 'kioku-viz-livewalk-'));
+    try {
+      await mkdir(join(tmpVault, 'wiki', 'concepts'), { recursive: true });
+      await mkdir(join(tmpVault, 'wiki', 'projects'), { recursive: true });
+      await mkdir(join(tmpVault, 'wiki', 'decisions'), { recursive: true });
+      // exclude dirs (must be filtered out by walkLiveWikiPages)
+      await mkdir(join(tmpVault, 'wiki', '.archive'), { recursive: true });
+      await mkdir(join(tmpVault, 'wiki', 'templates'), { recursive: true });
+      await writeFile(join(tmpVault, 'wiki', 'index.md'), '---\ntype: index\ntitle: Index\n---\n\n# Index\n\n[[jwt]] [[oauth]]\n');
+      await writeFile(join(tmpVault, 'wiki', 'concepts', 'jwt.md'), '---\ntitle: JWT\n---\n\n# JWT\n\n[[oauth]]\n');
+      await writeFile(join(tmpVault, 'wiki', 'concepts', 'oauth.md'), '---\ntitle: OAuth\n---\n\n# OAuth\n\n[[jwt]]\n');
+      await writeFile(join(tmpVault, 'wiki', 'projects', 'kioku.md'), '---\ntype: project\ntitle: KIOKU\n---\n\n# KIOKU\n');
+      await writeFile(join(tmpVault, 'wiki', 'decisions', 'use-postgres.md'), '---\ntype: decision\ntitle: Use Postgres\n---\n\n# Use Postgres\n');
+      // exclude dir 配下 — walk すべきでない
+      await writeFile(join(tmpVault, 'wiki', '.archive', 'old.md'), '---\n---\n# Old\n');
+      await writeFile(join(tmpVault, 'wiki', 'templates', 'tmpl.md'), '---\n---\n# Tmpl\n');
+
+      const livePages = await walkLiveWikiPages(tmpVault);
+      const names = livePages.map((p) => p.name).sort();
+      assert.deepEqual(names, ['index', 'jwt', 'kioku', 'oauth', 'use-postgres'],
+        'walkLiveWikiPages must walk wiki/ and exclude .archive/ + templates/');
+
+      // type inference (path-based fallback) が効く
+      const jwt = livePages.find((p) => p.name === 'jwt');
+      assert.equal(jwt.type, 'concept', 'jwt.md under concepts/ should infer type=concept');
+      const kioku = livePages.find((p) => p.name === 'kioku');
+      assert.equal(kioku.type, 'project', 'frontmatter type=project preserved');
+      const useP = livePages.find((p) => p.name === 'use-postgres');
+      assert.equal(useP.type, 'decision');
+
+      // collectFirstViewData が snapshot 空でも live walk fallback で graph_preview を生成
+      const result = await collectFirstViewData(tmpVault, {
+        health: makeMockHealth(),
+        snapshots: [], // 意図的に空 → fallback to live walk
+        now: new Date('2026-05-12T00:00:00.000Z'),
+      });
+      assert.ok(result.graph_preview.hot_pages.length > 0,
+        'graph_preview should be populated via live walk fallback');
+      assert.ok(result.graph_preview.active_projects.some((p) => p.name === 'kioku'),
+        'active_projects must include kioku (live walk)');
+      assert.ok(result.graph_preview.recent_decisions.some((p) => p.name === 'use-postgres'),
+        'recent_decisions must include use-postgres (live walk)');
+
+      // walkLiveWikiPages nonexistent path → 空配列 (graceful)
+      const empty = await walkLiveWikiPages('/nonexistent-' + Date.now());
+      assert.deepEqual(empty, []);
+    } finally {
+      await rm(tmpVault, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/wiki-walker.test.mjs
+++ b/tests/wiki-walker.test.mjs
@@ -1,0 +1,191 @@
+// wiki-walker.test.mjs — Tests for the shared wiki-walker.mjs module
+// (Sprint 3 Phase 3 §46 LEARN#8b N=3 mandatory refactor anchor).
+//
+// 実行: node --test tools/claude-brain/tests/wiki-walker.test.mjs
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  walkPages,
+  listMarkdownRefs,
+  inferPageType,
+  resolvePageTitle,
+  DEFAULT_EXCLUDE_DIRS,
+} from '../mcp/lib/wiki-walker.mjs';
+
+async function makeVault() {
+  const root = await mkdtemp(join(tmpdir(), 'kioku-walker-test-'));
+  await mkdir(join(root, 'wiki', 'concepts'), { recursive: true });
+  await mkdir(join(root, 'wiki', 'projects'), { recursive: true });
+  await mkdir(join(root, 'wiki', 'summaries'), { recursive: true });
+  await mkdir(join(root, 'wiki', '.archive'), { recursive: true });
+  await mkdir(join(root, 'wiki', 'templates'), { recursive: true });
+  await mkdir(join(root, 'raw-sources', 'pdf'), { recursive: true });
+
+  await writeFile(
+    join(root, 'wiki', 'index.md'),
+    '---\ntype: index\ntitle: Vault Index\n---\n\n# Index\n\n- [[concepts/jwt]]\n',
+  );
+  await writeFile(
+    join(root, 'wiki', 'concepts', 'jwt.md'),
+    '---\ntype: concept\ntags: [auth]\n---\n\n# JWT\n\nSee [[oauth]].\n',
+  );
+  await writeFile(
+    join(root, 'wiki', 'concepts', 'oauth.md'),
+    '---\ntags: [auth]\n---\n\n# OAuth\n\n[[jwt]]\n',
+  );
+  await writeFile(
+    join(root, 'wiki', 'projects', 'kioku.md'),
+    '---\ntype: project\ntitle: KIOKU\n---\n\n# KIOKU\n',
+  );
+  await writeFile(
+    join(root, 'wiki', 'summaries', 'rag-summary.md'),
+    '---\nsource_sha256: abc123\nsource: pdf/rag.pdf\n---\n\n# RAG summary\n',
+  );
+
+  // Files that MUST be filtered out
+  await writeFile(join(root, 'wiki', '.archive', 'ghost.md'), '# ghost');
+  await writeFile(join(root, 'wiki', 'templates', 'note.md'), '# template');
+  await writeFile(join(root, 'wiki', '.hidden.md'), '# dotfile');
+  await writeFile(join(root, 'wiki', 'concepts', 'README.txt'), 'not markdown');
+
+  // raw-sources
+  await writeFile(join(root, 'raw-sources', 'pdf', 'rag.pdf'), '%PDF-1.4 fake');
+  await writeFile(join(root, 'raw-sources', 'pdf', 'rag.md'), '# raw extracted markdown');
+  return root;
+}
+
+describe('wiki-walker.mjs (§46 N=3 shared util)', () => {
+  test('BLUE-VIZ-WALKER-1: default walk returns flat metadata for wiki/', async () => {
+    const root = await makeVault();
+    try {
+      const pages = await walkPages(root);
+      const rels = pages.map((p) => p.rel).sort();
+      assert.deepEqual(rels, [
+        'concepts/jwt.md',
+        'concepts/oauth.md',
+        'index.md',
+        'projects/kioku.md',
+        'summaries/rag-summary.md',
+      ], '.archive/ + templates/ + .hidden.md must be filtered out');
+      const jwt = pages.find((p) => p.rel === 'concepts/jwt.md');
+      assert.equal(jwt.name, 'jwt');
+      assert.equal(jwt.type, 'concept');
+      assert.equal(jwt.title, 'JWT', 'title resolves from body H1 when frontmatter.title absent');
+      assert.deepEqual(jwt.wikilinks, ['oauth']);
+      assert.ok(jwt.frontmatter, 'frontmatter present by default');
+      assert.ok(!('body' in jwt), 'body excluded unless withBody');
+      assert.ok(!('text' in jwt), 'text excluded unless withBody');
+      assert.ok(!('mtime' in jwt), 'mtime excluded unless withMtime');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('BLUE-VIZ-WALKER-2: withBody + withMtime include text/body/mtime fields', async () => {
+    const root = await makeVault();
+    try {
+      const pages = await walkPages(root, { withBody: true, withMtime: true });
+      const jwt = pages.find((p) => p.rel === 'concepts/jwt.md');
+      assert.ok(typeof jwt.text === 'string' && jwt.text.startsWith('---'));
+      assert.ok(typeof jwt.body === 'string' && jwt.body.includes('# JWT'));
+      assert.ok(jwt.mtime instanceof Date);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('BLUE-VIZ-WALKER-3: subDir + extensions support raw-sources walk', async () => {
+    const root = await makeVault();
+    try {
+      const raws = await walkPages(root, {
+        subDir: 'raw-sources',
+        extensions: ['.pdf', '.md'],
+        withFrontmatter: false,
+        withWikilinks: false,
+      });
+      const rels = raws.map((r) => r.rel).sort();
+      assert.deepEqual(rels, ['pdf/rag.md', 'pdf/rag.pdf']);
+      const pdf = raws.find((r) => r.rel === 'pdf/rag.pdf');
+      assert.equal(pdf.name, 'rag');
+      // non-.md → no frontmatter / wikilinks parse attempted
+      assert.ok(!pdf.wikilinks || pdf.wikilinks.length === 0);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('BLUE-VIZ-WALKER-4: nonexistent subDir returns empty array (graceful)', async () => {
+    const root = await makeVault();
+    try {
+      const out = await walkPages(root, { subDir: 'does-not-exist' });
+      assert.deepEqual(out, []);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('BLUE-VIZ-WALKER-5: listMarkdownRefs back-compat shape {abs, rel}', async () => {
+    const root = await makeVault();
+    try {
+      const refs = await listMarkdownRefs(root);
+      assert.ok(Array.isArray(refs));
+      assert.ok(refs.length >= 5);
+      for (const r of refs) {
+        assert.equal(typeof r.abs, 'string');
+        assert.equal(typeof r.rel, 'string');
+        assert.ok(!('frontmatter' in r), 'frontmatter omitted from legacy shape');
+        assert.ok(!('wikilinks' in r));
+      }
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('BLUE-VIZ-WALKER-6: inferPageType priority (system > frontmatter.type > subdir > other)', () => {
+    assert.equal(inferPageType('index.md'), 'index');
+    assert.equal(inferPageType('log.md'), 'log');
+    assert.equal(inferPageType('hot.md'), 'hot');
+    assert.equal(inferPageType('index.md', { type: 'concept' }), 'index', 'system files override frontmatter');
+    assert.equal(inferPageType('concepts/x.md', { type: 'custom' }), 'custom', 'frontmatter beats subdir');
+    assert.equal(inferPageType('projects/x.md', {}), 'project');
+    assert.equal(inferPageType('summaries/x.md', null), 'summary');
+    assert.equal(inferPageType('decisions/x.md'), 'decision');
+    assert.equal(inferPageType('weird-dir/x.md', {}), 'other');
+  });
+
+  test('BLUE-VIZ-WALKER-7: resolvePageTitle priority (frontmatter > H1 > basename)', () => {
+    assert.equal(resolvePageTitle('a/b.md', { title: 'Hello' }, '# World'), 'Hello');
+    assert.equal(resolvePageTitle('a/b.md', {}, '# H1 only'), 'H1 only');
+    assert.equal(resolvePageTitle('a/b.md', null, ''), 'b');
+    assert.equal(resolvePageTitle('a/b.md', { title: '  trimmed  ' }, ''), 'trimmed');
+  });
+
+  test('BLUE-VIZ-WALKER-8: DEFAULT_EXCLUDE_DIRS contains expected dirs', () => {
+    assert.ok(DEFAULT_EXCLUDE_DIRS instanceof Set);
+    for (const dir of ['.obsidian', '.archive', '.trash', 'templates', '.cache']) {
+      assert.ok(DEFAULT_EXCLUDE_DIRS.has(dir), `${dir} must be excluded by default`);
+    }
+  });
+
+  test('BLUE-VIZ-WALKER-9: corrupt non-utf8 file is skipped silently', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'kioku-walker-corrupt-'));
+    try {
+      await mkdir(join(root, 'wiki'), { recursive: true });
+      // valid file
+      await writeFile(join(root, 'wiki', 'ok.md'), '# ok');
+      // binary garbage (still parseable as utf8 lossy, but contents are not markdown):
+      // wiki walker should not crash and should include it
+      await writeFile(join(root, 'wiki', 'binary.md'), Buffer.from([0x00, 0x01, 0xFF, 0xFE]));
+      const pages = await walkPages(root);
+      // walker does not validate content, only existence + ext — both should appear
+      assert.equal(pages.length, 2);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Parent repo → kioku next sync (LEARN#11 8-step cascade Step 2-3)。

## v0.8.0 = Sprint 3 完走 (HTML Visualizer β)

| Phase | scope | merge |
|---|---|---|
| Phase 1 | Value-first first view 4 layer (Vault overview + Health focus + Graph preview + Action queue) | #124 |
| Phase 2 | Health overlay (5 viz pure CSS+DOM: broken cluster / sha256 dup / warm gradient / type chart / growth sparkline + status banner) | #125 |
| Phase 3 | Raw-source lineage graph (3 layer / 5 edge / 300 cap / 1-2 hop helper) + §46 N=3 mandatory refactor (wiki-walker.mjs 抽出) | #126 |
| Phase 4 | Auto-lint drawer 化 (Phase 2 negative→positive flip) + fixture vault hybrid + CI screenshot regression | #127 |

## Path C+β viewer 70% 達成

✅ read / visualize / analyze / dashboard / ingest / agent integration
⏳ search / navigate (Sprint 4 で land 予定)
❌ edit (Sprint 6+ Path C+α、defer 中)

## Real Vault dogfood (162 page)

- first_view 4 layer: broken=23 / sha256_dup=2 / warm=99 / hot=10 / active=5 / action=5
- lineage graph: 184 nodes (raw=24/wiki=127/summary=33) / 846 edges / 68ms (300 cap 余裕)
- auto-lint drawer: 4 categories / generated_at:'2026-05-08'
- HTML self-contained: external 全 0、61.5KB

## Tests

- 38/38 Phase 4 新規 (visualizer-data 24 + visualizer 10 + screenshot 4)
- 45/45 Phase 3 (wiki-walker 9 + lineage-graph 7+補強 + visualizer-data 15 + mcp/visualizer 9)
- 全 Node + Bash regression pass
- 削除 symbol (inferTypeFromPath / WALK_EXCLUDE_DIRS / PATH_TO_TYPE) 残存ゼロ

## Parent ref

- 主軸 PRs: #122 (codex strategic) + #123 (Path C+β decision + tactical handoff) + #124-#127 (Phase 1-4 impl) + #128 (version bump)
- 4 session pipeline: codex strategic → PM tactical → 制作 impl × 4 → マーケ retrospect (Step 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)