### PR TITLE
docs: v0.8.0 Changelog entry を 10 言語 README に展開 (Sprint 3 完走 / HTML Visualizer β)

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -263,6 +263,19 @@ Si encuentras un problema de seguridad, repórtalo a través de [SECURITY.md](SE
 
 ## Cambios
 
+### 2026-05-13 — v0.8.0: "Abre KIOKU y ve como tu memoria se ve" — HTML Visualizer β (Sprint 3 completado)
+
+v0.8.0 marca la **finalizacion del Sprint 3 (価値の可視化)**. El primer release donde KIOKU puede mostrar su valor sin Obsidian — drag-and-drop el HTML generado en cualquier browser y ver tu second brain.
+
+- **Overview tab (4 layers)**: Vault overview / Health focus / Graph preview / Action queue, todo en 5 segundos
+- **5 visualizaciones pure CSS+DOM** (Phase 2): bar chart, sparkline, warm zone gradient, broken wikilink cluster, sha256 duplicate cluster
+- **Lineage tab (Phase 3)**: raw-sources → summaries → wiki pages 3-layer lineage graph, 5 edge types, 300-node cap, best-effort hint
+- **Quality notes drawer (Phase 4)**: `wiki/lint-report.md` rendered como 5to card, `kioku_health` y auto-lint con non-overlapping surface
+- **§46 N=3 mandatory refactor**: `wiki-walker.mjs` extraido, 3 callers unificados
+- **Real-world dogfood (PM Vault, 162 paginas)**: broken=23 / sha256_dup=2 / warm=99, lineage 184 nodos / 846 edges en 68ms, HTML self-contained 61.5KB
+- **Tests**: 38 Phase 4 + 45 Phase 3 + Node + Bash regression todos pasaron
+- [Release v0.8.0](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.8.0)
+
 ### 2026-05-08 — v0.7.5: Sprint 2 completado — `kioku_health` 11 metricas (5 stretch agregadas) + auto-lint refactor
 
 v0.7.5 marca la **finalizacion del Sprint 2 (記憶品質 dashboard)** — micro cascade del mismo dia tras el release matutino de v0.7.4.

--- a/README.fr.md
+++ b/README.fr.md
@@ -326,6 +326,19 @@ Si vous trouvez un probleme de securite, veuillez le signaler via [SECURITY.md](
 
 ## Journal des modifications
 
+### 2026-05-13 — v0.8.0 : "Ouvrez KIOKU et voyez votre memoire" — HTML Visualizer β (Sprint 3 termine)
+
+v0.8.0 marque la **finalisation du Sprint 3 (価値の可視化)**. Premier release ou KIOKU peut montrer sa valeur sans Obsidian — drag-and-drop le HTML genere dans n'importe quel navigateur.
+
+- **Overview tab (4 layers)** : Vault overview / Health focus / Graph preview / Action queue, tout en 5 secondes
+- **5 visualisations pure CSS+DOM** (Phase 2) : bar chart, sparkline, warm zone gradient, broken wikilink cluster, sha256 duplicate cluster
+- **Lineage tab (Phase 3)** : raw-sources → summaries → wiki pages 3-layer lineage graph, 5 edge types, 300-node cap, best-effort hint
+- **Quality notes drawer (Phase 4)** : `wiki/lint-report.md` rendu comme 5e card, `kioku_health` et auto-lint avec non-overlapping surface
+- **§46 N=3 mandatory refactor** : `wiki-walker.mjs` extrait, 3 callers unifies
+- **Real-world dogfood (PM Vault, 162 pages)** : broken=23 / sha256_dup=2 / warm=99, lineage 184 noeuds / 846 edges en 68ms, HTML self-contained 61.5KB
+- **Tests** : 38 Phase 4 + 45 Phase 3 + Node + Bash regression tous passes
+- [Release v0.8.0](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.8.0)
+
 ### 2026-05-08 — v0.7.5 : Sprint 2 termine — `kioku_health` 11 metriques (5 stretch ajoutees) + auto-lint refactor
 
 v0.7.5 marque la **finalisation du Sprint 2 (記憶品質 dashboard)** — micro cascade le meme jour apres la release matinale de v0.7.4.

--- a/README.hi.md
+++ b/README.hi.md
@@ -263,6 +263,19 @@ KIOKU एक Hook सिस्टम है जो **सभी Claude Code स�
 
 ## परिवर्तन इतिहास
 
+### 2026-05-13 — v0.8.0: "KIOKU खोलें और देखें कि आपकी memory कैसी दिखती है" — HTML Visualizer β (Sprint 3 पूर्ण)
+
+v0.8.0 **Sprint 3 (価値の可視化) पूर्ण होने** को mark करता है। पहला release जहाँ KIOKU अपना value Obsidian के बिना दिखा सकता है — generated HTML को किसी भी browser में drag-and-drop करें और अपना second brain देखें।
+
+- **Overview tab (4 layers)**: Vault overview / Health focus / Graph preview / Action queue, सब 5 seconds में
+- **5 visualizations pure CSS+DOM** (Phase 2): bar chart, sparkline, warm zone gradient, broken wikilink cluster, sha256 duplicate cluster
+- **Lineage tab (Phase 3)**: raw-sources → summaries → wiki pages 3-layer lineage graph, 5 edge types, 300-node cap, best-effort hint
+- **Quality notes drawer (Phase 4)**: `wiki/lint-report.md` 5वें card के रूप में render, `kioku_health` और auto-lint non-overlapping surface में
+- **§46 N=3 mandatory refactor**: `wiki-walker.mjs` extracted, 3 callers unified
+- **Real-world dogfood (PM Vault, 162 pages)**: broken=23 / sha256_dup=2 / warm=99, lineage 184 nodes / 846 edges in 68ms, HTML self-contained 61.5KB
+- **Tests**: 38 Phase 4 + 45 Phase 3 + Node + Bash regression सभी pass
+- [Release v0.8.0](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.8.0)
+
 ### 2026-05-08 — v0.7.5: Sprint 2 पूर्ण — `kioku_health` 11 metrics (5 stretch जोड़े गए) + auto-lint refactor
 
 v0.7.5 **Sprint 2 (記憶品質 dashboard) के पूर्ण होने** को chihnit करता है — v0.7.4 की सुबह की release के बाद उसी दिन का micro cascade।

--- a/README.ja.md
+++ b/README.ja.md
@@ -484,6 +484,30 @@ KIOKU は Claude Code の**全セッション入出力にアクセスする Hook
 
 ## 更新履歴
 
+### 2026-05-13 — v0.8.0: 「自分の記憶が育っているか」を 5 秒で見せる HTML Visualizer β (Sprint 3 完走)
+
+v0.8.0 は **Sprint 3 (価値の可視化) 完走**。Sprint 1 (信頼性) + Sprint 2 (記憶品質) で「自分の KIOKU はちゃんと動いてる? Wiki は腐ってない?」に答える土台ができた上で、Sprint 3 は **「自分の記憶がどう育っているか」を視覚的に体験できる HTML Visualizer β** を提供する。
+
+Obsidian がなくても browser に drag-and-drop するだけで second brain の状態が見える、KIOKU が単体で価値を見せられる初めての release。
+
+- **Overview tab (Phase 1 + 2)** — HTML を開いて 5 秒で見える 4 層:
+  - **Vault overview** — ページ総数 / summaries growth (7日/30日) / page type 分布
+  - **Health focus** — broken wikilinks (cluster で merge 候補表示) / source sha256 重複 / warm zone (7-30 日、fresh→warm→stale gradient)
+  - **Graph preview** — 入リンク数で hot pages / active projects / recent decisions
+  - **Action queue** — 今日直すと価値が高い 3-5 件、P0/P1/P2 priority + 具体的な `next_action` 付き
+- **Status banner + 5 つの可視化 (Phase 2)** — 全て pure CSS + DOM、外部 chart ライブラリ不使用:
+  - page type 分布の bar chart
+  - summaries 増加率の sparkline (7d/30d)
+  - warm zone gradient (fresh/warm/stale の 3 セグメント bar)
+  - broken wikilink cluster (target ごとにグループ化、merge 候補 view)
+  - source_sha256 重複 cluster (同じソースから生まれた重複ページ)
+- **Lineage tab (Phase 3)** — KIOKU 固有の差別化 view: **raw-sources → summaries → wiki pages の 3 層 lineage graph**、5 種の edge (sha256 / derived_from / filename / wikilink / time proximity)。300 ノード cap、best-effort hint、1-2 hop subgraph helper。実環境 dogfooding: 184 ノード / 846 エッジを 68ms で構築。
+- **Quality notes drawer (Phase 4)** — `wiki/lint-report.md` (auto-lint 出力) を Overview 5 枚目の card として表示。Phase 2 で 2 重 negative assert していた契約を **Phase 4 で flip** (negative → positive) — auto-lint の 4 観点 (概念の矛盾 / 概念の splinter / 専用ページ候補 / 意味的相互リンク欠落) が drawer に並ぶ。`kioku_health` の 11 機械検査メトリクスと auto-lint の LLM judgment が **重複しない surface** で共存する設計。
+- **§46 N=3 mandatory refactor** — `mcp/lib/wiki-walker.mjs` を抽出、3 caller (health-metrics / visualizer-data / lineage-graph) を `walkPages()` 共通 entry point に統一。LEARN#8b フレームワークの好例 (N=2 で defer、N=3 で extract)。
+- **テスト**: Phase 4 で 38 件新規 (visualizer-data 24 + visualizer 10 + screenshot 4) + Phase 3 で 45 件新規 (wiki-walker 9 + lineage-graph 7+補強 + visualizer-data 15 + mcp/visualizer 9) + 既存 Node + Bash 全 pass。CI screenshot regression (`tests/mcp/tools-visualizer-screenshot.test.mjs`) で empty / small Vault fixture を deterministic に走らせる
+- **実環境 dogfooding (PM Vault、162 ページ)** — Overview tab で broken=23 / sha256_dup=2 / warm=99、Lineage tab で 184 ノード / 846 エッジ、auto-lint drawer で 4 categories を即時 surface。HTML self-contained 61.5KB (external script/link/fetch 全 0)
+- [Release v0.8.0](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.8.0) — `kioku-wiki-0.8.0.mcpb` attached
+
 ### 2026-05-08 — v0.7.5: Sprint 2 完走 — `kioku_health` 11 メトリクス (stretch 5 追加) + auto-lint 改訂
 
 v0.7.5 は **Sprint 2 (記憶品質 dashboard) の完走 marker** — v0.7.4 (本日朝) との overnight micro cascade。v0.7.4 が **コア 6 メトリクス** (orphan / stale / duplicate title / hot.md age / last ingest / unprocessed session-logs) を ship したのに対し、v0.7.5 は codex roadmap §「指標案」 の **stretch 5 メトリクス** を追加 + **auto-lint を refactor** して `kioku_health` の machine-checkable な領域と重複しないよう役割分担を明示する。

--- a/README.ko.md
+++ b/README.ko.md
@@ -326,6 +326,19 @@ KIOKU은 **모든 Claude Code 세션 입출력**에 접근하는 Hook 시스템�
 
 ## 변경 이력
 
+### 2026-05-13 — v0.8.0: "KIOKU 열고 내 기억이 어떻게 자라는지 본다" — HTML Visualizer β (Sprint 3 완주)
+
+v0.8.0은 **Sprint 3 (価値の可視化) 완주 marker**. Obsidian 없이 KIOKU 가치를 보여줄 수 있는 첫 release — 생성된 HTML을 browser에 drag-and-drop으로 second brain을 본다.
+
+- **Overview tab (4 layers)**: Vault overview / Health focus / Graph preview / Action queue, 5초 안에 다 보임
+- **5 visualizations pure CSS+DOM** (Phase 2): bar chart, sparkline, warm zone gradient, broken wikilink cluster, sha256 duplicate cluster
+- **Lineage tab (Phase 3)**: raw-sources → summaries → wiki pages 3-layer lineage graph, 5 edge types, 300-node cap, best-effort hint
+- **Quality notes drawer (Phase 4)**: `wiki/lint-report.md`를 5번째 card로 render, `kioku_health`와 auto-lint를 non-overlapping surface로 공존
+- **§46 N=3 mandatory refactor**: `wiki-walker.mjs` 추출, 3 callers 통일
+- **Real-world dogfood (PM Vault, 162 페이지)**: broken=23 / sha256_dup=2 / warm=99, lineage 184 nodes / 846 edges in 68ms, HTML self-contained 61.5KB
+- **Tests**: 38 Phase 4 + 45 Phase 3 + Node + Bash regression 모두 pass
+- [Release v0.8.0](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.8.0)
+
 ### 2026-05-08 — v0.7.5: Sprint 2 완주 — `kioku_health` 11개 metrics (stretch 5개 추가) + auto-lint refactor
 
 v0.7.5는 **Sprint 2 (記憶品質 dashboard) 완주 marker** — v0.7.4 아침 release 후 같은 날의 micro cascade.

--- a/README.md
+++ b/README.md
@@ -465,6 +465,30 @@ If you find a security issue, please report it via [SECURITY.md](SECURITY.md) �
 
 ## Changelog
 
+### 2026-05-13 — v0.8.0: "Open KIOKU and see what your memory looks like" — HTML Visualizer β (Sprint 3 完走)
+
+v0.8.0 ships **Sprint 3 (価値の可視化) completion** — Sprint 1 (信頼性) と Sprint 2 (記憶品質) で 「自分の KIOKU は動いてる? Wiki は腐ってない?」 に答える土台ができた上で、Sprint 3 は **「自分の記憶がどう育っているか」 を 5 秒で見せる HTML Visualizer β** を提供する。Obsidian なしで開ける self-contained HTML として、`kioku_generate_viz` MCP tool が 4 view (Overview / Timeline / Diff / Lineage) を 1 ファイルに包む。
+
+This is the first release where **KIOKU can show its value without Obsidian** — drag-and-drop the generated HTML into any browser and see your second brain breathe.
+
+- **Overview tab (Phase 1 + 2)** — Open KIOKU and see 4 layers at a glance:
+  - **Vault overview** — pages total, summaries growth (7d/30d), page type distribution
+  - **Health focus** — broken wikilinks (cluster view with merge candidates) / source sha256 duplicates / warm zone (7-30 days, fresh→warm→stale gradient)
+  - **Graph preview** — hot pages by inbound degree / active projects / recent decisions
+  - **Action queue** — 3-5 actionable items with P0/P1/P2 priority + concrete `next_action`
+- **Status banner + 5 visualizations (Phase 2)** — All pure CSS + DOM, no external chart library:
+  - bar chart for page type distribution
+  - sparkline for summaries growth rate (7d/30d)
+  - warm zone gradient (fresh/warm/stale 3-segment bar)
+  - broken wikilink cluster (target で grouped, merge candidate view)
+  - source_sha256 duplicate cluster (same-source 重複 page の merge surface)
+- **Lineage tab (Phase 3)** — KIOKU's distinctive view: **raw-sources → summaries → wiki pages** の 3 layer lineage graph with 5 edge types (sha256 / derived_from / filename / wikilink / time proximity). 300-node cap, best-effort hint, 1-2 hop subgraph helper. Real Vault dogfood: 184 nodes / 846 edges in 68ms.
+- **Quality notes drawer (Phase 4)** — `wiki/lint-report.md` (auto-lint output) を 5 枚目の Overview card として表示。Phase 2 で 2 重 negative assert していた契約を **Phase 4 で flip** (negative → positive) — auto-lint 4 観点 (concept contradiction / concept splinter / dedicated page candidate / semantic wikilink gap) が drawer に並ぶ。`kioku_health` の 11 machine-checkable metrics と auto-lint の LLM judgment が **non-overlapping surface** で共存する。
+- **§46 N=3 mandatory refactor** — `mcp/lib/wiki-walker.mjs` 抽出、3 caller (health-metrics / visualizer-data / lineage-graph) を `walkPages()` 共通 entry point に統一。LEARN#8b framework の好例。
+- **Tests**: 38 Phase 4 (visualizer-data 24 + visualizer 10 + screenshot 4) + 45 Phase 3 (wiki-walker 9 + lineage-graph 7+補強 + visualizer-data 15 + mcp/visualizer 9) + 全 Node + Bash regression 全 pass。CI screenshot regression (`tests/mcp/tools-visualizer-screenshot.test.mjs`) で empty / small Vault fixture を deterministic に走らせる。
+- **Real-world dogfood (PM Vault, 162 pages)** — Overview tab で broken=23 / sha256_dup=2 / warm=99、Lineage tab で 184 nodes / 846 edges、auto-lint drawer で 4 categories surface。HTML self-contained 61.5KB (external script/link/fetch 全 0)
+- [Release v0.8.0](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.8.0) — `kioku-wiki-0.8.0.mcpb` attached
+
 ### 2026-05-08 — v0.7.5: Sprint 2 完走 — `kioku_health` 11 metrics (stretch 5 追加) + auto-lint refactor
 
 v0.7.5 marks **Sprint 2 (記憶品質 dashboard) completion** — same-day micro cascade after v0.7.4 morning release. Where v0.7.4 shipped the **core 6 metrics** (orphan / stale / duplicate title / hot.md age / last ingest / unprocessed session-logs), v0.7.5 adds the **stretch 5 metrics** identified in the codex roadmap §「指標案」 and **refactors auto-lint** to no longer overlap with `kioku_health`'s machine-checkable surface.

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -326,6 +326,19 @@ Se voce encontrar um problema de seguranca, por favor reporte via [SECURITY.md](
 
 ## Histórico de mudanças
 
+### 2026-05-13 — v0.8.0: "Abra KIOKU e veja como sua memoria parece" — HTML Visualizer β (Sprint 3 concluido)
+
+v0.8.0 marca a **conclusao do Sprint 3 (価値の可視化)**. Primeiro release onde KIOKU pode mostrar seu valor sem Obsidian — drag-and-drop o HTML gerado em qualquer browser e veja seu second brain.
+
+- **Overview tab (4 layers)**: Vault overview / Health focus / Graph preview / Action queue, tudo em 5 segundos
+- **5 visualizacoes pure CSS+DOM** (Phase 2): bar chart, sparkline, warm zone gradient, broken wikilink cluster, sha256 duplicate cluster
+- **Lineage tab (Phase 3)**: raw-sources → summaries → wiki pages 3-layer lineage graph, 5 edge types, 300-node cap, best-effort hint
+- **Quality notes drawer (Phase 4)**: `wiki/lint-report.md` renderizado como 5o card, `kioku_health` e auto-lint com non-overlapping surface
+- **§46 N=3 mandatory refactor**: `wiki-walker.mjs` extraido, 3 callers unificados
+- **Real-world dogfood (PM Vault, 162 paginas)**: broken=23 / sha256_dup=2 / warm=99, lineage 184 nos / 846 edges em 68ms, HTML self-contained 61.5KB
+- **Tests**: 38 Phase 4 + 45 Phase 3 + Node + Bash regression todos passaram
+- [Release v0.8.0](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.8.0)
+
 ### 2026-05-08 — v0.7.5: Sprint 2 concluido — `kioku_health` 11 metricas (5 stretch adicionadas) + auto-lint refactor
 
 v0.7.5 marca a **conclusao do Sprint 2 (記憶品質 dashboard)** — micro cascade do mesmo dia apos a release matinal de v0.7.4.

--- a/README.ru.md
+++ b/README.ru.md
@@ -331,6 +331,19 @@ KIOKU спроектирован для **совместного использ�
 
 ## История изменений
 
+### 2026-05-13 — v0.8.0: "Откройте KIOKU и увидите, как растет ваша память" — HTML Visualizer β (Sprint 3 завершен)
+
+v0.8.0 отмечает **завершение Sprint 3 (価値の可視化)**. Первый release, где KIOKU может показать ценность без Obsidian — drag-and-drop сгенерированный HTML в любой browser и увидеть свой second brain.
+
+- **Overview tab (4 layers)**: Vault overview / Health focus / Graph preview / Action queue, всё за 5 секунд
+- **5 визуализаций pure CSS+DOM** (Phase 2): bar chart, sparkline, warm zone gradient, broken wikilink cluster, sha256 duplicate cluster
+- **Lineage tab (Phase 3)**: raw-sources → summaries → wiki pages 3-layer lineage graph, 5 edge types, 300-node cap, best-effort hint
+- **Quality notes drawer (Phase 4)**: `wiki/lint-report.md` отрендерен как 5й card, `kioku_health` и auto-lint с non-overlapping surface
+- **§46 N=3 mandatory refactor**: `wiki-walker.mjs` извлечён, 3 callers унифицированы
+- **Real-world dogfood (PM Vault, 162 страницы)**: broken=23 / sha256_dup=2 / warm=99, lineage 184 узлов / 846 edges за 68ms, HTML self-contained 61.5KB
+- **Tests**: 38 Phase 4 + 45 Phase 3 + Node + Bash regression все pass
+- [Release v0.8.0](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.8.0)
+
 ### 2026-05-08 — v0.7.5: Sprint 2 завершен — `kioku_health` 11 метрик (5 stretch добавлены) + auto-lint refactor
 
 v0.7.5 отмечает **завершение Sprint 2 (記憶品質 dashboard)** — micro cascade в тот же день после утренней release v0.7.4.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -331,6 +331,19 @@ KIOKU 是一个可以访问**所有 Claude Code 会话输入输出**的 Hook 系
 
 ## 更新历史
 
+### 2026-05-13 — v0.8.0：「打开 KIOKU 看看你的记忆长什么样」— HTML Visualizer β (Sprint 3 完成)
+
+v0.8.0 标志着 **Sprint 3 (価値の可視化) 完成**。KIOKU 首次能够无需 Obsidian 展示价值 — 将生成的 HTML 拖入任何 browser，即可看到你的 second brain。
+
+- **Overview tab (4 layers)**：Vault overview / Health focus / Graph preview / Action queue，5 秒内全部可见
+- **5 个可视化 pure CSS+DOM** (Phase 2)：bar chart、sparkline、warm zone gradient、broken wikilink cluster、sha256 duplicate cluster
+- **Lineage tab (Phase 3)**：raw-sources → summaries → wiki pages 3-layer lineage graph、5 edge types、300-node cap、best-effort hint
+- **Quality notes drawer (Phase 4)**：`wiki/lint-report.md` 作为第 5 张 card 渲染，`kioku_health` 与 auto-lint 在 non-overlapping surface 共存
+- **§46 N=3 mandatory refactor**：`wiki-walker.mjs` 抽出，3 callers 统一
+- **Real-world dogfood (PM Vault, 162 页)**：broken=23 / sha256_dup=2 / warm=99，lineage 184 nodes / 846 edges 用时 68ms，HTML self-contained 61.5KB
+- **Tests**：38 Phase 4 + 45 Phase 3 + Node + Bash regression 全部 pass
+- [Release v0.8.0](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.8.0)
+
 ### 2026-05-08 — v0.7.5：Sprint 2 完成 — `kioku_health` 11 个指标 (新增 stretch 5) + auto-lint refactor
 
 v0.7.5 标志着 **Sprint 2 (記憶品質 dashboard) 完成** — v0.7.4 上午 release 后同日的 micro cascade。

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -331,6 +331,19 @@ KIOKU 是一個存取**所有 Claude Code 工作階段 I/O** 的 Hook 系統。
 
 ## 更新歷史
 
+### 2026-05-13 — v0.8.0：「打開 KIOKU 看看你的記憶長什麼樣」— HTML Visualizer β (Sprint 3 完成)
+
+v0.8.0 標記著 **Sprint 3 (価値の可視化) 完成**。KIOKU 首次能夠不需 Obsidian 展示價值 — 將生成的 HTML 拖入任何 browser，即可看到你的 second brain。
+
+- **Overview tab (4 layers)**：Vault overview / Health focus / Graph preview / Action queue，5 秒內全部可見
+- **5 個可視化 pure CSS+DOM** (Phase 2)：bar chart、sparkline、warm zone gradient、broken wikilink cluster、sha256 duplicate cluster
+- **Lineage tab (Phase 3)**：raw-sources → summaries → wiki pages 3-layer lineage graph、5 edge types、300-node cap、best-effort hint
+- **Quality notes drawer (Phase 4)**：`wiki/lint-report.md` 作為第 5 張 card 渲染，`kioku_health` 與 auto-lint 在 non-overlapping surface 共存
+- **§46 N=3 mandatory refactor**：`wiki-walker.mjs` 抽出，3 callers 統一
+- **Real-world dogfood (PM Vault, 162 頁)**：broken=23 / sha256_dup=2 / warm=99，lineage 184 nodes / 846 edges 用時 68ms，HTML self-contained 61.5KB
+- **Tests**：38 Phase 4 + 45 Phase 3 + Node + Bash regression 全部 pass
+- [Release v0.8.0](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.8.0)
+
 ### 2026-05-08 — v0.7.5：Sprint 2 完成 — `kioku_health` 11 個指標 (新增 stretch 5) + auto-lint refactor
 
 v0.7.5 標記 **Sprint 2 (記憶品質 dashboard) 完成** — v0.7.4 上午 release 後同日的 micro cascade。


### PR DESCRIPTION
Sprint 3 完走 (HTML Visualizer β + Path C+β viewer 70% 達成) narrative を 10 言語 README に parity で挿入。

LEARN#11 mandatory step (README は parent release PR に含めず、別 PR で kioku 側に直接 push、post-release-sync の rsync 全上書きで消失する trap 回避)。

## Parity 10/10

EN (README.md) + JA (英語混入最小化) + es / fr / hi / ko / pt-BR / ru / zh-CN / zh-TW

## Title pattern (ユーザー視点ルール適用)

- EN: "Open KIOKU and see what your memory looks like"
- JA: 「自分の記憶が育っているか」を 5 秒で見せる
- 各言語 user 疑問形 / benefit 提示型タイトル

## entry 構造

- EN + JA: 長文 (Phase 1-4 詳述、Real Vault dogfood 数値、§46 refactor narrative)
- 残 8 言語: compact 5 bullet (v0.7.5 pattern 踏襲)

## Parent ref

- 主軸 PR: #122-#127 (Sprint 3 Phase 1-4) + #128 (version bump)
- kioku next → main sync PR: #45 (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)