### PR TITLE
KIOKU v0.9.0 release (Sprint 3 + Sprint 4 全 phase 完走、Path C+β 70%→100% 達成)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "KIOKU: Hardened LLM Wiki for Claude Code / Claude Desktop by megaphone-tokyo",
-    "version": "0.8.0"
+    "version": "0.9.0"
   },
   "plugins": [
     {
@@ -17,7 +17,7 @@
         "ref": "main"
       },
       "description": "Hardened LLM Wiki for Claude Code + Claude Desktop. Automatic conversation → Obsidian Vault knowledge base. Hot cache + PostCompact hook + secret masking + Git sync.",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "author": {
         "name": "megaphone-tokyo",
         "url": "https://github.com/megaphone-tokyo"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kioku",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "KIOKU — Hardened LLM Wiki for Claude Code + Claude Desktop. Automatic conversation capture to Obsidian Vault, Karpathy LLM Wiki pattern, hot cache + PostCompact hook, secret masking, cross-machine Git sync. Research/legal/enterprise-grade memory for Claude.",
   "author": {
     "name": "megaphone-tokyo",

--- a/hooks/sync-vault.mjs
+++ b/hooks/sync-vault.mjs
@@ -1,0 +1,379 @@
+#!/usr/bin/env node
+// hooks/sync-vault.mjs — Vault Git sync with retry queue (Sprint 4 Phase 4 PR A4).
+//
+// Replaces the inline shell oneliners that previously lived in:
+//   - scripts/install-hooks.sh         SessionStart (pull) / SessionEnd (push)
+//   - scripts/install-hooks-gemini.sh  same pair
+//   - scripts/install-hooks-codex.sh   same pair
+//
+// Two CLI modes invoked by hook commands:
+//   --pull-and-retry  (SessionStart): git pull --rebase, then drain retry queue
+//   --push            (SessionEnd):   git add/commit/push; on failure, enqueue
+//
+// Failure semantics (preserves prior `2>/dev/null || true` behavior):
+//   - Never exits non-zero. Always exit code 0 so the hook chain never blocks
+//     a Claude session. Status is communicated via stderr text only.
+//   - User-facing messages go to stderr in Japanese (UX consistency with prior
+//     silent flow). Token literals are scrubbed via maskText (LEARN#13 +
+//     scan-secrets MASK_RULES single source of truth from scripts/lib/masking.mjs).
+//
+// Retry queue file: $OBSIDIAN_VAULT/.kioku-sync-retry.json
+//   {
+//     "errorType":    "network" | "non-fast-forward" | "auth" | "unknown",
+//     "message":      "<masked stderr excerpt, <=512 chars>",
+//     "firstAttempt": "<ISO8601>",
+//     "lastAttempt":  "<ISO8601>",
+//     "retryCount":   <int>
+//   }
+//
+// Security contract (open-issues §40 / LEARN#13):
+//   - Every stderr string is passed through maskText() before write or print.
+//     maskText already covers ghp_*, github_pat_*, Bearer, embedded URL creds.
+//   - Never reads process.env.GH_TOKEN/GITHUB_TOKEN; the queue records type +
+//     masked message only.
+//   - Writes are atomic (tmp file + rename) so a partial JSON can never be
+//     observed by a concurrent reader (doctor.sh, SessionStart hook).
+//   - Reads tolerate malformed JSON by treating queue as absent (defensive).
+
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import {
+  mkdtemp,
+  readFile,
+  rename,
+  rm,
+  unlink,
+  writeFile,
+} from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { maskText } from '../scripts/lib/masking.mjs';
+
+// -----------------------------------------------------------------------------
+// Constants
+// -----------------------------------------------------------------------------
+
+const RETRY_QUEUE_FILENAME = '.kioku-sync-retry.json';
+const MAX_STDERR_EXCERPT = 512;
+const COMMIT_PATHS = ['wiki/', 'raw-sources/', 'templates/', 'CLAUDE.md'];
+
+// -----------------------------------------------------------------------------
+// Pure helpers (exported for unit tests)
+// -----------------------------------------------------------------------------
+
+/**
+ * Classify a git push/pull stderr into one of four bucket strings.
+ * Kept conservative: only patterns we're confident map to a single bucket.
+ */
+export function classifyGitError(stderr) {
+  if (typeof stderr !== 'string' || stderr.length === 0) return 'unknown';
+  if (
+    /Could not resolve host/i.test(stderr) ||
+    /network is unreachable/i.test(stderr) ||
+    /connection refused/i.test(stderr) ||
+    /operation timed out/i.test(stderr) ||
+    /could not read from remote repository/i.test(stderr) ||
+    /unable to access/i.test(stderr)
+  ) {
+    return 'network';
+  }
+  if (
+    /\bnon-fast-forward\b/i.test(stderr) ||
+    /\[rejected\]/i.test(stderr) ||
+    /failed to push some refs/i.test(stderr) ||
+    /tip of your current branch is behind/i.test(stderr)
+  ) {
+    return 'non-fast-forward';
+  }
+  if (
+    /authentication failed/i.test(stderr) ||
+    /permission denied \(publickey\)/i.test(stderr) ||
+    /invalid username or password/i.test(stderr) ||
+    /could not read username/i.test(stderr) ||
+    /403 forbidden/i.test(stderr) ||
+    /401 unauthorized/i.test(stderr)
+  ) {
+    return 'auth';
+  }
+  return 'unknown';
+}
+
+/**
+ * Mask credential-like substrings before they leak into the retry queue file
+ * or user-visible stderr. Thin wrapper for maskText — keeping the named export
+ * so call sites read intentionally ("we are masking for credential safety").
+ */
+export function maskCredentials(text) {
+  if (typeof text !== 'string') return '';
+  return maskText(text);
+}
+
+/**
+ * Atomically write the retry queue file. Writes to a tmp file in the parent
+ * directory of the target, then renames into place — rename is atomic on the
+ * same filesystem, so concurrent readers never see partial JSON.
+ */
+export async function writeRetryQueue(retryQueuePath, entry) {
+  const parent = dirname(retryQueuePath);
+  const tmpDir = await mkdtemp(join(parent, '.kioku-sync-retry-tmp-'));
+  const tmpFile = join(tmpDir, 'queue.json');
+  try {
+    await writeFile(tmpFile, JSON.stringify(entry, null, 2) + '\n', 'utf8');
+    await rename(tmpFile, retryQueuePath);
+  } finally {
+    try {
+      await unlink(tmpFile);
+    } catch {
+      /* expected when rename succeeded */
+    }
+    try {
+      await rm(tmpDir, { recursive: true, force: true });
+    } catch {
+      /* tolerate */
+    }
+  }
+}
+
+/**
+ * Read and parse the retry queue. Returns null if file is missing or malformed
+ * (defensive: a corrupt queue should not block SessionStart).
+ */
+export async function readRetryQueue(retryQueuePath) {
+  if (!existsSync(retryQueuePath)) return null;
+  try {
+    const raw = await readFile(retryQueuePath, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object') return parsed;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Remove the retry queue file. Idempotent — missing file is not an error.
+ */
+export async function clearRetryQueue(retryQueuePath) {
+  try {
+    await unlink(retryQueuePath);
+  } catch (e) {
+    if (e && e.code === 'ENOENT') return;
+    // best-effort; don't throw — the queue file is auxiliary state
+  }
+}
+
+/**
+ * Build a retry queue entry. Centralizes the masking + truncation contract so
+ * callers cannot forget to mask. `previous` lets callers preserve firstAttempt
+ * + retryCount when updating an existing entry.
+ */
+export function buildRetryQueueEntry({ errorType, stderr, previous, now }) {
+  const clock = typeof now === 'function' ? now : () => new Date().toISOString();
+  const ts = clock();
+  const message = maskCredentials(stderr || '').slice(0, MAX_STDERR_EXCERPT);
+  if (previous && typeof previous === 'object') {
+    return {
+      errorType,
+      message,
+      firstAttempt: previous.firstAttempt || ts,
+      lastAttempt: ts,
+      retryCount: Number.isFinite(previous.retryCount) ? previous.retryCount + 1 : 1,
+    };
+  }
+  return {
+    errorType,
+    message,
+    firstAttempt: ts,
+    lastAttempt: ts,
+    retryCount: 0,
+  };
+}
+
+/**
+ * Compute the retry queue path for a given vault. Centralized so tests + impl
+ * agree on the filename.
+ */
+export function retryQueuePathFor(vaultPath) {
+  return join(vaultPath, RETRY_QUEUE_FILENAME);
+}
+
+// -----------------------------------------------------------------------------
+// Git invocation (kept narrow so spawn injection via opts.spawn enables mocking)
+// -----------------------------------------------------------------------------
+
+function runGit(vaultPath, args, opts) {
+  const spawn = (opts && opts.spawn) || spawnSync;
+  const result = spawn('git', args, {
+    cwd: vaultPath,
+    encoding: 'utf8',
+  });
+  return {
+    status: typeof result.status === 'number' ? result.status : 1,
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+  };
+}
+
+// -----------------------------------------------------------------------------
+// Pre-flight (preserves prior shell oneliner gates)
+// -----------------------------------------------------------------------------
+
+export async function shouldRunPush({ vaultPath, env = process.env, spawn }) {
+  if (env.KIOKU_NO_LOG === '1') return false;
+  if (!existsSync(vaultPath)) return false;
+  const gitignorePath = join(vaultPath, '.gitignore');
+  if (!existsSync(gitignorePath)) return false;
+  let gitignore;
+  try {
+    gitignore = await readFile(gitignorePath, 'utf8');
+  } catch {
+    return false;
+  }
+  if (!/^session-logs\//m.test(gitignore)) return false;
+  const head = runGit(vaultPath, ['symbolic-ref', '-q', 'HEAD'], { spawn });
+  if (head.status !== 0) return false;
+  return true;
+}
+
+// -----------------------------------------------------------------------------
+// SessionEnd flow: add + commit + push, queue on failure
+// -----------------------------------------------------------------------------
+
+export async function syncToRemote({
+  vaultPath,
+  env = process.env,
+  spawn,
+  stderr = (msg) => process.stderr.write(msg + '\n'),
+  now,
+}) {
+  if (!(await shouldRunPush({ vaultPath, env, spawn }))) {
+    return { status: 'skipped' };
+  }
+
+  runGit(vaultPath, ['add', ...COMMIT_PATHS], { spawn });
+
+  const cached = runGit(vaultPath, ['diff', '--cached', '--quiet'], { spawn });
+  if (cached.status === 0) {
+    return { status: 'no-changes' };
+  }
+
+  const commitMsg = `auto: wiki update ${formatNowForCommit(now)}`;
+  const commit = runGit(vaultPath, ['commit', '-m', commitMsg, '--quiet'], { spawn });
+  if (commit.status !== 0) {
+    return { status: 'commit-failed', stderr: maskCredentials(commit.stderr) };
+  }
+
+  const push = runGit(vaultPath, ['push', '--quiet'], { spawn });
+  if (push.status === 0) {
+    await clearRetryQueue(retryQueuePathFor(vaultPath));
+    return { status: 'pushed' };
+  }
+
+  const errorType = classifyGitError(push.stderr);
+  const queuePath = retryQueuePathFor(vaultPath);
+  const previous = await readRetryQueue(queuePath);
+  const entry = buildRetryQueueEntry({
+    errorType,
+    stderr: push.stderr,
+    previous,
+    now,
+  });
+  await writeRetryQueue(queuePath, entry);
+  stderr(`クラウド同期できませんでした。次回 Claude 起動時に再同期されます (詳細: ${errorType})`);
+  return { status: 'queued', errorType, retryCount: entry.retryCount };
+}
+
+// -----------------------------------------------------------------------------
+// SessionStart flow: pull, then drain retry queue if present
+// -----------------------------------------------------------------------------
+
+export async function checkAndRetrySync({
+  vaultPath,
+  env = process.env,
+  spawn,
+  stderr = (msg) => process.stderr.write(msg + '\n'),
+  stdout = (msg) => process.stdout.write(msg + '\n'),
+  now,
+}) {
+  if (env.KIOKU_NO_LOG === '1') return { status: 'skipped' };
+  if (!existsSync(vaultPath)) return { status: 'skipped' };
+
+  runGit(vaultPath, ['pull', '--rebase', '--quiet'], { spawn });
+
+  const queuePath = retryQueuePathFor(vaultPath);
+  const previous = await readRetryQueue(queuePath);
+  if (!previous) return { status: 'no-retry-needed' };
+
+  const head = runGit(vaultPath, ['symbolic-ref', '-q', 'HEAD'], { spawn });
+  if (head.status !== 0) {
+    stderr(`クラウド同期の retry queue が残っていますが、現在のブランチ状態で再試行できません (累計 ${previous.retryCount} 回)`);
+    return { status: 'retry-blocked', retryCount: previous.retryCount };
+  }
+
+  const retryPush = runGit(vaultPath, ['push', '--quiet'], { spawn });
+  if (retryPush.status === 0) {
+    await clearRetryQueue(queuePath);
+    stdout(`クラウド同期が再開しました (前回失敗から ${previous.retryCount + 1} 回目で成功)`);
+    return { status: 'retry-success', retryCount: previous.retryCount + 1 };
+  }
+
+  const errorType = classifyGitError(retryPush.stderr);
+  const entry = buildRetryQueueEntry({
+    errorType,
+    stderr: retryPush.stderr,
+    previous,
+    now,
+  });
+  await writeRetryQueue(queuePath, entry);
+  stderr(`クラウド同期に再失敗 (累計 ${entry.retryCount} 回、最新 error: ${errorType})`);
+  return { status: 'retry-failed', errorType, retryCount: entry.retryCount };
+}
+
+// -----------------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------------
+
+function formatNowForCommit(now) {
+  const iso = (typeof now === 'function' ? now() : new Date().toISOString());
+  const m = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})/.exec(iso);
+  if (!m) return iso;
+  return `${m[1]}${m[2]}${m[3]}-${m[4]}${m[5]}`;
+}
+
+// -----------------------------------------------------------------------------
+// CLI entry (LEARN#14 isEntry pattern — never fires during test import)
+// -----------------------------------------------------------------------------
+
+function isEntry() {
+  return Boolean(
+    process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href
+  );
+}
+
+async function main() {
+  const mode = process.argv[2];
+  const vaultPath = process.env.OBSIDIAN_VAULT;
+  if (!vaultPath) {
+    return;
+  }
+  try {
+    if (mode === '--pull-and-retry') {
+      await checkAndRetrySync({ vaultPath });
+    } else if (mode === '--push') {
+      await syncToRemote({ vaultPath });
+    }
+  } catch (e) {
+    try {
+      process.stderr.write(
+        `sync-vault: unexpected error (${maskCredentials(String((e && e.message) || e))})\n`
+      );
+    } catch {
+      /* suppress secondary failures */
+    }
+  }
+}
+
+if (isEntry()) {
+  main();
+}

--- a/mcp/lib/bases-renderer.mjs
+++ b/mcp/lib/bases-renderer.mjs
@@ -1,0 +1,580 @@
+// bases-renderer.mjs — Internal `.base` (Obsidian Bases plugin format) parser + renderer.
+//
+// Sprint 4 Phase 1 PR A (plan/claude/26051301_v0-9-phase1-impl-plan.md §「PR A」 L147-1068).
+//
+// Scope (v0.9 P0 7 項目 + P1 warning, codex strategic doc 260513 Axis 1):
+//   - filters.and with file.inFolder("path") / file.ext == "ext" / file.name == "X"
+//     / negation !expr / <frontmatter_key> == "X" / formula.<name> <op> N
+//   - formulas.age_days: '(now() - file.mtime).days'
+//   - properties.<name>.displayName: "Label"
+//   - views: [{ type: table | list, name, limit, filters, order, groupBy }]
+//   - Unknown expression → P1 warning + exclude from view (silent misrender 禁止)
+//
+// Security boundary (P1, Sprint 3 継承 + LEARN#13):
+//   - NO dynamic code execution (no eval / vm / Function constructor).
+//   - Filters / formulas are evaluated by a structured switch / table-driven dispatch.
+//   - page.body NEVER touched (Sprint 3 body 漏洩契約継承). walkPages is invoked with
+//     withBody:false. RenderedView pages only expose rel/name/type/title/frontmatter/mtime/computed.
+//   - regex literals avoid invisible Unicode (no U+2028 / U+2029 / U+200B / U+FEFF).
+
+import { walkPages } from './wiki-walker.mjs';
+
+export class BasesParseError extends Error {
+  constructor(message, line) {
+    super(`${message}${line != null ? ` (line ${line})` : ''}`);
+    this.name = 'BasesParseError';
+    this.line = line;
+  }
+}
+
+export function parseBaseFile(text) {
+  const warnings = [];
+  if (typeof text !== 'string') {
+    throw new BasesParseError('parseBaseFile expects a string');
+  }
+  const raw = parseYamlLike(text);
+  const ast = {
+    filters: null,
+    formulas: {},
+    properties: {},
+    views: [],
+  };
+  if (raw && typeof raw === 'object') {
+    if (raw.filters != null) {
+      if (typeof raw.filters !== 'object' || !raw.filters.and) {
+        throw new BasesParseError('filters must contain "and" key');
+      }
+      if (!Array.isArray(raw.filters.and)) {
+        throw new BasesParseError('filters.and must be a list');
+      }
+      ast.filters = { and: raw.filters.and };
+    }
+    if (raw.formulas && typeof raw.formulas === 'object') {
+      ast.formulas = raw.formulas;
+    }
+    if (raw.properties && typeof raw.properties === 'object') {
+      ast.properties = raw.properties;
+    }
+    if (Array.isArray(raw.views)) {
+      ast.views = raw.views.map((v) => normalizeView(v));
+    }
+  }
+  return { ast, warnings };
+}
+
+function normalizeView(v) {
+  if (!v || typeof v !== 'object') {
+    throw new BasesParseError('view entry must be a mapping');
+  }
+  const out = {
+    type: typeof v.type === 'string' ? v.type : 'list',
+    name: typeof v.name === 'string' ? v.name : '',
+  };
+  if (typeof v.limit === 'number') out.limit = v.limit;
+  if (v.filters && typeof v.filters === 'object' && Array.isArray(v.filters.and)) {
+    out.filters = { and: v.filters.and };
+  }
+  if (Array.isArray(v.order)) out.order = v.order;
+  if (v.groupBy && typeof v.groupBy === 'object' && typeof v.groupBy.property === 'string') {
+    out.groupBy = {
+      property: v.groupBy.property,
+      direction: v.groupBy.direction === 'DESC' ? 'DESC' : 'ASC',
+    };
+  }
+  return out;
+}
+
+export async function renderBases(vault, ast, options = {}) {
+  const now = options.now instanceof Date ? options.now : new Date();
+  const warnings = [];
+  if (typeof vault !== 'string' || !vault) {
+    return { views: [], warnings };
+  }
+  const pages = await walkPages(vault, {
+    subDir: 'wiki',
+    withFrontmatter: true,
+    withWikilinks: false,
+    withBody: false,
+    withMtime: true,
+  });
+
+  // Compute formulas first — filters can reference page.computed.<name>.
+  for (const p of pages) {
+    p.computed = computeFormulas(p, ast, now, warnings);
+  }
+
+  // Apply global filters (filters.and).
+  let filtered = pages;
+  if (ast.filters && Array.isArray(ast.filters.and)) {
+    filtered = filtered.filter((p) =>
+      ast.filters.and.every((expr) => evaluateFilter(expr, p, ast, now, warnings)),
+    );
+  }
+
+  const views = [];
+  for (const view of ast.views) {
+    let vp = filtered;
+    if (view.filters && Array.isArray(view.filters.and)) {
+      vp = vp.filter((p) =>
+        view.filters.and.every((expr) => evaluateFilter(expr, p, ast, now, warnings)),
+      );
+    }
+    vp = applyOrder(vp, view.order);
+    const rendered = {
+      name: view.name,
+      type: view.type,
+      pages: [],
+    };
+    if (view.groupBy) {
+      const groups = applyGroupBy(vp, view.groupBy);
+      rendered.groupBy = view.groupBy;
+      rendered.groups = (groups || []).map((g) => ({
+        key: g.key,
+        pages: g.pages.map(normalizeRenderedPage),
+      }));
+      rendered.pages = applyLimit(vp, view.limit).map(normalizeRenderedPage);
+    } else {
+      rendered.pages = applyLimit(vp, view.limit).map(normalizeRenderedPage);
+    }
+    views.push(rendered);
+  }
+  return { views, warnings };
+}
+
+// P1 Security boundary (Sprint 3 継承): RenderedView pages must NOT expose `abs`
+// (absolute filesystem path) — that would leak local filesystem layout when shell
+// templates serialize the view to inline JSON downstream. Whitelist the contract
+// fields explicitly so a future walkPages addition cannot accidentally widen the
+// surface.
+function normalizeRenderedPage(p) {
+  return {
+    rel: p.rel,
+    name: p.name,
+    type: p.type,
+    title: p.title,
+    frontmatter: p.frontmatter || {},
+    mtime: p.mtime instanceof Date ? p.mtime : null,
+    computed: p.computed || {},
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Filter evaluation (Task A-3): 6 P0 operators + unknown → warning.
+// ---------------------------------------------------------------------------
+
+function evaluateFilter(expr, page, ast, now, warnings) {
+  if (typeof expr !== 'string') {
+    warnings.push(`unknown filter expression: ${JSON.stringify(expr)}`);
+    return false;
+  }
+  const trimmed = expr.trim();
+
+  // 1. Negation: !inner
+  if (trimmed.startsWith('!')) {
+    return !evaluateFilter(trimmed.slice(1).trim(), page, ast, now, warnings);
+  }
+
+  // 2. file.inFolder("path")
+  let m = trimmed.match(/^file\.inFolder\("([^"]+)"\)$/);
+  if (m) {
+    const folder = m[1];
+    if (folder === 'wiki') return true;
+    if (folder.startsWith('wiki/')) {
+      const sub = folder.slice('wiki/'.length);
+      if (sub === '') return true;
+      return page.rel === sub || page.rel.startsWith(`${sub}/`);
+    }
+    return false;
+  }
+
+  // 3. file.ext == "X"
+  m = trimmed.match(/^file\.ext\s*==\s*"([^"]+)"$/);
+  if (m) {
+    const ext = m[1];
+    return page.rel.endsWith(`.${ext}`);
+  }
+
+  // 4. file.name == "X"
+  m = trimmed.match(/^file\.name\s*==\s*"([^"]+)"$/);
+  if (m) {
+    return page.name === m[1];
+  }
+
+  // 5. formula.<name> <op> N
+  m = trimmed.match(/^formula\.([A-Za-z_][A-Za-z0-9_]*)\s*(>=|<=|==|>|<)\s*(-?\d+(?:\.\d+)?)$/);
+  if (m) {
+    const fname = m[1];
+    const op = m[2];
+    const rhs = Number(m[3]);
+    const lhs = (page.computed || {})[fname];
+    if (typeof lhs !== 'number') return false;
+    switch (op) {
+      case '>': return lhs > rhs;
+      case '<': return lhs < rhs;
+      case '>=': return lhs >= rhs;
+      case '<=': return lhs <= rhs;
+      case '==': return lhs === rhs;
+      default: return false;
+    }
+  }
+
+  // 6. <frontmatter_key> == "X"   (matches single identifier, not file.* / formula.*)
+  m = trimmed.match(/^([A-Za-z_][A-Za-z0-9_]*)\s*==\s*"([^"]+)"$/);
+  if (m) {
+    const key = m[1];
+    const expected = m[2];
+    if (key === 'file' || key === 'formula') {
+      // shouldn't happen — covered above — but fall through to unknown
+    } else {
+      const value = page.frontmatter && page.frontmatter[key];
+      return value === expected;
+    }
+  }
+
+  warnings.push(`unknown filter expression: ${trimmed}`);
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Formula evaluation (Task A-4): age_days only (P0).
+// ---------------------------------------------------------------------------
+
+function computeFormulas(page, ast, now, warnings) {
+  const out = {};
+  if (!ast.formulas) return out;
+  for (const [name, expr] of Object.entries(ast.formulas)) {
+    const value = evaluateFormula(expr, page, now);
+    if (value === null && !isKnownFormula(expr)) {
+      if (Array.isArray(warnings)) {
+        warnings.push(`unknown formula expression: ${name}: ${expr}`);
+      }
+    }
+    out[name] = value;
+  }
+  return out;
+}
+
+const AGE_DAYS_RE = /^\(now\(\)\s*-\s*file\.mtime\)\.days$/;
+
+function isKnownFormula(expr) {
+  if (typeof expr !== 'string') return false;
+  return AGE_DAYS_RE.test(expr.trim());
+}
+
+function evaluateFormula(expr, page, now) {
+  if (typeof expr !== 'string') return null;
+  const trimmed = expr.trim();
+  if (AGE_DAYS_RE.test(trimmed)) {
+    if (!(page.mtime instanceof Date)) return null;
+    const diffMs = now.getTime() - page.mtime.getTime();
+    return Math.floor(diffMs / (1000 * 60 * 60 * 24));
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Order / limit / groupBy (Task A-6).
+// ---------------------------------------------------------------------------
+
+function resolveField(page, field) {
+  if (field === 'file.name') return page.name;
+  if (field === 'file.mtime') return page.mtime;
+  if (field === 'file.rel') return page.rel;
+  if (typeof field === 'string' && field.startsWith('formula.')) {
+    return (page.computed || {})[field.slice('formula.'.length)];
+  }
+  return page.frontmatter ? page.frontmatter[field] : undefined;
+}
+
+function compareValues(a, b) {
+  if (a == null && b == null) return 0;
+  if (a == null) return 1;
+  if (b == null) return -1;
+  if (a instanceof Date && b instanceof Date) {
+    return a.getTime() - b.getTime();
+  }
+  if (typeof a === 'number' && typeof b === 'number') {
+    return a - b;
+  }
+  const as = String(a);
+  const bs = String(b);
+  if (as < bs) return -1;
+  if (as > bs) return 1;
+  return 0;
+}
+
+function applyOrder(pages, orderFields) {
+  if (!Array.isArray(orderFields) || orderFields.length === 0) return pages;
+  return [...pages].sort((a, b) => {
+    for (const field of orderFields) {
+      const cmp = compareValues(resolveField(a, field), resolveField(b, field));
+      if (cmp !== 0) return cmp;
+    }
+    return 0;
+  });
+}
+
+function applyLimit(pages, limit) {
+  if (typeof limit !== 'number' || limit < 0) return pages;
+  return pages.slice(0, limit);
+}
+
+function applyGroupBy(pages, groupBy) {
+  if (!groupBy || !groupBy.property) return null;
+  const groupsMap = new Map();
+  for (const p of pages) {
+    const raw = resolveField(p, groupBy.property);
+    const key = raw == null ? '(unknown)' : String(raw);
+    if (!groupsMap.has(key)) groupsMap.set(key, []);
+    groupsMap.get(key).push(p);
+  }
+  const direction = groupBy.direction === 'DESC' ? -1 : 1;
+  return Array.from(groupsMap.entries())
+    .sort(([a], [b]) => {
+      if (a < b) return -1 * direction;
+      if (a > b) return 1 * direction;
+      return 0;
+    })
+    .map(([key, items]) => ({ key, pages: items }));
+}
+
+// ---------------------------------------------------------------------------
+// Mini YAML-subset parser (Task A-2).
+//
+// Supports:
+//   - 2-space indent (any consistent indent, derived from indent jumps)
+//   - key: value  (string, number, boolean, null, single/double-quoted string)
+//   - lists: '- item' (string) or '- key: value' (object, additional sub-keys
+//     allowed at deeper indent)
+//   - nested objects (key: with empty value, then deeper indented block)
+//   - comments (# until end of line) and blank lines
+//   - keys may contain literal dots (e.g., formula.age_days)
+//
+// Does NOT support:
+//   - YAML anchors / aliases
+//   - flow style ({} / [])
+//   - multi-line scalars (folded / literal)
+//   - tags
+// Throws BasesParseError on malformed input.
+// ---------------------------------------------------------------------------
+
+function parseYamlLike(text) {
+  const rawLines = text.split('\n');
+  const lines = rawLines.map((line, idx) => ({
+    raw: line,
+    lineNum: idx + 1,
+  }));
+
+  let i = 0;
+
+  function skipBlank() {
+    while (i < lines.length) {
+      const trimmed = lines[i].raw.trim();
+      if (trimmed === '' || trimmed.startsWith('#')) {
+        i++;
+        continue;
+      }
+      return;
+    }
+  }
+
+  function getIndent(line) {
+    let n = 0;
+    while (n < line.length && line[n] === ' ') n++;
+    return n;
+  }
+
+  function parseScalar(raw, lineNum) {
+    const trimmed = raw.trim();
+    if (trimmed === '') return null;
+    if (trimmed[0] === '"') {
+      if (trimmed.length < 2 || trimmed[trimmed.length - 1] !== '"') {
+        throw new BasesParseError(`unterminated double-quoted string: ${trimmed}`, lineNum);
+      }
+      return trimmed.slice(1, -1);
+    }
+    if (trimmed[0] === "'") {
+      if (trimmed.length < 2 || trimmed[trimmed.length - 1] !== "'") {
+        throw new BasesParseError(`unterminated single-quoted string: ${trimmed}`, lineNum);
+      }
+      return trimmed.slice(1, -1);
+    }
+    if (/^-?\d+(?:\.\d+)?$/.test(trimmed)) return Number(trimmed);
+    if (trimmed === 'true') return true;
+    if (trimmed === 'false') return false;
+    if (trimmed === 'null' || trimmed === '~') return null;
+    return trimmed;
+  }
+
+  // Find first non-blank colon outside quotes (keys cannot contain unquoted colons).
+  function findKeyColon(content) {
+    let inSingle = false;
+    let inDouble = false;
+    let inParen = 0;
+    for (let idx = 0; idx < content.length; idx++) {
+      const ch = content[idx];
+      if (ch === '"' && !inSingle) inDouble = !inDouble;
+      else if (ch === "'" && !inDouble) inSingle = !inSingle;
+      else if (!inSingle && !inDouble) {
+        if (ch === '(') inParen++;
+        else if (ch === ')') inParen--;
+        else if (ch === ':' && inParen === 0) return idx;
+      }
+    }
+    return -1;
+  }
+
+  function parseBlock(parentIndent) {
+    const out = {};
+    while (i < lines.length) {
+      skipBlank();
+      if (i >= lines.length) break;
+      const { raw, lineNum } = lines[i];
+      const ind = getIndent(raw);
+      if (ind <= parentIndent) break;
+      const content = raw.slice(ind);
+      if (content.startsWith('- ') || content === '-') {
+        throw new BasesParseError(
+          `unexpected list item where mapping expected: "${content}"`,
+          lineNum,
+        );
+      }
+      const colonIdx = findKeyColon(content);
+      if (colonIdx === -1) {
+        throw new BasesParseError(`expected ":" in "${content}"`, lineNum);
+      }
+      const key = content.slice(0, colonIdx).trim();
+      const rest = content.slice(colonIdx + 1).trim();
+      i++;
+      if (rest === '') {
+        // Look at next non-blank line to decide list vs object vs null.
+        const savedI = i;
+        skipBlank();
+        if (i < lines.length) {
+          const childInd = getIndent(lines[i].raw);
+          if (childInd > ind) {
+            const peek = lines[i].raw.slice(childInd);
+            if (peek.startsWith('- ') || peek === '-') {
+              out[key] = parseList(ind);
+            } else {
+              out[key] = parseBlock(ind);
+            }
+            continue;
+          }
+        }
+        i = savedI;
+        out[key] = null;
+      } else {
+        out[key] = parseScalar(rest, lineNum);
+      }
+    }
+    return out;
+  }
+
+  function parseList(parentIndent) {
+    const out = [];
+    while (i < lines.length) {
+      skipBlank();
+      if (i >= lines.length) break;
+      const { raw, lineNum } = lines[i];
+      const ind = getIndent(raw);
+      if (ind <= parentIndent) break;
+      const content = raw.slice(ind);
+      if (!content.startsWith('- ') && content !== '-') break;
+      const rest = content === '-' ? '' : content.slice(2);
+      const itemBodyIndent = ind + 2;
+      i++;
+      if (rest === '') {
+        // Item value is on subsequent indented lines.
+        const savedI = i;
+        skipBlank();
+        if (i < lines.length) {
+          const childInd = getIndent(lines[i].raw);
+          if (childInd > ind) {
+            const peek = lines[i].raw.slice(childInd);
+            if (peek.startsWith('- ') || peek === '-') {
+              out.push(parseList(ind));
+            } else {
+              out.push(parseBlock(ind));
+            }
+            continue;
+          }
+        }
+        i = savedI;
+        out.push(null);
+        continue;
+      }
+      const restColonIdx = findKeyColon(rest);
+      if (restColonIdx !== -1) {
+        const key = rest.slice(0, restColonIdx).trim();
+        const valuePart = rest.slice(restColonIdx + 1).trim();
+        const obj = {};
+        if (valuePart === '') {
+          // Look at sub-lines deeper than itemBodyIndent for nested value of this key.
+          const savedI = i;
+          skipBlank();
+          if (i < lines.length) {
+            const childInd = getIndent(lines[i].raw);
+            if (childInd > itemBodyIndent) {
+              const peek = lines[i].raw.slice(childInd);
+              if (peek.startsWith('- ') || peek === '-') {
+                obj[key] = parseList(itemBodyIndent);
+              } else {
+                obj[key] = parseBlock(itemBodyIndent);
+              }
+            } else {
+              obj[key] = null;
+              i = savedI;
+            }
+          } else {
+            obj[key] = null;
+          }
+        } else {
+          obj[key] = parseScalar(valuePart, lineNum);
+        }
+        // Continue collecting sibling keys at itemBodyIndent.
+        while (i < lines.length) {
+          const savedI = i;
+          skipBlank();
+          if (i >= lines.length) break;
+          const nextRaw = lines[i].raw;
+          const nextInd = getIndent(nextRaw);
+          if (nextInd !== itemBodyIndent) {
+            i = savedI;
+            break;
+          }
+          const nextContent = nextRaw.slice(nextInd);
+          if (nextContent.startsWith('- ') || nextContent === '-') {
+            i = savedI;
+            break;
+          }
+          const sub = parseBlock(itemBodyIndent - 1);
+          Object.assign(obj, sub);
+          break;
+        }
+        out.push(obj);
+      } else {
+        out.push(parseScalar(rest, lineNum));
+      }
+    }
+    return out;
+  }
+
+  // Top-level block starts at indent -1 (anything ≥ 0 counts).
+  return parseBlock(-1);
+}
+
+// ---------------------------------------------------------------------------
+// Test-only exports.
+// ---------------------------------------------------------------------------
+
+export const _internals = {
+  evaluateFilter,
+  evaluateFormula,
+  computeFormulas,
+  applyOrder,
+  applyLimit,
+  applyGroupBy,
+  resolveField,
+  parseYamlLike,
+};

--- a/mcp/lib/qmd-search-index.mjs
+++ b/mcp/lib/qmd-search-index.mjs
@@ -1,0 +1,349 @@
+// qmd-search-index.mjs — Precompute top-N popular queries for shell snapshot mode.
+//
+// Plan: tools/claude-brain/plan/claude/26051402_v0-9-phase2-qmd-search-impl-plan.md §「PR A2」
+// Architectural Decision: tools/claude-brain/plan/claude/26051403_meeting_phase2-architectural-decision-option-c.md
+//   (Option C = Option A snapshot precomputed を Claude-augmented Search の Tier 1+2 design として意図化)
+//
+// Responsibility:
+//   - Discover top-N "interesting queries" from vault state (referenced tags + recent headings).
+//   - For each query, call kioku_search (lex/vec/hybrid) -> collect top-K results.
+//   - Return shell-consumable JSON shape (no body leak, escape-ready strings).
+//
+// Exports:
+//   buildSearchIndex(vault, options?) -> SearchIndex
+//   SEARCH_INDEX_SCHEMA_VERSION (=1)
+//   __test__ (internal helpers exposed for unit tests only)
+//
+// Security:
+//   - Result snippets are textContent-safe strings (no HTML escape here; render layer responsible).
+//   - No body / file path absolute leak (rel paths only, body field dropped by normalizeResults).
+//   - Path C+beta boundary: no editor / Canvas write / Plugin loader / cloud connector / fetch family.
+
+import { readFile, readdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { handleSearch } from '../tools/search.mjs';
+import { getFileHistory, isGitRepo } from './git-history.mjs';
+
+export const SEARCH_INDEX_SCHEMA_VERSION = 1;
+
+const DEFAULT_TOP_QUERIES = 10;
+const DEFAULT_RESULTS_PER_QUERY = 10;
+const MAX_TOP_QUERIES = 30;
+const MAX_RESULTS_PER_QUERY = 20;
+
+// Tag regex: #word-with-hyphen 形式、#1 等の純数字は除外、最低 2 文字。
+// LEARN#13: regex literal 内 invisible unicode は禁止だが本 regex は ASCII のみで safe。
+const TAG_RE = /(?:^|[^\w])#([a-z][a-z0-9-]{1,30})/gi;
+
+// wikilink: [[name]] 形式 (name に ] を含まない)。
+const WIKILINK_RE = /\[\[([^\]|]+?)(?:\|[^\]]+)?\]\]/g;
+
+// heading: # から始まる ATX h1-h3 (簡易抽出、log entry の "- " bullet は除外)。
+const HEADING_RE = /^#{1,3}\s+(.+?)\s*$/gm;
+
+// raw-sources / wiki/*.md broadly-referenced 用: ATX h1 + h2 のみ。
+const HEADING_H1H2_RE = /^#{1,2}\s+(.+?)\s*$/gm;
+
+// hot.md 単独行 #tag: 行頭 → #tag → 行末 (空白許容、ASCII tag 名のみ、log inline #tag と区別)。
+// LEARN#13: ASCII のみ、invisible unicode 不使用。
+const STANDALONE_TAG_RE = /^\s*#([a-z][a-z0-9-]{1,30})\s*$/gim;
+
+// Source 3 / wiki/*.md heading scan cap (mirrors MAX_RAW_SOURCES_SCAN).
+const MAX_SCAN_FILES = 30;
+
+// Source 4 (raw-sources/) の上限 (cf. source 3 と同 MAX_SCAN_FILES、再帰 walker でも cap)。
+const MAX_RAW_SOURCES_SCAN = 30;
+
+// Source 4 traversal cap: `scanned` は .md file 単位 (= file 内容読込 cost)、
+// `walks` は entry 単位 (= directory descent + file 検査 cost)。
+// pathological raw-sources/ (大量の空 subdir / 非 .md file) で .md 30 個に辿り着く前の DoS surface を bound。
+// 5x = .md と無関係 entry が 4 個ごとに 1 個 .md (= 80% noise) でも 30 file 完走可能なヘッドルーム。
+const MAX_RAW_SOURCES_WALK = MAX_RAW_SOURCES_SCAN * 5;
+
+// Source 5 (git commit) の直近 max 100 commits。
+const MAX_RECENT_COMMITS = 100;
+
+export async function buildSearchIndex(vault, options = {}) {
+  if (typeof vault !== 'string' || vault.length === 0) {
+    throw new Error('buildSearchIndex: vault path is required');
+  }
+  const topQueries = clamp(options.topQueries ?? DEFAULT_TOP_QUERIES, 1, MAX_TOP_QUERIES);
+  const resultsPer = clamp(options.resultsPer ?? DEFAULT_RESULTS_PER_QUERY, 1, MAX_RESULTS_PER_QUERY);
+  const mode = options.mode ?? 'hybrid';
+
+  // Step 1: discover interesting queries from vault state
+  const queries = await discoverQueries(vault, topQueries);
+
+  // Step 2: invoke kioku_search per query, normalize results
+  const items = [];
+  for (const q of queries) {
+    let res;
+    try {
+      res = await handleSearch(vault, { query: q, limit: resultsPer, mode });
+    } catch {
+      // 個別 query の失敗で全体を落とさない (build time precompute の robustness)
+      continue;
+    }
+    items.push({
+      query: q,
+      mode,
+      results: normalizeResults(res?.results ?? []),
+    });
+  }
+
+  return {
+    schema_version: SEARCH_INDEX_SCHEMA_VERSION,
+    generated_at: new Date().toISOString(),
+    queries: items,
+  };
+}
+
+/**
+ * Discover top-N "interesting" queries from vault state.
+ *
+ * Sources (in priority order, weight noted):
+ *   1. wiki/log.md tag refs (#tag) — weight 3
+ *   2. wiki/index.md outgoing wikilinks ([[name]]) — weight 2
+ *   3. wiki/*.md (log/index/hot 除く) top-level headings h1-h3 — weight 1
+ *   4. raw-sources/ .md の h1 + h2 headings — weight 2
+ *      (raw 取り込みされた素材の主題が popular query になりやすい)
+ *   5. git commit subjects (直近 MAX_RECENT_COMMITS) — weight 1.5
+ *      (実装の動向と整合する query、非 git repo は graceful skip)
+ *   6. wiki/hot.md ATX heading (h1-h3) + standalone-line #tag — weight 2.5
+ *      (hot context = 直近 priority、user 関心と整合度高)
+ *   7. wiki/*.md broadly-referenced (>=2 files) — bonus 1.2 * (file_count - 1)
+ *      (broadly referenced concept; source 3 と独立に bonus、double-count 回避は per-file Set で記録)
+ *
+ * Dedupe / score: Map で同 query 加算、最後に weight 降順 sort + limit clamp。
+ *
+ * @param {string} vault - absolute path to Obsidian vault root
+ * @param {number} limit - max number of queries to return
+ * @returns {Promise<string[]>}
+ */
+async function discoverQueries(vault, limit) {
+  const wikiDir = join(vault, 'wiki');
+  const counts = new Map();
+
+  // Source 1: log.md tag refs (highest priority)
+  const logPath = join(wikiDir, 'log.md');
+  const logContent = await safeReadFile(logPath);
+  if (logContent) {
+    let m;
+    TAG_RE.lastIndex = 0;
+    while ((m = TAG_RE.exec(logContent)) !== null) {
+      const tag = m[1].toLowerCase();
+      counts.set(tag, (counts.get(tag) ?? 0) + 3); // tag weight = 3
+    }
+  }
+
+  // Source 2: index.md outgoing wikilinks
+  const indexPath = join(wikiDir, 'index.md');
+  const indexContent = await safeReadFile(indexPath);
+  if (indexContent) {
+    let m;
+    WIKILINK_RE.lastIndex = 0;
+    while ((m = WIKILINK_RE.exec(indexContent)) !== null) {
+      const name = m[1].trim().toLowerCase();
+      if (name) counts.set(name, (counts.get(name) ?? 0) + 2); // wikilink weight = 2
+    }
+  }
+
+  // Source 3: wiki/*.md (log/index/hot 除く) top-level headings
+  // Source 7 (broadly-referenced) を同時計算するため、per-heading の出現 file set を tracking。
+  const headingFileSets = new Map(); // heading -> Set<filename>
+  let entries;
+  try {
+    entries = await readdir(wikiDir, { withFileTypes: true });
+  } catch {
+    entries = [];
+  }
+  let scanned = 0;
+  for (const dirent of entries) {
+    if (scanned >= MAX_SCAN_FILES) break;
+    if (!dirent.isFile() || !dirent.name.endsWith('.md')) continue;
+    // log/index は専用 source (1,2)、hot.md は source 6 で個別 scan
+    if (dirent.name === 'log.md' || dirent.name === 'index.md' || dirent.name === 'hot.md') continue;
+    scanned++;
+    const content = await safeReadFile(join(wikiDir, dirent.name));
+    if (!content) continue;
+    let m;
+    HEADING_RE.lastIndex = 0;
+    while ((m = HEADING_RE.exec(content)) !== null) {
+      const heading = m[1].trim().toLowerCase();
+      if (heading.length < 2 || heading.length > 80) continue;
+      counts.set(heading, (counts.get(heading) ?? 0) + 1); // heading weight = 1
+      // Source 7 用: file set 記録 (Set で per-file uniq)
+      let fileSet = headingFileSets.get(heading);
+      if (!fileSet) {
+        fileSet = new Set();
+        headingFileSets.set(heading, fileSet);
+      }
+      fileSet.add(dirent.name);
+    }
+  }
+
+  // Source 4: raw-sources/ 配下 .md の h1 + h2 headings (weight 2)
+  // 再帰 walker、cap MAX_RAW_SOURCES_SCAN files で abort。
+  const rawSourcesDir = join(vault, 'raw-sources');
+  await scanRawSourcesHeadings(rawSourcesDir, counts);
+
+  // Source 5: git commit subjects 直近 MAX_RECENT_COMMITS (weight 1.5)
+  // 非 git repo / git 未インストールは graceful skip (getFileHistory が error shape で返す)
+  await ingestGitSubjects(vault, counts);
+
+  // Source 6: wiki/hot.md ATX heading + standalone-line #tag (weight 2.5)
+  const hotContent = await safeReadFile(join(wikiDir, 'hot.md'));
+  if (hotContent) {
+    let m;
+    HEADING_RE.lastIndex = 0;
+    while ((m = HEADING_RE.exec(hotContent)) !== null) {
+      const heading = m[1].trim().toLowerCase();
+      if (heading.length < 2 || heading.length > 80) continue;
+      counts.set(heading, (counts.get(heading) ?? 0) + 2.5);
+    }
+    STANDALONE_TAG_RE.lastIndex = 0;
+    while ((m = STANDALONE_TAG_RE.exec(hotContent)) !== null) {
+      const tag = m[1].toLowerCase();
+      if (!tag) continue;
+      counts.set(tag, (counts.get(tag) ?? 0) + 2.5);
+    }
+  }
+
+  // Source 7: wiki/*.md broadly-referenced concept (>= 2 files) に bonus 加算。
+  // 「重複度 high-N」 → file_count >= 2 の heading に bonus 1.2 * (file_count - 1) 加算。
+  // Source 3 の per-occurrence weight 1 とは独立 (source 3 = 出現回数、source 7 = 出現 file 数の breadth)。
+  for (const [heading, fileSet] of headingFileSets.entries()) {
+    if (fileSet.size >= 2) {
+      const bonus = 1.2 * (fileSet.size - 1);
+      counts.set(heading, (counts.get(heading) ?? 0) + bonus);
+    }
+  }
+
+  // sort by weighted score desc, take top N, dedupe (Map keys already unique)
+  return Array.from(counts.entries())
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, limit)
+    .map(([q]) => q);
+}
+
+// Source 4 helper: raw-sources/ 配下 .md を再帰 walk、h1 + h2 headings を抽出。
+// readdir({ recursive: true }) は Node 20+ なので、明示 walker で Node 18 互換。
+//
+// 2 段 budget で cost を bound:
+//   - `scanned`: .md file の内容読込数 (= file-content cost、上限 MAX_RAW_SOURCES_SCAN)
+//   - `walks`: directory descent + file entry 検査の総数 (= traversal cost、上限 MAX_RAW_SOURCES_WALK)
+// pathological 入力 (大量の空 subdir / 非 .md file 山) でも walker が完走 → DoS surface を bound。
+async function scanRawSourcesHeadings(rootDir, counts) {
+  let scanned = 0;
+  let walks = 0;
+  async function walk(dir) {
+    if (scanned >= MAX_RAW_SOURCES_SCAN) return;
+    if (walks >= MAX_RAW_SOURCES_WALK) return;
+    let dirents;
+    try {
+      dirents = await readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const dirent of dirents) {
+      if (scanned >= MAX_RAW_SOURCES_SCAN) return;
+      if (walks >= MAX_RAW_SOURCES_WALK) return;
+      walks++;
+      const full = join(dir, dirent.name);
+      if (dirent.isDirectory()) {
+        await walk(full);
+      } else if (dirent.isFile() && dirent.name.endsWith('.md')) {
+        scanned++;
+        const content = await safeReadFile(full);
+        if (!content) continue;
+        let m;
+        HEADING_H1H2_RE.lastIndex = 0;
+        while ((m = HEADING_H1H2_RE.exec(content)) !== null) {
+          const heading = m[1].trim().toLowerCase();
+          if (heading.length < 2 || heading.length > 80) continue;
+          counts.set(heading, (counts.get(heading) ?? 0) + 2); // raw-sources weight = 2
+        }
+      }
+    }
+  }
+  await walk(rootDir);
+}
+
+// Source 5 helper: git log の subject から query 候補を抽出 (weight 1.5)。
+// git-history.mjs の getFileHistory を再利用 (SAFE_CONFIG + GIT_CONFIG_NOSYSTEM hardened spawn)、
+// 非 git repo / git 未インストール / getFileHistory error は graceful skip。
+// subject 全体を 1 つの query として登録 (subject は通常 short = popular query 候補に適している)。
+//
+// 第 3 引数 options.historyProvider は test 用 injection (defense-in-depth で getFileHistory が
+// `{ commits: [], error: 'not_a_git_repo' }` shape を返した場合の graceful path を直接 verify する用途)。
+// production code は呼ばない (default で real isGitRepo / getFileHistory を使用)。
+async function ingestGitSubjects(vault, counts, options = {}) {
+  const isRepoFn = options.isRepoProvider ?? isGitRepo;
+  const historyFn = options.historyProvider ?? getFileHistory;
+  let isRepo;
+  try {
+    isRepo = await isRepoFn(vault);
+  } catch {
+    return; // git binary 不在 等で throw した場合も graceful
+  }
+  if (!isRepo) return;
+  let history;
+  try {
+    history = await historyFn(vault, { maxCommits: MAX_RECENT_COMMITS });
+  } catch {
+    return;
+  }
+  if (!history || history.error || !Array.isArray(history.commits)) return;
+  for (const c of history.commits) {
+    if (!c || typeof c.subject !== 'string') continue;
+    const subject = c.subject.trim().toLowerCase();
+    // 安全 / 長さ filter (短すぎ / 長すぎは query として無用)
+    if (subject.length < 4 || subject.length > 120) continue;
+    counts.set(subject, (counts.get(subject) ?? 0) + 1.5);
+  }
+}
+
+/**
+ * Normalize raw kioku_search results to a whitelist shape.
+ * Drops `body`, `abs_path`, and any other non-whitelisted field for security.
+ *
+ * @param {Array<object>} rawResults
+ * @returns {Array<{title: string, rel: string, snippet: string, score: number|null}>}
+ */
+function normalizeResults(rawResults) {
+  if (!Array.isArray(rawResults)) return [];
+  return rawResults.slice(0, MAX_RESULTS_PER_QUERY).map((r) => ({
+    title: String(r?.title ?? '').slice(0, 200),
+    rel: String(r?.rel ?? r?.path ?? '').slice(0, 300),
+    snippet: String(r?.snippet ?? r?.excerpt ?? '').slice(0, 500),
+    score: typeof r?.score === 'number' ? r.score : null,
+    // 注意: body / abs_path / 他 field は whitelist で必ず drop。
+    // (Phase 1 normalizeRenderedPage と同じ XSS / path-leak 防御原則)
+  }));
+}
+
+function clamp(val, min, max) {
+  if (typeof val !== 'number' || !Number.isFinite(val)) return min;
+  return Math.max(min, Math.min(max, Math.trunc(val)));
+}
+
+async function safeReadFile(p) {
+  try {
+    return await readFile(p, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+// Internal helpers exposed for unit tests only. Production code should not use this.
+export const __test__ = Object.freeze({
+  discoverQueries,
+  ingestGitSubjects,
+  normalizeResults,
+  clamp,
+  TAG_RE,
+  WIKILINK_RE,
+  HEADING_RE,
+  MAX_TOP_QUERIES,
+  MAX_RESULTS_PER_QUERY,
+});

--- a/mcp/lib/web-ui-shell.mjs
+++ b/mcp/lib/web-ui-shell.mjs
@@ -1,0 +1,336 @@
+// web-ui-shell.mjs — KIOKU Web UI shell layer (Sprint 4 Phase 1 PR B).
+//
+// Plan: tools/claude-brain/plan/claude/26051301_v0-9-phase1-impl-plan.md §「PR B」 (L1070-1769).
+//
+// Responsibility:
+//   - Combine PR A bases-renderer output (Dashboard tab) with Sprint 3 Visualizer β
+//     data layer (Overview / Timeline / Diff / Lineage tabs) into a single shell HTML.
+//   - `snapshot` mode (default): self-contained HTML with all data inlined as JSON
+//     for offline / share / archive use.
+//   - `served` mode: placeholder for Phase 2 Search (live backend), currently no-op
+//     beyond shell_meta.mode tag — Phase 1 ships shell with mode flag only.
+//
+// Exports:
+//   buildShellData(vault, options?) → ShellData
+//   buildShellHtml(vault, options?) → string (full HTML)
+//
+// Security:
+//   - innerHTML must not be used (template uses textContent + createElement only)
+//   - safeJsonForScript escapes `</script>`, U+2028, U+2029 before inline embedding
+//   - No external <script src>, <link href>, fetch, XHR, sendBeacon in snapshot mode
+//   - Path C+β boundary: no editor / Canvas write / Plugin loader / cloud connector
+
+import { basename, dirname, join } from 'node:path';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+
+import { collectHealthMetrics } from './health-metrics.mjs';
+import { collectFirstViewData } from './visualizer-data.mjs';
+import { buildLineageGraph } from './lineage-graph.mjs';
+import { getFileHistory } from './git-history.mjs';
+import { buildWikiSnapshot } from './wiki-snapshot.mjs';
+import { parseBaseFile, renderBases } from './bases-renderer.mjs';
+import { buildSearchIndex } from './qmd-search-index.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SHELL_TEMPLATE_PATH = join(__dirname, '..', 'templates', 'shell-template.html');
+const VIZ_TEMPLATE_PATH = join(__dirname, '..', 'templates', 'viz-template.html');
+
+export const SHELL_SCHEMA_VERSION = 1;
+
+// 8 tabs: 6 active (Phase 1 base 5 + Phase 2 Search) + 2 placeholder (Phase 3-4).
+// Order = visual left-to-right rendering order.
+const SHELL_TABS = Object.freeze([
+  { id: 'dashboard', label: 'Dashboard', enabled: true },
+  { id: 'overview', label: 'Overview', enabled: true },
+  { id: 'timeline', label: 'Timeline', enabled: true },
+  { id: 'diff', label: 'Diff', enabled: true },
+  { id: 'lineage', label: 'Lineage', enabled: true },
+  { id: 'search', label: 'Search', enabled: true },
+  { id: 'navigation', label: 'Navigation', enabled: false, gate: 'phase3' },
+  { id: 'wikilink-graph', label: 'Wikilink graph', enabled: false, gate: 'phase4' },
+]);
+
+// Canonical location written by tools/claude-brain/scripts/setup-vault.sh:221-222
+// (REPO source `tools/claude-brain/templates/wiki/meta/dashboard.base` → installed
+// at `${vault}/wiki/meta/dashboard.base`). Callers can override via
+// options.base_source if their vault uses a different path.
+const DEFAULT_BASE_SOURCE = 'wiki/meta/dashboard.base';
+const DEFAULT_MAX_COMMITS = 50;
+const MAX_COMMITS_HARD_CAP = 5000;
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export async function buildShellData(vault, options = {}) {
+  if (typeof vault !== 'string' || vault.length === 0) {
+    throw new Error('buildShellData: vault path is required');
+  }
+  const mode = options.mode === 'served' ? 'served' : 'snapshot';
+  const now = options.now instanceof Date ? options.now : new Date();
+
+  const visualizer = await buildVisualizerData(vault, options, now);
+  const dashboard = await buildDashboardData(vault, options, now);
+  const searchIndex = await buildSearchIndexSafe(vault, options.search ?? {}, now);
+
+  return {
+    schema_version: SHELL_SCHEMA_VERSION,
+    shell_meta: {
+      mode,
+      default_tab: 'dashboard',
+      tabs: SHELL_TABS.map((tab) => ({ ...tab })),
+      generated_at: now.toISOString(),
+      vault_name: basename(vault),
+      search: {
+        precomputed: Array.isArray(searchIndex.queries) ? searchIndex.queries.length : 0,
+        generated_at: searchIndex.generated_at,
+      },
+    },
+    visualizer,
+    dashboard,
+    search_index: searchIndex,
+  };
+}
+
+// Defensive wrapper around buildSearchIndex.
+// PR A2/B2 already harden the discovery / search path (graceful per-query failure,
+// non-git skip, fs error swallow), but we still wrap the top-level call so a
+// hypothetical regression in qmd-search-index.mjs never blocks the shell.
+async function buildSearchIndexSafe(vault, searchOptions, now) {
+  try {
+    return await buildSearchIndex(vault, searchOptions);
+  } catch (err) {
+    return {
+      schema_version: 1,
+      generated_at: now.toISOString(),
+      queries: [],
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+export async function buildShellHtml(vault, options = {}) {
+  const data = await buildShellData(vault, options);
+  const shellTpl = await readFile(SHELL_TEMPLATE_PATH, 'utf8');
+  const vizInline = await loadVizInline();
+  const dataJson = safeJsonForScript(data);
+  return shellTpl
+    .replace('__KIOKU_VIZ_INLINE__', vizInline)
+    .replace('__KIOKU_SHELL_DATA__', dataJson);
+}
+
+// ---------------------------------------------------------------------------
+// Visualizer data (delegates to Sprint 3 lib)
+// ---------------------------------------------------------------------------
+
+async function buildVisualizerData(vault, options, now) {
+  const since = typeof options.since === 'string' ? options.since : defaultSinceISO(now);
+  const maxCommits = typeof options.max_commits === 'number'
+    ? Math.max(1, Math.min(options.max_commits, MAX_COMMITS_HARD_CAP))
+    : DEFAULT_MAX_COMMITS;
+
+  let histRes;
+  try {
+    histRes = await getFileHistory(vault, { since, subPath: 'wiki/', maxCommits });
+  } catch (err) {
+    return {
+      schema_version: 4,
+      error: 'history_failed',
+      error_message: err instanceof Error ? err.message : String(err),
+      snapshots: [],
+      since,
+      commits_total: 0,
+      history_truncated: false,
+      first_view: null,
+      first_view_error: 'history_failed',
+      lineage: null,
+      lineage_error: 'history_failed',
+    };
+  }
+  if (histRes && histRes.error === 'not_a_git_repo') {
+    return {
+      schema_version: 4,
+      error: 'not_a_git_repo',
+      snapshots: [],
+      since,
+      commits_total: 0,
+      history_truncated: false,
+      first_view: null,
+      first_view_error: 'not_a_git_repo',
+      lineage: null,
+      lineage_error: 'not_a_git_repo',
+    };
+  }
+
+  const snapshots = [];
+  for (const commit of histRes.commits) {
+    try {
+      const snap = await buildWikiSnapshot(vault, commit.sha, {
+        subPath: 'wiki/',
+        timestamp: commit.timestamp,
+      });
+      snapshots.push({
+        sha: snap.sha,
+        shortSha: commit.shortSha,
+        timestamp: snap.timestamp ?? commit.timestamp,
+        author: commit.author,
+        subject: commit.subject,
+        pages: snap.pages,
+        links: snap.links,
+        truncated: Boolean(snap.truncated),
+        error: snap.error ?? null,
+      });
+    } catch (err) {
+      snapshots.push({
+        sha: commit.sha,
+        shortSha: commit.shortSha,
+        timestamp: commit.timestamp,
+        author: commit.author,
+        subject: commit.subject,
+        pages: [],
+        links: [],
+        truncated: false,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  let firstView = null;
+  let firstViewError = null;
+  try {
+    const health = await collectHealthMetrics(vault, { now });
+    firstView = await collectFirstViewData(vault, { now, snapshots, health });
+  } catch (err) {
+    firstViewError = err instanceof Error ? err.message : String(err);
+  }
+
+  let lineage = null;
+  let lineageError = null;
+  try {
+    lineage = await buildLineageGraph(vault, { now });
+  } catch (err) {
+    lineageError = err instanceof Error ? err.message : String(err);
+  }
+
+  return {
+    schema_version: 4,
+    snapshots,
+    since,
+    commits_total: histRes.commits.length,
+    history_truncated: Boolean(histRes.truncated),
+    first_view: firstView,
+    first_view_error: firstViewError,
+    lineage,
+    lineage_error: lineageError,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Dashboard data (delegates to PR A bases-renderer)
+// ---------------------------------------------------------------------------
+
+async function buildDashboardData(vault, options, now) {
+  const baseSource = typeof options.base_source === 'string' && options.base_source.length > 0
+    ? options.base_source
+    : DEFAULT_BASE_SOURCE;
+
+  let baseText;
+  try {
+    baseText = await readFile(join(vault, baseSource), 'utf8');
+  } catch (err) {
+    return {
+      base_source: baseSource,
+      views: [],
+      warnings: [],
+      base_error: `file_not_found: ${err.message}`,
+    };
+  }
+
+  let parsed;
+  try {
+    parsed = parseBaseFile(baseText);
+  } catch (err) {
+    return {
+      base_source: baseSource,
+      views: [],
+      warnings: [],
+      base_error: `parse_error: ${err.message}`,
+    };
+  }
+
+  try {
+    const { views, warnings } = await renderBases(vault, parsed.ast, { now });
+    return {
+      base_source: baseSource,
+      views,
+      warnings: [...(parsed.warnings || []), ...(warnings || [])],
+      base_error: null,
+    };
+  } catch (err) {
+    return {
+      base_source: baseSource,
+      views: [],
+      warnings: parsed.warnings || [],
+      base_error: `render_error: ${err.message}`,
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// HTML helpers
+// ---------------------------------------------------------------------------
+
+// Extract <body> inner content from viz-template.html for shell inlining.
+// We intentionally take only the <body> content — the shell template provides
+// its own <head> with merged styles — to avoid duplicate <html>/<head>/<body>.
+async function loadVizInline() {
+  try {
+    const vizTpl = await readFile(VIZ_TEMPLATE_PATH, 'utf8');
+    const match = vizTpl.match(/<body[^>]*>([\s\S]*?)<\/body>/i);
+    if (!match) return '<!-- viz-template body not found -->';
+    return match[1];
+  } catch (err) {
+    return `<!-- viz-template load error: ${escapeHtmlComment(err.message)} -->`;
+  }
+}
+
+function escapeHtmlComment(text) {
+  return String(text).replace(/--/g, '—');
+}
+
+// safeJsonForScript: serialize an object to a JSON string that is safe to embed
+// inside a <script type="application/json"> block. Escapes:
+//   - </ → </  (prevents </script> injection)
+//   - U+2028 / U+2029 (LINE / PARAGRAPH SEPARATOR — JSON-legal but ECMAScript
+//     parser-illegal in inline <script type="application/javascript">; harmless
+//     in application/json but escaping keeps inline JS safe even if reused.)
+function safeJsonForScript(obj) {
+  const raw = JSON.stringify(obj);
+  const u2028 = String.fromCharCode(0x2028);
+  const u2029 = String.fromCharCode(0x2029);
+  return raw
+    .split('</').join('\\u003c/')
+    .split(u2028).join('\\u2028')
+    .split(u2029).join('\\u2029');
+}
+
+function defaultSinceISO(now) {
+  const d = new Date(now);
+  d.setFullYear(d.getFullYear() - 1);
+  return d.toISOString().slice(0, 10);
+}
+
+// ---------------------------------------------------------------------------
+// Test hook
+// ---------------------------------------------------------------------------
+
+export const _internals = {
+  SHELL_TABS,
+  SHELL_SCHEMA_VERSION,
+  safeJsonForScript,
+  loadVizInline,
+  buildVisualizerData,
+  buildDashboardData,
+  defaultSinceISO,
+};

--- a/mcp/manifest.json
+++ b/mcp/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "kioku-wiki",
   "display_name": "KIOKU Wiki",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Read, search, and write your KIOKU Obsidian Wiki from Claude Desktop or Claude Code.",
   "long_description": "KIOKU is a personal knowledge base ('second brain') built on top of an Obsidian Vault. This MCP server exposes eleven tools (kioku_search, kioku_read, kioku_list, kioku_write_note, kioku_write_wiki, kioku_delete, kioku_ingest_pdf, kioku_ingest_url, kioku_ingest_document, kioku_generate_viz, kioku_health) so that Claude Desktop and Claude Code can browse and update the Wiki without leaving the chat. All operations are local stdio — nothing leaves your machine. See https://github.com/megaphone-tokyo/kioku for the full project.",
   "author": {

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kioku-mcp",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "type": "module",
   "description": "KIOKU local MCP server (Wiki read/list/search/write_note/write_wiki/delete) for Claude Desktop and Claude Code.",

--- a/mcp/templates/shell-template.html
+++ b/mcp/templates/shell-template.html
@@ -1,0 +1,1044 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+<!-- Sprint 4 Phase 3 PR B3: CSP navigate-to policy (plan 26051405 §「PR B3 セキュリティ contract」L314-318)
+     Tier 2 Mobile deep-link で window.location.href へ代入する scheme/host を claude: + https://claude.ai のみに pin。
+     navigate-to は CSP3 draft directive (現状 browser support 限定的) だが forward-compat hardening として宣言、
+     JS-side でも openTier2Search 内で whitelist 検証する 2 段防御 design。 -->
+<meta http-equiv="Content-Security-Policy" content="navigate-to 'self' claude: https://claude.ai">
+<title>KIOKU Web UI — Path C+β v0.9</title>
+<style>
+:root {
+  --bg: #0d0f12;
+  --bg-soft: #161b22;
+  --fg: #e6edf3;
+  --accent: #58a6ff;
+  --accent-soft: rgba(88, 166, 255, 0.15);
+  --muted: #7d8590;
+  --border: #30363d;
+  --warning: #f0883e;
+  --danger: #ff7b72;
+  --success: #56d364;
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Hiragino Kaku Gothic ProN", "Noto Sans CJK JP", sans-serif;
+  background: var(--bg);
+  color: var(--fg);
+  font-size: 14px;
+  line-height: 1.45;
+}
+.shell-header {
+  padding: 14px 24px 10px;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+.shell-header h1 {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+}
+.shell-header .vault-name {
+  color: var(--muted);
+  font-size: 14px;
+  margin-left: 8px;
+}
+.shell-header .meta-line {
+  color: var(--muted);
+  font-size: 12px;
+  display: flex;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+.shell-header .meta-line strong { color: var(--fg); }
+.shell-tabs {
+  display: flex;
+  gap: 2px;
+  padding: 0 16px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-soft);
+  flex-wrap: wrap;
+}
+.tab {
+  position: relative;
+  padding: 9px 14px;
+  cursor: pointer;
+  border: 0;
+  background: transparent;
+  color: var(--muted);
+  font-size: 13px;
+  font-family: inherit;
+  border-bottom: 2px solid transparent;
+  transition: color 0.08s, border-color 0.08s;
+}
+.tab:hover { color: var(--fg); }
+.tab.active { color: var(--fg); border-bottom-color: var(--accent); }
+.tab.disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+.tab .gate-pill {
+  display: inline-block;
+  margin-left: 6px;
+  padding: 1px 6px;
+  border-radius: 9px;
+  background: var(--border);
+  color: var(--muted);
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.tab-content {
+  padding: 20px 24px;
+  min-height: 320px;
+}
+.tab-content[hidden] { display: none; }
+.dashboard-view {
+  margin-bottom: 28px;
+  padding: 14px 16px;
+  background: var(--bg-soft);
+  border-radius: 8px;
+  border: 1px solid var(--border);
+}
+.dashboard-view h3 {
+  margin: 0 0 10px;
+  font-size: 15px;
+  font-weight: 600;
+}
+.dashboard-view h4 {
+  margin: 14px 0 6px;
+  font-size: 13px;
+  color: var(--muted);
+  font-weight: 500;
+}
+.dashboard-view table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+.dashboard-view th,
+.dashboard-view td {
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--border);
+  text-align: left;
+  vertical-align: top;
+}
+.dashboard-view th {
+  font-weight: 600;
+  color: var(--muted);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.dashboard-view tbody tr:last-child td { border-bottom: 0; }
+.dashboard-view ul {
+  margin: 0;
+  padding-left: 20px;
+  font-size: 13px;
+}
+.dashboard-view li { padding: 2px 0; }
+.dashboard-view .empty-note {
+  color: var(--muted);
+  font-style: italic;
+  font-size: 12px;
+}
+.dashboard-warnings {
+  margin-top: 16px;
+  padding: 10px 12px;
+  background: rgba(240, 136, 62, 0.1);
+  border-left: 3px solid var(--warning);
+  border-radius: 4px;
+  font-size: 12px;
+}
+.dashboard-error {
+  padding: 14px;
+  background: rgba(255, 123, 114, 0.1);
+  border-left: 3px solid var(--danger);
+  border-radius: 4px;
+}
+.viz-stub {
+  padding: 14px 18px;
+  background: var(--bg-soft);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  margin-bottom: 14px;
+}
+.viz-stub h3 {
+  margin: 0 0 8px;
+  font-size: 15px;
+  font-weight: 600;
+}
+.viz-stub p, .viz-stub li {
+  margin: 4px 0;
+  font-size: 13px;
+  color: var(--fg);
+}
+.viz-stub .muted { color: var(--muted); }
+.placeholder-note {
+  padding: 14px;
+  color: var(--muted);
+  font-size: 13px;
+  text-align: center;
+}
+.search-tab-hint {
+  padding: 12px 14px;
+  background: var(--bg-soft);
+  border-left: 3px solid var(--accent);
+  border-radius: 4px;
+  margin-bottom: 14px;
+  font-size: 12px;
+  color: var(--muted);
+}
+.search-tab-hint strong { color: var(--fg); }
+.search-controls {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 14px;
+  flex-wrap: wrap;
+}
+.search-controls input[type="search"] {
+  flex: 1 1 240px;
+  background: var(--bg-soft);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 7px 10px;
+  color: var(--fg);
+  font: inherit;
+  font-size: 13px;
+}
+.search-controls input[type="search"]:focus {
+  outline: 1px solid var(--accent);
+  outline-offset: 0;
+  border-color: var(--accent);
+}
+.search-controls select {
+  background: var(--bg-soft);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 7px 10px;
+  color: var(--fg);
+  font: inherit;
+  font-size: 12px;
+}
+.search-query-block {
+  margin-bottom: 18px;
+  padding: 12px 14px;
+  background: var(--bg-soft);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+.search-query-block h3 {
+  margin: 0 0 10px;
+  font-size: 14px;
+  font-weight: 600;
+}
+.search-query-block .mode-pill {
+  display: inline-block;
+  margin-left: 8px;
+  padding: 1px 6px;
+  background: var(--border);
+  color: var(--muted);
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  border-radius: 9px;
+}
+.search-result-item {
+  padding: 8px 10px;
+  margin-bottom: 6px;
+  background: var(--bg);
+  border-radius: 6px;
+  font-size: 12px;
+}
+.search-result-item strong { color: var(--fg); font-size: 13px; }
+.search-result-item .rel { color: var(--muted); margin-left: 6px; }
+.search-result-item p {
+  margin: 4px 0 0;
+  color: var(--fg);
+  line-height: 1.45;
+  word-break: break-word;
+}
+.search-empty-note {
+  color: var(--muted);
+  font-style: italic;
+  font-size: 12px;
+  padding: 12px 0;
+}
+.search-deepdive {
+  margin-top: 12px;
+  padding: 10px 12px;
+  background: var(--bg-soft);
+  border-left: 3px solid var(--accent);
+  border-radius: 4px;
+  font-size: 12px;
+  color: var(--muted);
+}
+.search-deepdive code {
+  background: var(--border);
+  padding: 1px 5px;
+  border-radius: 3px;
+  font-size: 11px;
+  color: var(--fg);
+}
+.search-view-graph {
+  display: inline-block;
+  margin-left: 8px;
+  font-size: 12px;
+  color: var(--muted);
+  text-decoration: none;
+}
+.search-view-graph:hover {
+  color: var(--fg);
+  text-decoration: underline;
+}
+
+/* ---- Mobile responsive (Sprint 4 Phase 3 PR A3) ----
+   plan 26051405 §「PR A3」L120-235 canonical impl spec
+   - Breakpoint: < 768px (max-width: 767px)
+   - Layout: horizontal tab nav → hamburger menu + vertical stack overlay
+   - Touch UX: tap target 44pt+ enforcement on interactive elements
+   - Class names use kioku- prefix per plan, mapped onto existing shell tabs */
+.kioku-mobile-menu-button {
+  display: none;
+  background: var(--bg-soft);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-size: 18px;
+  cursor: pointer;
+}
+@media (max-width: 767px) {
+  .shell-tabs {
+    display: none; /* hamburger menu に切替 */
+  }
+  .kioku-mobile-menu-button {
+    display: block;
+    position: fixed;
+    top: 1rem;
+    right: 1rem;
+    min-width: 44px;
+    min-height: 44px;
+    z-index: 110;
+  }
+  .tab {
+    padding: 1rem 0.5rem; /* tap target 44pt+ */
+    min-height: 44px;
+  }
+  .shell-tabs.mobile-open {
+    display: flex;
+    flex-direction: column;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: var(--bg);
+    z-index: 100;
+    padding: 56px 16px 16px;
+    overflow-y: auto;
+  }
+  .shell-tabs.mobile-open .tab {
+    width: 100%;
+    text-align: left;
+    border-bottom: 1px solid var(--border);
+  }
+  .shell-header {
+    padding: 10px 16px 8px;
+  }
+  .tab-content {
+    padding: 14px 16px;
+  }
+  /* ---- Sprint 4 Phase 3 PR B3: Search tab Mobile UX ----
+     plan 26051405 §「PR B3」L276-289 canonical impl spec
+     - kioku-search-input: font-size 16px (iOS Safari < 16px で input focus 時 auto-zoom 発生、UX 阻害)
+     - kioku-search-results: max-height + overflow-y + -webkit-overflow-scrolling
+       (virtual keyboard 開時にも viewport 内に収まり momentum scroll を維持) */
+  .kioku-search-input,
+  #kioku-search-input {
+    font-size: 16px; /* iOS Safari auto-zoom 防止 (16px 以上必須) */
+  }
+  .kioku-search-results,
+  #kioku-search-results {
+    max-height: calc(100vh - 200px); /* virtual keyboard 開時の viewport 縮小に追随 */
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch; /* iOS momentum scroll */
+  }
+  .kioku-tier2-search-btn {
+    width: 100%;
+    margin-top: 12px;
+    min-height: 44px; /* tap target */
+  }
+}
+/* tap target 44pt+ enforcement (全 interactive element、breakpoint 外でも適用)
+   plan 26051405 §PR A3 line 169-172 */
+button, a, input, select {
+  min-width: 44px;
+  min-height: 44px;
+}
+/* ---- Sprint 4 Phase 3 PR B3: Tier 2 deep-link button (desktop でも表示) ---- */
+.kioku-tier2-search-btn {
+  margin-top: 10px;
+  padding: 8px 16px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  border: 1px solid var(--accent);
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 500;
+}
+.kioku-tier2-search-btn:hover {
+  background: var(--accent);
+  color: var(--bg);
+}
+.kioku-tier2-search-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+</style>
+</head>
+<body>
+<header class="shell-header">
+  <div>
+    <h1>KIOKU Web UI <span class="vault-name" id="vault-name"></span></h1>
+    <div class="meta-line" id="meta-line"></div>
+  </div>
+</header>
+<button class="kioku-mobile-menu-button" id="kioku-mobile-menu-button" type="button" aria-label="Toggle menu" aria-expanded="false" aria-controls="shell-tabs">☰</button>
+<nav class="shell-tabs" id="shell-tabs" aria-label="KIOKU shell tabs"></nav>
+<main id="shell-main">
+  <section class="tab-content" id="tab-dashboard"></section>
+  <section class="tab-content" id="tab-overview" hidden></section>
+  <section class="tab-content" id="tab-timeline" hidden></section>
+  <section class="tab-content" id="tab-diff" hidden></section>
+  <section class="tab-content" id="tab-lineage" hidden></section>
+  <section class="tab-content" id="tab-search" hidden></section>
+</main>
+<!--
+  Visualizer β body content from viz-template.html is parked inside the
+  template element below. <template> content is parsed but not rendered and
+  its scripts are not executed automatically — this lets us stash the full
+  Sprint 3 UI for Phase 1.5 / PR C activation without colliding with shell
+  DOM ids or running viz scripts at shell boot.
+-->
+<template id="kioku-viz-body">__KIOKU_VIZ_INLINE__</template>
+<script id="kioku-shell-data" type="application/json">__KIOKU_SHELL_DATA__</script>
+<script>
+(() => {
+  'use strict';
+
+  const dataNode = document.getElementById('kioku-shell-data');
+  if (!dataNode) return;
+  let data;
+  try {
+    data = JSON.parse(dataNode.textContent);
+  } catch (err) {
+    document.body.appendChild(buildErrorBanner('Shell data parse error: ' + err.message));
+    return;
+  }
+
+  // ---- Header --------------------------------------------------------------
+  document.getElementById('vault-name').textContent = data.shell_meta.vault_name || '';
+  const meta = document.getElementById('meta-line');
+  appendMetaItem(meta, 'mode', data.shell_meta.mode);
+  appendMetaItem(meta, 'generated', shortTimestamp(data.shell_meta.generated_at));
+  appendMetaItem(meta, 'shell schema', String(data.schema_version));
+  if (data.visualizer && typeof data.visualizer.schema_version === 'number') {
+    appendMetaItem(meta, 'viz schema', String(data.visualizer.schema_version));
+  }
+  if (data.visualizer && typeof data.visualizer.commits_total === 'number') {
+    appendMetaItem(meta, 'commits', String(data.visualizer.commits_total));
+  }
+
+  // ---- Tabs ----------------------------------------------------------------
+  const tabsEl = document.getElementById('shell-tabs');
+  for (const tab of data.shell_meta.tabs) {
+    const btn = document.createElement('button');
+    btn.className = 'tab' + (tab.enabled ? '' : ' disabled');
+    btn.type = 'button';
+    btn.dataset.tabId = tab.id;
+    btn.textContent = tab.label;
+    if (!tab.enabled && tab.gate) {
+      const pill = document.createElement('span');
+      pill.className = 'gate-pill';
+      pill.textContent = tab.gate + ' で実装予定';
+      btn.appendChild(pill);
+      btn.title = tab.gate + ' で実装予定';
+      btn.disabled = true;
+    } else {
+      btn.addEventListener('click', () => activateTab(tab.id));
+    }
+    tabsEl.appendChild(btn);
+  }
+
+  // ---- Hamburger menu (Sprint 4 Phase 3 PR A3、Mobile responsive)
+  // plan 26051405 §「PR A3」L120-235、< 768px breakpoint で hamburger menu toggle
+  const hamburgerBtn = document.getElementById('kioku-mobile-menu-button');
+  if (hamburgerBtn) {
+    hamburgerBtn.addEventListener('click', () => {
+      const isOpen = tabsEl.classList.toggle('mobile-open');
+      hamburgerBtn.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+    });
+  }
+
+  // ---- Render each enabled tab --------------------------------------------
+  renderDashboard(data.dashboard);
+  renderOverview(data.visualizer);
+  renderTimeline(data.visualizer);
+  renderDiff(data.visualizer);
+  renderLineage(data.visualizer);
+  renderSearch(data.search_index);
+
+  activateTab(data.shell_meta.default_tab || 'dashboard');
+
+  // ---- helpers -------------------------------------------------------------
+
+  function activateTab(id) {
+    document.querySelectorAll('.tab').forEach((b) => {
+      b.classList.toggle('active', b.dataset.tabId === id);
+    });
+    document.querySelectorAll('.tab-content').forEach((s) => {
+      s.hidden = s.id !== 'tab-' + id;
+    });
+    // Mobile: tab 選択時 hamburger menu を閉じる + aria-expanded 同期 (PR A3)
+    if (tabsEl.classList.contains('mobile-open')) {
+      tabsEl.classList.remove('mobile-open');
+      if (hamburgerBtn) hamburgerBtn.setAttribute('aria-expanded', 'false');
+    }
+  }
+
+  function appendMetaItem(parent, label, value) {
+    const span = document.createElement('span');
+    span.textContent = label + ': ';
+    const strong = document.createElement('strong');
+    strong.textContent = value;
+    span.appendChild(strong);
+    parent.appendChild(span);
+  }
+
+  function shortTimestamp(iso) {
+    if (typeof iso !== 'string') return '';
+    return iso.replace('T', ' ').replace(/\..*$/, ' UTC');
+  }
+
+  function buildErrorBanner(message) {
+    const div = document.createElement('div');
+    div.className = 'dashboard-error';
+    div.textContent = message;
+    return div;
+  }
+
+  // ---- Dashboard rendering (PR A renderBases output) ----------------------
+  function renderDashboard(dashboard) {
+    const root = document.getElementById('tab-dashboard');
+    clearChildren(root);
+    if (!dashboard) {
+      root.appendChild(buildErrorBanner('Dashboard data is missing.'));
+      return;
+    }
+    if (dashboard.base_error) {
+      const err = buildErrorBanner('Dashboard error: ' + dashboard.base_error);
+      root.appendChild(err);
+      return;
+    }
+    if (!Array.isArray(dashboard.views) || dashboard.views.length === 0) {
+      const note = document.createElement('div');
+      note.className = 'placeholder-note';
+      note.textContent = 'Dashboard has no views yet. Configure ' + (dashboard.base_source || 'wiki/meta/dashboard.base') + '.';
+      root.appendChild(note);
+      return;
+    }
+    for (const view of dashboard.views) {
+      root.appendChild(renderDashboardView(view));
+    }
+    if (Array.isArray(dashboard.warnings) && dashboard.warnings.length > 0) {
+      const w = document.createElement('div');
+      w.className = 'dashboard-warnings';
+      const head = document.createElement('strong');
+      head.textContent = 'Warnings (' + dashboard.warnings.length + '): ';
+      w.appendChild(head);
+      const text = document.createTextNode(dashboard.warnings.join('; '));
+      w.appendChild(text);
+      root.appendChild(w);
+    }
+  }
+
+  function renderDashboardView(view) {
+    const block = document.createElement('div');
+    block.className = 'dashboard-view';
+    const h = document.createElement('h3');
+    h.textContent = view.name || '(unnamed view)';
+    block.appendChild(h);
+    if (Array.isArray(view.groups) && view.groups.length > 0) {
+      for (const g of view.groups) {
+        const gh = document.createElement('h4');
+        gh.textContent = g.key + ' (' + (Array.isArray(g.pages) ? g.pages.length : 0) + ')';
+        block.appendChild(gh);
+        block.appendChild(renderPagesByType(g.pages, view.type));
+      }
+    } else {
+      block.appendChild(renderPagesByType(view.pages, view.type));
+    }
+    return block;
+  }
+
+  function renderPagesByType(pages, type) {
+    const safePages = Array.isArray(pages) ? pages : [];
+    if (safePages.length === 0) {
+      const note = document.createElement('div');
+      note.className = 'empty-note';
+      note.textContent = '— (no pages matched)';
+      return note;
+    }
+    if (type === 'table') return renderPagesTable(safePages);
+    return renderPagesList(safePages);
+  }
+
+  function renderPagesTable(pages) {
+    const t = document.createElement('table');
+    const thead = document.createElement('thead');
+    const headRow = document.createElement('tr');
+    ['Name', 'Type', 'Status', 'Updated', 'Days'].forEach((h) => {
+      const th = document.createElement('th');
+      th.textContent = h;
+      headRow.appendChild(th);
+    });
+    thead.appendChild(headRow);
+    t.appendChild(thead);
+    const tb = document.createElement('tbody');
+    for (const p of pages) {
+      const fm = p.frontmatter || {};
+      const computed = p.computed || {};
+      const row = [
+        p.name || '',
+        fm.type || '',
+        fm.status || '',
+        fm.updated || '',
+        computed.age_days != null ? String(computed.age_days) : '',
+      ];
+      const tr = document.createElement('tr');
+      for (const cell of row) {
+        const td = document.createElement('td');
+        td.textContent = cell;
+        tr.appendChild(td);
+      }
+      tb.appendChild(tr);
+    }
+    t.appendChild(tb);
+    return t;
+  }
+
+  function renderPagesList(pages) {
+    const ul = document.createElement('ul');
+    for (const p of pages) {
+      const li = document.createElement('li');
+      const fm = p.frontmatter || {};
+      let text = p.name || '(unnamed)';
+      if (fm.type) text += ' [' + fm.type + ']';
+      if (fm.status) text += ' — ' + fm.status;
+      li.textContent = text;
+      ul.appendChild(li);
+    }
+    return ul;
+  }
+
+  function clearChildren(node) {
+    while (node.firstChild) node.removeChild(node.firstChild);
+  }
+
+  // ---- Visualizer β tab stubs ---------------------------------------------
+  // Phase 1 PR B: surface summary info from data.visualizer so users see live
+  // Sprint 3 data inside the shell. Full interactive UI is staged in PR C via
+  // the visualizer.mjs `mode` parameter (the viz body is parked in
+  // <template id="kioku-viz-body"> for future activation).
+
+  function renderOverview(viz) {
+    const root = document.getElementById('tab-overview');
+    clearChildren(root);
+    if (!viz) {
+      root.appendChild(buildErrorBanner('Visualizer data is missing.'));
+      return;
+    }
+    const card = document.createElement('div');
+    card.className = 'viz-stub';
+    const h = document.createElement('h3');
+    h.textContent = 'Overview — Visualizer β summary';
+    card.appendChild(h);
+    if (viz.first_view_error) {
+      const p = document.createElement('p');
+      p.className = 'muted';
+      p.textContent = 'first_view error: ' + viz.first_view_error;
+      card.appendChild(p);
+    }
+    const summary = viz.first_view && viz.first_view.summary ? viz.first_view.summary : null;
+    if (summary) {
+      const ul = document.createElement('ul');
+      const fields = ['total_pages', 'live_pages', 'orphan_pages', 'stale_pages'];
+      for (const f of fields) {
+        if (typeof summary[f] !== 'number') continue;
+        const li = document.createElement('li');
+        li.textContent = f + ': ' + summary[f];
+        ul.appendChild(li);
+      }
+      card.appendChild(ul);
+    } else {
+      const p = document.createElement('p');
+      p.className = 'muted';
+      p.textContent = 'No first_view summary available yet.';
+      card.appendChild(p);
+    }
+    root.appendChild(card);
+    appendVizFootnote(root);
+  }
+
+  function renderTimeline(viz) {
+    const root = document.getElementById('tab-timeline');
+    clearChildren(root);
+    if (!viz) {
+      root.appendChild(buildErrorBanner('Visualizer data is missing.'));
+      return;
+    }
+    const card = document.createElement('div');
+    card.className = 'viz-stub';
+    const h = document.createElement('h3');
+    h.textContent = 'Timeline — ' + (Array.isArray(viz.snapshots) ? viz.snapshots.length : 0) + ' commit(s)';
+    card.appendChild(h);
+    if (Array.isArray(viz.snapshots) && viz.snapshots.length > 0) {
+      const ul = document.createElement('ul');
+      for (const snap of viz.snapshots) {
+        const li = document.createElement('li');
+        const ts = snap.timestamp || '';
+        const subj = snap.subject || '';
+        li.textContent = (snap.shortSha || '????') + '  ' + ts + '  — ' + subj;
+        ul.appendChild(li);
+      }
+      card.appendChild(ul);
+    } else {
+      const p = document.createElement('p');
+      p.className = 'muted';
+      p.textContent = 'No snapshots available.';
+      card.appendChild(p);
+    }
+    root.appendChild(card);
+    appendVizFootnote(root);
+  }
+
+  function renderDiff(viz) {
+    const root = document.getElementById('tab-diff');
+    clearChildren(root);
+    const card = document.createElement('div');
+    card.className = 'viz-stub';
+    const h = document.createElement('h3');
+    h.textContent = 'Diff — Visualizer β summary';
+    card.appendChild(h);
+    const snapshots = (viz && Array.isArray(viz.snapshots)) ? viz.snapshots : [];
+    if (snapshots.length >= 2) {
+      const a = snapshots[snapshots.length - 1];
+      const b = snapshots[snapshots.length - 2];
+      const p = document.createElement('p');
+      p.textContent = 'Latest two snapshots: ' + (b.shortSha || '?') + ' → ' + (a.shortSha || '?');
+      card.appendChild(p);
+      const ap = Array.isArray(a.pages) ? a.pages.length : 0;
+      const bp = Array.isArray(b.pages) ? b.pages.length : 0;
+      const stat = document.createElement('p');
+      stat.className = 'muted';
+      stat.textContent = 'Page counts: ' + bp + ' → ' + ap + ' (Δ ' + (ap - bp) + ')';
+      card.appendChild(stat);
+    } else {
+      const p = document.createElement('p');
+      p.className = 'muted';
+      p.textContent = 'Diff needs at least 2 snapshots.';
+      card.appendChild(p);
+    }
+    root.appendChild(card);
+    appendVizFootnote(root);
+  }
+
+  function renderLineage(viz) {
+    const root = document.getElementById('tab-lineage');
+    clearChildren(root);
+    const card = document.createElement('div');
+    card.className = 'viz-stub';
+    const h = document.createElement('h3');
+    h.textContent = 'Lineage — Visualizer β summary';
+    card.appendChild(h);
+    if (viz && viz.lineage_error) {
+      const p = document.createElement('p');
+      p.className = 'muted';
+      p.textContent = 'lineage error: ' + viz.lineage_error;
+      card.appendChild(p);
+    }
+    const lineage = viz && viz.lineage ? viz.lineage : null;
+    if (lineage && Array.isArray(lineage.nodes) && Array.isArray(lineage.edges)) {
+      const p1 = document.createElement('p');
+      p1.textContent = 'Nodes: ' + lineage.nodes.length + ', Edges: ' + lineage.edges.length;
+      card.appendChild(p1);
+      if (typeof lineage.truncated === 'boolean') {
+        const p2 = document.createElement('p');
+        p2.className = 'muted';
+        p2.textContent = 'truncated: ' + lineage.truncated;
+        card.appendChild(p2);
+      }
+    } else {
+      const p = document.createElement('p');
+      p.className = 'muted';
+      p.textContent = 'No lineage graph available.';
+      card.appendChild(p);
+    }
+    root.appendChild(card);
+    appendVizFootnote(root);
+  }
+
+  function appendVizFootnote(root) {
+    const note = document.createElement('p');
+    note.className = 'placeholder-note';
+    note.textContent = 'Full interactive Visualizer β UI is staged for PR C (mode param in visualizer.mjs).';
+    root.appendChild(note);
+  }
+
+  // ---- Sprint 4 Phase 3 PR B3: Tier 2 Mobile deep-link helpers ----
+  // plan 26051405 §「PR B3」L240-274 canonical impl spec
+  //
+  // openTier2Search(query):
+  //   - Mobile (< 768px): claude:// URI scheme attempt + 1.5s timeout で claude.ai/new fallback。
+  //     visibility change (app 起動成功 = tab hidden) を観測したら timeout cancel し fallback 抑止。
+  //   - Desktop: copyMcpToolPrompt 経由で MCP tool 呼び出し prompt を clipboard へ転送。
+  //
+  // Security contract: window.location.href には claude:// + https://claude.ai のみ assign。
+  //                    user input (query) は encodeURIComponent 経由で escape。
+  //                    CSP navigate-to directive (head の meta) と JS-side whitelist で 2 段防御。
+  function openTier2Search(query) {
+    const encoded = encodeURIComponent(typeof query === 'string' ? query : '');
+    const isMobile = typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(max-width: 767px)').matches;
+    if (isMobile) {
+      const claudeAppUrl = 'claude://chat?prompt=Search%20KIOKU%20for:%20' + encoded;
+      const claudeWebUrl = 'https://claude.ai/new?q=Search%20KIOKU%20for:%20' + encoded;
+      // 1.5s timeout で web fallback (URI scheme handler が無ければ web へ)
+      let timeoutId = setTimeout(function () {
+        window.location.href = claudeWebUrl;
+      }, 1500);
+      // visibility change で timeout cancel (claude:// app 起動成功時)
+      const onVisChange = function () {
+        if (document.hidden) {
+          clearTimeout(timeoutId);
+          document.removeEventListener('visibilitychange', onVisChange);
+        }
+      };
+      document.addEventListener('visibilitychange', onVisChange);
+      window.location.href = claudeAppUrl;
+    } else {
+      copyMcpToolPrompt(query);
+    }
+  }
+
+  // Desktop path: MCP tool 呼び出し prompt を clipboard へ転送。
+  // navigator.clipboard が未対応な場合は graceful degrade (silent skip)。
+  function copyMcpToolPrompt(query) {
+    const safeQuery = typeof query === 'string' ? query : '';
+    const prompt = 'kioku_search query: ' + safeQuery;
+    if (typeof navigator !== 'undefined' &&
+        navigator.clipboard &&
+        typeof navigator.clipboard.writeText === 'function') {
+      navigator.clipboard.writeText(prompt).catch(function () {
+        // clipboard 権限 deny 等 → graceful degrade、UI 上は無反応で OK (description text が代替案内)
+      });
+    }
+  }
+
+  // ---- Search tab (Phase 2 Tier 1: shell offline quick filter; Tier 2: Claude conversation deep-dive) ----
+  function renderSearch(searchIndex) {
+    const root = document.getElementById('tab-search');
+    clearChildren(root);
+    const hint = document.createElement('div');
+    hint.className = 'search-tab-hint';
+    const hintStrong1 = document.createElement('strong');
+    hintStrong1.textContent = 'Tier 1: shell 単独 quick lookup';
+    hint.appendChild(hintStrong1);
+    hint.appendChild(document.createTextNode(' — 事前計算された候補から、入力中の文字でローカル絞り込み (offline)。'));
+    hint.appendChild(document.createElement('br'));
+    const hintStrong2 = document.createElement('strong');
+    hintStrong2.textContent = 'Tier 2: Claude conversation で深掘り';
+    hint.appendChild(hintStrong2);
+    hint.appendChild(document.createTextNode(' — free-text 検索や関連ページ探索は MCP tool '));
+    const hintCode = document.createElement('code');
+    hintCode.textContent = 'kioku_search';
+    hint.appendChild(hintCode);
+    hint.appendChild(document.createTextNode(' を Claude 会話から呼び出す。'));
+    root.appendChild(hint);
+
+    if (searchIndex && typeof searchIndex.error === 'string' && searchIndex.error.length > 0) {
+      const errorNote = document.createElement('div');
+      errorNote.className = 'search-empty-note';
+      errorNote.textContent = 'Search index build failed: ' + searchIndex.error;
+      root.appendChild(errorNote);
+      return;
+    }
+    if (!searchIndex || !Array.isArray(searchIndex.queries) || searchIndex.queries.length === 0) {
+      const note = document.createElement('div');
+      note.className = 'search-empty-note';
+      note.textContent = 'Search index is empty. Run kioku_generate_viz with mode="shell" on a vault with content.';
+      root.appendChild(note);
+      return;
+    }
+
+    const controls = document.createElement('div');
+    controls.className = 'search-controls';
+    const input = document.createElement('input');
+    input.type = 'search';
+    input.id = 'kioku-search-input';
+    // Sprint 4 Phase 3 PR B3: class 付与で Mobile media query (font-size 16px iOS auto-zoom 防止) 対象化
+    input.className = 'kioku-search-input';
+    input.placeholder = 'Quick filter (offline)。詳しくは Claude で深掘り';
+    input.setAttribute('autocomplete', 'off');
+    input.setAttribute('aria-label', 'Filter precomputed queries');
+    controls.appendChild(input);
+    // Mode selector is only meaningful when buildSearchIndex emitted queries
+    // tagged with multiple modes. In the current Tier 1 single-mode design
+    // (default 'hybrid'), every precomputed query carries the same mode, so
+    // the selector would be dead UI: picking 'lex' or 'vec' would always
+    // render "No queries match". Gate the selector on distinctModes.size > 1
+    // and skip the mode filter step in applyFilter when omitted.
+    const distinctModes = new Set(searchIndex.queries.map((q) => q.mode));
+    let modeSelect = null;
+    if (distinctModes.size > 1) {
+      modeSelect = document.createElement('select');
+      modeSelect.id = 'kioku-search-mode';
+      modeSelect.setAttribute('aria-label', 'Search mode filter');
+      const modes = [
+        { value: 'all', label: 'All modes' },
+        { value: 'lex', label: 'BM25 (lex)' },
+        { value: 'vec', label: 'Embedding (vec)' },
+        { value: 'hybrid', label: 'Hybrid' },
+      ];
+      for (const m of modes) {
+        // Only offer modes that are actually present in the precomputed data,
+        // plus the synthetic 'all' aggregate option.
+        if (m.value !== 'all' && !distinctModes.has(m.value)) continue;
+        const opt = document.createElement('option');
+        opt.value = m.value;
+        opt.textContent = m.label;
+        if (m.value === 'all') opt.selected = true;
+        modeSelect.appendChild(opt);
+      }
+      controls.appendChild(modeSelect);
+    }
+    root.appendChild(controls);
+
+    const resultsRoot = document.createElement('div');
+    resultsRoot.id = 'kioku-search-results';
+    // Sprint 4 Phase 3 PR B3: class 付与で Mobile scroll behavior (overflow-y / -webkit-overflow-scrolling) 対象化
+    resultsRoot.className = 'kioku-search-results';
+    resultsRoot.setAttribute('role', 'list');
+    root.appendChild(resultsRoot);
+
+    const deepDive = document.createElement('div');
+    deepDive.className = 'search-deepdive';
+    deepDive.appendChild(document.createTextNode('深掘り検索や全文検索が必要なときは、Claude conversation で '));
+    const ddCode = document.createElement('code');
+    ddCode.textContent = 'kioku_search';
+    deepDive.appendChild(ddCode);
+    deepDive.appendChild(document.createTextNode(' tool を呼び出してください (Tier 2、LLM-augmented)。'));
+    // Sprint 4 Phase 3 PR B3: Tier 2 Mobile deep-link button — Mobile では claude:// URI scheme 試行 + claude.ai web fallback、
+    //                         Desktop では clipboard へ MCP tool prompt を copy (copyMcpToolPrompt)、両 path で actionable 化。
+    //                         plan 26051405 §「PR B3」L240-274 canonical impl spec。
+    deepDive.appendChild(document.createElement('br'));
+    const tier2Btn = document.createElement('button');
+    tier2Btn.type = 'button';
+    tier2Btn.className = 'kioku-tier2-search-btn';
+    tier2Btn.textContent = 'Claude で深掘り検索';
+    tier2Btn.setAttribute('aria-label', 'Open current query in Claude conversation (Tier 2)');
+    tier2Btn.addEventListener('click', function () {
+      openTier2Search(input.value);
+    });
+    deepDive.appendChild(tier2Btn);
+    root.appendChild(deepDive);
+
+    function applyFilter() {
+      const filter = input.value.trim().toLowerCase();
+      const modeFilter = modeSelect ? modeSelect.value : 'all';
+      clearChildren(resultsRoot);
+      let renderedCount = 0;
+      for (const q of searchIndex.queries) {
+        if (modeSelect && modeFilter !== 'all' && q.mode !== modeFilter) continue;
+        if (filter && !q.query.toLowerCase().includes(filter)) continue;
+        const block = document.createElement('article');
+        block.className = 'search-query-block';
+        block.setAttribute('role', 'listitem');
+        const h = document.createElement('h3');
+        h.textContent = q.query;
+        const pill = document.createElement('span');
+        pill.className = 'mode-pill';
+        pill.textContent = q.mode || '';
+        h.appendChild(pill);
+        block.appendChild(h);
+        const results = Array.isArray(q.results) ? q.results : [];
+        if (results.length === 0) {
+          const empty = document.createElement('div');
+          empty.className = 'search-empty-note';
+          empty.textContent = '(no results for this query)';
+          block.appendChild(empty);
+        } else {
+          for (const r of results.slice(0, 10)) {
+            const item = document.createElement('div');
+            item.className = 'search-result-item';
+            const titleEl = document.createElement('strong');
+            titleEl.textContent = r.title || '';
+            item.appendChild(titleEl);
+            if (r.rel) {
+              const relEl = document.createElement('span');
+              relEl.className = 'rel';
+              relEl.textContent = '— ' + r.rel;
+              item.appendChild(relEl);
+            }
+            if (r.snippet) {
+              const snipEl = document.createElement('p');
+              snipEl.textContent = r.snippet;
+              item.appendChild(snipEl);
+            }
+            // View in graph link — deep-link to snapshot HTML's URL fragment highlight (PR C2)
+            // Uses visualizer-graph.html as the target filename (separate snapshot mode output path).
+            // Convention: generate snapshot mode to visualizer-graph.html alongside the shell HTML.
+            const graphLink = document.createElement('a');
+            graphLink.className = 'search-view-graph';
+            graphLink.textContent = ' [view in graph]';
+            graphLink.href = 'visualizer-graph.html#q=' + encodeURIComponent(q.query);
+            item.appendChild(graphLink);
+            block.appendChild(item);
+          }
+        }
+        resultsRoot.appendChild(block);
+        renderedCount++;
+      }
+      if (renderedCount === 0) {
+        const empty = document.createElement('div');
+        empty.className = 'search-empty-note';
+        empty.setAttribute('role', 'listitem');
+        empty.textContent = filter ? 'No queries match filter "' + filter + '".' : 'No queries match.';
+        resultsRoot.appendChild(empty);
+      }
+    }
+
+    let initialQuery = '';
+    try {
+      initialQuery = decodeURIComponent((window.location.hash || '').replace(/^#q=/, ''));
+    } catch (_) {
+      // Malformed URI fragment — degrade silently rather than crash the shell.
+    }
+    if (initialQuery) input.value = initialQuery;
+    input.addEventListener('input', applyFilter);
+    if (modeSelect) modeSelect.addEventListener('change', applyFilter);
+    applyFilter();
+  }
+})();
+</script>
+</body>
+</html>

--- a/mcp/templates/viz-template.html
+++ b/mcp/templates/viz-template.html
@@ -31,6 +31,7 @@
     --node-removed: #ff6b6b;
     --panel: #171a21;
     --panel-edge: #262a33;
+    --highlight: #ff6b35;
   }
   * { box-sizing: border-box; }
   html, body { margin: 0; padding: 0; height: 100%; }
@@ -103,6 +104,15 @@
   svg.graph .node.modified circle { fill: var(--modified); }
   svg.graph .node text { fill: var(--muted); font-size: 10px; pointer-events: none; }
   svg.graph .node:hover text { fill: var(--fg); }
+  svg.graph .node.kioku-viz-highlighted circle {
+    stroke: var(--highlight);
+    stroke-width: 3;
+    filter: drop-shadow(0 0 4px var(--highlight));
+  }
+  svg.graph .node.kioku-viz-highlighted text {
+    fill: var(--highlight);
+    font-weight: 600;
+  }
 
   .legend { display: flex; gap: 12px; font-size: 11px; color: var(--muted); padding: 4px 12px; }
   .legend .chip { display: inline-flex; align-items: center; gap: 4px; }
@@ -622,6 +632,30 @@
     font-style: italic;
     padding: 8px 0;
   }
+
+  /* ---- Mobile responsive (Sprint 4 Phase 3 PR A3) ----
+     plan 26051405 §「PR A3」L181-202 canonical impl spec
+     - .visualizer-graph wraps SVG graph (existing .canvas-wrap), hidden on Mobile
+     - .visualizer-graph-mobile-fallback section displays simplified text view
+       (PR A3 では section 配置のみ、PR C3 で renderMobileFallback で content 注入) */
+  .visualizer-graph-mobile-fallback {
+    display: none;
+  }
+  @media (max-width: 767px) {
+    .visualizer-graph {
+      /* Mobile: simplified message + link to text list view (PR C3 で実装) */
+      display: none;
+    }
+    .visualizer-graph-mobile-fallback {
+      display: block;
+      padding: 2rem;
+      text-align: center;
+    }
+    .visualizer-graph-mobile-fallback p {
+      font-size: 1.1em;
+      color: var(--muted);
+    }
+  }
 </style>
 </head>
 <body>
@@ -637,6 +671,15 @@
   <button id="tab-diff" data-view="view-diff">Diff Viewer</button>
   <button id="tab-lineage" data-view="view-lineage">Lineage</button>
 </nav>
+
+<!-- Sprint 4 Phase 3 PR A3: Mobile fallback section (section 配置のみ).
+     Sprint 4 Phase 3 PR C3: content 注入を renderMobileFallback で実装、
+     placeholder <p> は JS が clearNode して page list を生成。
+     CSS @media (max-width: 767px) で .visualizer-graph を hide、
+     本 section を display: block にして simplified view へ誘導。 -->
+<section class="visualizer-graph-mobile-fallback" id="visualizer-graph-mobile-fallback" aria-label="Visualizer Mobile fallback">
+  <p>Loading simplified view…</p>
+</section>
 
 <main>
   <div id="warnings"></div>
@@ -1677,6 +1720,37 @@
     svg.appendChild(gNodes);
   }
 
+  // ───────────────────────── URL fragment search highlight (Sprint 4 Phase 2 PR C2) ─────────────────────────
+  // Clears prior .kioku-viz-highlighted, reads location.hash (#q=<query>), then re-applies the
+  // class to g.node whose text content (case-insensitive substring) matches the query.
+  // Idempotent across renderGraph re-render (nodes are recreated) AND across hashchange
+  // (existing highlights are cleared before re-application).
+  function applySearchHighlight(svg) {
+    if (!svg) return;
+    const previouslyHighlighted = svg.querySelectorAll('g.node.kioku-viz-highlighted');
+    for (const node of previouslyHighlighted) {
+      node.classList.remove('kioku-viz-highlighted');
+    }
+    const raw = String(location.hash || '');
+    if (raw.indexOf('#q=') !== 0) return;
+    let query;
+    try {
+      query = decodeURIComponent(raw.slice(3));
+    } catch (_e) {
+      return;
+    }
+    if (!query) return;
+    const needle = query.toLowerCase();
+    const nodes = svg.querySelectorAll('g.node');
+    for (const node of nodes) {
+      const labelEl = node.querySelector('text');
+      const label = labelEl ? (labelEl.textContent || '') : '';
+      if (label.toLowerCase().includes(needle)) {
+        node.classList.add('kioku-viz-highlighted');
+      }
+    }
+  }
+
   // ───────────────────────── View 1: Timeline Player ─────────────────────────
   const tpSvg = document.getElementById("tp-svg");
   const tpSlider = document.getElementById("tp-slider");
@@ -1698,6 +1772,7 @@
     function renderTimelineAt(idx) {
       const snap = ordered[idx];
       renderGraph(tpSvg, snap.pages, snap.links, null, function (node) { showTimelineNodeDetail(snap, node); });
+      applySearchHighlight(tpSvg);
       const date = new Date(snap.timestamp).toISOString().slice(0, 19).replace("T", " ");
       tpCounter.textContent = "[" + (idx + 1) + "/" + ordered.length + "]  " + date
         + "  pages=" + snap.pages.length + "  links=" + snap.links.length;
@@ -1855,6 +1930,7 @@
     renderGraph(dvSvg, after.pages, after.links, d, function (node) {
       showDiffNodeDetail(node, beforeMap.get(node.name), afterMap.get(node.name));
     });
+    applySearchHighlight(dvSvg);
     dvCounter.textContent = "added=" + d.added.length
       + "  removed=" + d.removed.length
       + "  modified=" + d.modified.length
@@ -1863,6 +1939,65 @@
   }
   dvDiff.addEventListener("click", runDiff);
   if (snapshots.length >= 2) runDiff();
+
+  // Re-apply highlight when URL fragment changes (e.g. user navigates from shell "view in graph" link)
+  window.addEventListener('hashchange', function () {
+    // Both views render their own SVG; applying to both is cheap and idempotent.
+    applySearchHighlight(tpSvg);
+    applySearchHighlight(dvSvg);
+  });
+
+  // ───────────── Sprint 4 Phase 3 PR C3: Mobile simplified view ─────────────
+  // plan 26051405 §「Visualizer β Mobile simplified view」 canonical impl spec.
+  // graph SVG は CSS @media (max-width: 767px) で hidden、本関数で text page list を注入。
+  // 全 DOM 操作は textContent + createElement のみ (Path C+β boundary policy: innerHTML
+  // assignment / outerHTML assignment / legacy doc-write API いずれも 0 hit 維持)。
+  function renderMobileFallback(rootData) {
+    const container = document.querySelector('.visualizer-graph-mobile-fallback');
+    if (!container) return;
+    clearNode(container);
+
+    const intro = document.createElement('p');
+    intro.textContent = 'Mobile では graph 表示を簡略化しています。下記 page list をご利用ください。';
+    container.appendChild(intro);
+
+    // page 出典: 最新 snapshot の pages を優先 (visualizer.mjs L186: snapshots[0].pages 由来)。
+    // 空 vault や lineage-only 構成では空 list を出して noisy 警告は出さない。
+    const snaps = Array.isArray(rootData.snapshots) ? rootData.snapshots : [];
+    const pages = (snaps.length > 0 && Array.isArray(snaps[0].pages)) ? snaps[0].pages : [];
+
+    if (pages.length === 0) {
+      const empty = document.createElement('p');
+      empty.className = 'muted';
+      empty.textContent = '(pages not available in this snapshot)';
+      container.appendChild(empty);
+      return;
+    }
+
+    const ul = document.createElement('ul');
+    for (let i = 0; i < pages.length; i += 1) {
+      const page = pages[i] || {};
+      const li = document.createElement('li');
+      const a = document.createElement('a');
+      // anchor href = '#' + page.name 相当 (graph node id と同等の hash navigation、
+      // PR A3 の hashchange listener と互換、external navigation 無し = CSP safe)。
+      a.href = '#' + encodeURIComponent(page.name || '');
+      a.textContent = page.title || page.name || '(untitled)';
+      li.appendChild(a);
+      ul.appendChild(li);
+    }
+    container.appendChild(ul);
+  }
+
+  // Mobile breakpoint 検出 (CSS @media (max-width: 767px) と同基準)。
+  // SSR / non-browser env では window.matchMedia 不在の可能性、defensive guard。
+  if (typeof window !== 'undefined'
+      && typeof window.matchMedia === 'function') {
+    const mobileMQ = window.matchMedia('(max-width: 767px)');
+    if (mobileMQ && mobileMQ.matches) {
+      renderMobileFallback(data);
+    }
+  }
 })();
 </script>
 </body>

--- a/mcp/tools/search.mjs
+++ b/mcp/tools/search.mjs
@@ -27,6 +27,11 @@ export const SEARCH_TOOL_DEF = {
       .enum(['lex', 'vec', 'hybrid'])
       .optional()
       .describe('lex=BM25, vec=embedding similarity, hybrid=qmd query (BM25+vec+rerank).'),
+    intent: z
+      .string()
+      .max(MAX_QUERY_LEN)
+      .optional()
+      .describe('Optional intent disambiguation for the query, passed to qmd if available.'),
   },
 };
 
@@ -39,8 +44,15 @@ export async function handleSearch(vault, args) {
   }
   const limit = clamp(args?.limit ?? 10, 1, MAX_LIMIT);
   const mode = args?.mode ?? 'hybrid';
+  // intent は qmd subprocess に転送する optional な disambiguation hint。
+  // undefined / 空文字なら subprocess flag を一切渡さない (qmd 旧 version 互換)。
+  const rawIntent = args?.intent;
+  const intent =
+    typeof rawIntent === 'string' && rawIntent.trim().length > 0
+      ? rawIntent.trim().slice(0, MAX_QUERY_LEN)
+      : null;
 
-  const qmdResult = await tryQmd(query, limit, mode);
+  const qmdResult = await tryQmd(query, limit, mode, intent);
   if (qmdResult) return qmdResult;
 
   const fallback = await fallbackSearch(vault, query, limit);
@@ -50,9 +62,14 @@ export async function handleSearch(vault, args) {
   };
 }
 
-async function tryQmd(query, limit, mode) {
+async function tryQmd(query, limit, mode, intent) {
   const subcommand = mode === 'lex' ? 'search' : mode === 'vec' ? 'vsearch' : 'query';
-  const args = [subcommand, '--json', '-n', String(limit), '-c', COLLECTION, query];
+  const args = [subcommand, '--json', '-n', String(limit), '-c', COLLECTION];
+  // intent flag は subcommand と query の間に挿入 (qmd CLI convention: flags 先、positional 末)。
+  if (intent) {
+    args.push('--intent', intent);
+  }
+  args.push(query);
   return new Promise((resolve) => {
     const child = spawn('qmd', args, {
       stdio: ['ignore', 'pipe', 'pipe'],

--- a/mcp/tools/visualizer.mjs
+++ b/mcp/tools/visualizer.mjs
@@ -24,6 +24,7 @@ import { buildWikiSnapshot, diffSnapshots } from '../lib/wiki-snapshot.mjs';
 import { collectHealthMetrics } from '../lib/health-metrics.mjs';
 import { collectFirstViewData } from '../lib/visualizer-data.mjs';
 import { buildLineageGraph } from '../lib/lineage-graph.mjs';
+import { buildShellHtml } from '../lib/web-ui-shell.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const TEMPLATE_PATH = join(__dirname, '..', 'templates', 'viz-template.html');
@@ -44,7 +45,7 @@ export const VISUALIZER_TOOL_DEF = {
   name: 'kioku_generate_viz',
   title: 'Generate KIOKU wiki visualizer (local HTML)',
   description:
-    'Generates a self-contained HTML visualizer of the wiki with 4 views: Overview (first view = vault overview + health focus + graph preview + action queue), Timeline Player (temporal evolution), Diff Viewer (2 時点の差分), and Lineage (raw-sources → summaries → wiki best-effort 3 layer lineage graph, Sprint 3 v0.8 β). Data is embedded as inline JSON — only frontmatter and wikilinks, never page body. Output is written to the vault .cache/viz/ directory and opened directly in a browser (no external network). Does NOT modify wiki/. Requires the vault to be a git repository.',
+    'Generates a self-contained HTML visualizer of the wiki with 4 views: Overview (first view = vault overview + health focus + graph preview + action queue), Timeline Player (temporal evolution), Diff Viewer (2 時点の差分), and Lineage (raw-sources → summaries → wiki best-effort 3 layer lineage graph, Sprint 3 v0.8 β). Data is embedded as inline JSON — only frontmatter and wikilinks, never page body. Output is written to the vault .cache/viz/ directory and opened directly in a browser (no external network). Does NOT modify wiki/. Requires the vault to be a git repository. mode=snapshot (default, backward compat): Sprint 3 4-view HTML. mode=shell (v0.9 Sprint 4 Phase 1): KIOKU Web UI shell with Dashboard tab (renders .base file) + Visualizer β 4 views integrated as a tab system.',
   inputShape: {
     output_path: z
       .string()
@@ -68,6 +69,16 @@ export const VISUALIZER_TOOL_DEF = {
       .boolean()
       .optional()
       .describe('Semantic cluster view (View 4). Deferred to v0.8; currently rejected if true.'),
+    mode: z
+      .enum(['snapshot', 'shell'])
+      .optional()
+      .describe('Output mode. "snapshot" (default, backward compat): Sprint 3 Visualizer β 4-view HTML. "shell" (v0.9 Sprint 4 Phase 1): KIOKU Web UI shell with Dashboard tab + Visualizer β views integrated.'),
+    base_source: z
+      .string()
+      .min(1)
+      .max(512)
+      .optional()
+      .describe('Path to .base file (vault-relative), used in shell mode for the Dashboard tab. Ignored in snapshot mode. Default: "wiki/meta/dashboard.base".'),
   },
 };
 
@@ -107,6 +118,46 @@ export async function handleGenerateViz(vault, args = {}) {
       throw new Error(`invalid output_path: ${err.message}`);
     }
     throw err;
+  }
+
+  // Sprint 4 Phase 1: mode dispatch.
+  //   - mode === 'shell'  → buildShellHtml (PR B web-ui-shell) で Dashboard + Visualizer β 統合 HTML 出力
+  //   - それ以外          → 既存 snapshot path (Sprint 3 既存 logic を bit-equal で実行、zero regression)
+  // mode が undefined / 'snapshot' / 不正値の何れでも snapshot path に fall through するため、
+  // backward-compat caller (mode 未指定) と explicit 'snapshot' caller が同一コードを通ることが保証される。
+  const mode = args.mode === 'shell' ? 'shell' : 'snapshot';
+  if (mode === 'shell') {
+    const baseSource =
+      typeof args.base_source === 'string' && args.base_source.length > 0
+        ? args.base_source
+        : undefined;
+    const html = await buildShellHtml(vault, {
+      since,
+      max_commits: maxCommits,
+      base_source: baseSource,
+    });
+    await mkdir(dirname(absOutputPath), { recursive: true });
+    const tmpPath = `${absOutputPath}.tmp-${randomBytes(6).toString('hex')}`;
+    try {
+      await writeFile(tmpPath, html, 'utf8');
+      await rename(tmpPath, absOutputPath);
+    } catch (err) {
+      try {
+        const { unlink } = await import('node:fs/promises');
+        await unlink(tmpPath);
+      } catch {
+        /* ignore */
+      }
+      throw err;
+    }
+    return {
+      path: absOutputPath,
+      path_relative: outputPathRel,
+      mode: 'shell',
+      since,
+      max_commits: maxCommits,
+      note: 'Open the generated shell HTML in a browser. Dashboard + Visualizer β 4 views available (Search / Navigation / Wikilink graph tabs are placeholders for Phase 2-4).',
+    };
   }
 
   // 1. git history 収集

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -520,6 +520,84 @@ check_metadata_parity() {
 }
 
 # -----------------------------------------------------------------------------
+# Section: Sync state (Sprint 4 Phase 4 PR B4)
+#
+# Vault が Git repo 配下である前提で、cloud sync (auto push/pull) の 3 軸の
+# 現在 state を表示する read-only diagnostic。retry queue file は
+# `hooks/sync-vault.mjs` (PR A4) が write/update する schema を read-only で
+# inspect する (write は一切しない)。
+#
+# - sync-last-commit    : `git log -1` の最新 commit timestamp
+# - sync-pending-retry  : `.kioku-sync-retry.json` の有無 + retryCount + errorType
+# - sync-network        : `github.com` reachability (curl --max-time 5、fail-fast)
+#
+# Vault が Git repo でない / OBSIDIAN_VAULT 未設定の場合は本 section を丸ごと
+# skip して "warn" 1 行のみ残す (existing env-vault-git check が既に状態を
+# 伝えているため重複を避ける)。
+# -----------------------------------------------------------------------------
+check_sync_state() {
+  if [[ -z "${OBSIDIAN_VAULT:-}" ]] || [[ ! -d "${OBSIDIAN_VAULT}" ]]; then
+    return 0
+  fi
+  if ! git -C "${OBSIDIAN_VAULT}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    add_check "sync-state" "warn" \
+      "Vault is not a Git repo — sync state diagnostic skipped"
+    return 0
+  fi
+
+  # Last commit timestamp (auto-commit と user commit を区別しない、最終 push 候補時刻として活用)
+  local last_commit_time
+  last_commit_time="$(git -C "${OBSIDIAN_VAULT}" log -1 --format='%cI' 2>/dev/null || true)"
+  if [[ -n "${last_commit_time}" ]]; then
+    add_check "sync-last-commit" "ok" \
+      "Last Vault commit: ${last_commit_time}"
+  else
+    add_check "sync-last-commit" "warn" \
+      "Vault has no commits yet (first session not run?)"
+  fi
+
+  # Pending retry queue (.kioku-sync-retry.json) inspect
+  # schema: { errorType, message, firstAttempt, lastAttempt, retryCount }
+  local retry_queue="${OBSIDIAN_VAULT}/.kioku-sync-retry.json"
+  if [[ ! -f "${retry_queue}" ]]; then
+    add_check "sync-pending-retry" "ok" \
+      "No pending sync retry"
+  elif [[ "${HAS_JQ}" -eq 1 ]]; then
+    local retry_count error_type first_attempt
+    retry_count="$(jq -r '.retryCount // "?"' "${retry_queue}" 2>/dev/null || echo "?")"
+    error_type="$(jq -r '.errorType // "unknown"' "${retry_queue}" 2>/dev/null || echo "unknown")"
+    first_attempt="$(jq -r '.firstAttempt // ""' "${retry_queue}" 2>/dev/null || echo "")"
+    local detail="${retry_count} attempts, last error: ${error_type}"
+    if [[ -n "${first_attempt}" ]]; then
+      detail="${detail}, since: ${first_attempt}"
+    fi
+    add_check "sync-pending-retry" "warn" \
+      "Pending sync retry queue: ${detail}" \
+      "Next Claude session will retry automatically (or run: node hooks/sync-vault.mjs --pull-and-retry)"
+  else
+    # jq 不在 fallback: file 存在のみ報告
+    add_check "sync-pending-retry" "warn" \
+      "Pending sync retry queue exists (install jq to inspect details)" \
+      "brew install jq  # or: apt-get install jq"
+  fi
+
+  # Network reachability — github.com への HEAD-only probe (curl --max-time 5)
+  # curl が無い環境では skip (warn)
+  if command -v curl >/dev/null 2>&1; then
+    if curl -fsS --head --max-time 5 https://github.com >/dev/null 2>&1; then
+      add_check "sync-network" "ok" \
+        "Network: github.com reachable"
+    else
+      add_check "sync-network" "warn" \
+        "Network: github.com unreachable (auto-sync will queue until reconnected)"
+    fi
+  else
+    add_check "sync-network" "warn" \
+      "curl not installed — cannot probe network reachability"
+  fi
+}
+
+# -----------------------------------------------------------------------------
 # Section: Dependencies
 # -----------------------------------------------------------------------------
 check_dependencies() {
@@ -692,6 +770,7 @@ check_hook_configs
 check_mcp_configs
 check_metadata_parity
 check_dependencies
+check_sync_state
 detect_install_mode
 
 if [[ "${JSON_MODE}" -eq 1 ]]; then

--- a/scripts/install-hooks-codex.sh
+++ b/scripts/install-hooks-codex.sh
@@ -29,6 +29,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ADAPTER_ABS="$(cd "${SCRIPT_DIR}/.." && pwd)/hooks/adapters/codex.mjs"
+SYNC_VAULT_ABS="$(cd "${SCRIPT_DIR}/.." && pwd)/hooks/sync-vault.mjs"
 
 APPLY_MODE=0
 ASSUME_YES=0
@@ -121,7 +122,7 @@ emit_snippet_json() {
         "hooks": [
           {
             "type": "command",
-            "command": "cd \"${OBSIDIAN_VAULT}\" && git pull --rebase --quiet 2>/dev/null || true"
+            "command": "OBSIDIAN_VAULT=\"${OBSIDIAN_VAULT}\" node '${SYNC_VAULT_ABS}' --pull-and-retry"
           }
         ]
       }
@@ -159,7 +160,7 @@ emit_snippet_json() {
           },
           {
             "type": "command",
-            "command": "[ \"\${KIOKU_NO_LOG:-0}\" = \"1\" ] || { cd \"${OBSIDIAN_VAULT}\" && grep -q '^session-logs/' .gitignore 2>/dev/null && git symbolic-ref -q HEAD >/dev/null 2>&1 && git add wiki/ raw-sources/ templates/ CLAUDE.md 2>/dev/null && (git diff --cached --quiet || (git commit -m \"auto: wiki update \$(date +%Y%m%d-%H%M)\" --quiet && git push --quiet)) 2>/dev/null; } || true",
+            "command": "OBSIDIAN_VAULT=\"${OBSIDIAN_VAULT}\" node '${SYNC_VAULT_ABS}' --push",
             "timeoutSec": 60
           }
         ]

--- a/scripts/install-hooks-gemini.sh
+++ b/scripts/install-hooks-gemini.sh
@@ -24,6 +24,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ADAPTER_ABS="$(cd "${SCRIPT_DIR}/.." && pwd)/hooks/adapters/gemini.mjs"
+SYNC_VAULT_ABS="$(cd "${SCRIPT_DIR}/.." && pwd)/hooks/sync-vault.mjs"
 
 # -----------------------------------------------------------------------------
 # 引数パース
@@ -148,7 +149,7 @@ emit_snippet_json() {
         "hooks": [
           {
             "type": "command",
-            "command": "cd \"${OBSIDIAN_VAULT}\" && git pull --rebase --quiet 2>/dev/null || true"
+            "command": "OBSIDIAN_VAULT=\"${OBSIDIAN_VAULT}\" node '${SYNC_VAULT_ABS}' --pull-and-retry"
           }
         ]
       }
@@ -205,7 +206,7 @@ emit_snippet_json() {
           {
             "name": "claude-brain-git-sync",
             "type": "command",
-            "command": "[ \"\${KIOKU_NO_LOG:-0}\" = \"1\" ] || { cd \"${OBSIDIAN_VAULT}\" && grep -q '^session-logs/' .gitignore 2>/dev/null && git symbolic-ref -q HEAD >/dev/null 2>&1 && git add wiki/ raw-sources/ templates/ CLAUDE.md 2>/dev/null && (git diff --cached --quiet || (git commit -m \"auto: wiki update \$(date +%Y%m%d-%H%M)\" --quiet && git push --quiet)) 2>/dev/null; } || true",
+            "command": "OBSIDIAN_VAULT=\"${OBSIDIAN_VAULT}\" node '${SYNC_VAULT_ABS}' --push",
             "timeout": 30000
           }
         ]

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -26,6 +26,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 HOOK_ABS="$(cd "${SCRIPT_DIR}/.." && pwd)/hooks/session-logger.mjs"
 INJECTOR_ABS="$(cd "${SCRIPT_DIR}/.." && pwd)/hooks/wiki-context-injector.mjs"
+SYNC_VAULT_ABS="$(cd "${SCRIPT_DIR}/.." && pwd)/hooks/sync-vault.mjs"
 
 # -----------------------------------------------------------------------------
 # 引数パース
@@ -112,6 +113,10 @@ if [[ ! -f "${INJECTOR_ABS}" ]]; then
   WARNINGS+=("Wiki context injector not found at expected path: ${INJECTOR_ABS}")
 fi
 
+if [[ ! -f "${SYNC_VAULT_ABS}" ]]; then
+  WARNINGS+=("Sync vault helper not found at expected path: ${SYNC_VAULT_ABS}")
+fi
+
 # -----------------------------------------------------------------------------
 # JSON スニペット生成関数 (stdout / --apply 両方で使う)
 #
@@ -127,7 +132,7 @@ emit_snippet_json() {
         "hooks": [
           {
             "type": "command",
-            "command": "cd \"${OBSIDIAN_VAULT}\" && git pull --rebase --quiet 2>/dev/null || true"
+            "command": "OBSIDIAN_VAULT=\"${OBSIDIAN_VAULT}\" node '${SYNC_VAULT_ABS}' --pull-and-retry"
           }
         ]
       },
@@ -194,7 +199,7 @@ emit_snippet_json() {
         "hooks": [
           {
             "type": "command",
-            "command": "[ \"\${KIOKU_NO_LOG:-0}\" = \"1\" ] || { cd \"${OBSIDIAN_VAULT}\" && grep -q '^session-logs/' .gitignore 2>/dev/null && git symbolic-ref -q HEAD >/dev/null 2>&1 && git add wiki/ raw-sources/ templates/ CLAUDE.md 2>/dev/null && (git diff --cached --quiet || (git commit -m \"auto: wiki update \$(date +%Y%m%d-%H%M)\" --quiet && git push --quiet)) 2>/dev/null; } || true"
+            "command": "OBSIDIAN_VAULT=\"${OBSIDIAN_VAULT}\" node '${SYNC_VAULT_ABS}' --push"
           }
         ]
       }
@@ -310,7 +315,7 @@ apply_merge() {
   rm -f "${snippet_file}"
 
   # VULN-014: Hook スクリプトのパーミッションを制御 (所有者のみ書き込み可能)
-  for hook_file in "${HOOK_ABS}" "${INJECTOR_ABS}"; do
+  for hook_file in "${HOOK_ABS}" "${INJECTOR_ABS}" "${SYNC_VAULT_ABS}"; do
     if [[ -f "${hook_file}" ]]; then
       chmod 755 "${hook_file}"
       echo "  chmod 755 ${hook_file}"
@@ -353,6 +358,7 @@ cat <<EOF
 #   OBSIDIAN_VAULT  = ${OBSIDIAN_VAULT}
 #   hook script     = ${HOOK_ABS}
 #   wiki injector   = ${INJECTOR_ABS}
+#   sync vault      = ${SYNC_VAULT_ABS}
 #
 EOF
 
@@ -368,18 +374,24 @@ fi
 
 cat <<'EOF'
 # Design notes (important):
-#   - SessionStart chains two commands: first 'git pull --rebase' against the
-#     Vault repository, then wiki-context-injector.mjs which outputs
-#     { "additionalContext": ... } containing wiki/index.md (+ wiki/hot.md
-#     if present) so Claude picks up the knowledge base automatically at
-#     session start. CLAUDE_HOOK_EVENT=SessionStart is exported so the
-#     injector branches correctly even if the stdin JSON path is unused.
+#   - SessionStart chains two commands: first sync-vault.mjs --pull-and-retry
+#     runs 'git pull --rebase' against the Vault repository and drains any
+#     pending retry queue (Sprint 4 Phase 4 PR A4); then
+#     wiki-context-injector.mjs outputs { "additionalContext": ... } containing
+#     wiki/index.md (+ wiki/hot.md if present) so Claude picks up the
+#     knowledge base automatically at session start. CLAUDE_HOOK_EVENT=
+#     SessionStart is exported so the injector branches correctly even if the
+#     stdin JSON path is unused.
 #   - PostCompact (v0.5.1 Phase B) invokes the same injector with
 #     CLAUDE_HOOK_EVENT=PostCompact, which injects ONLY wiki/hot.md. This
 #     restores the short hand-off context after Claude Code compacts the
 #     conversation. If wiki/hot.md is absent, the injector silently no-ops.
 #   - SessionEnd runs two chained commands: first session-logger.mjs appends
-#     the session summary, then 'git add / commit / push' syncs wiki changes.
+#     the session summary, then sync-vault.mjs --push stages wiki/,
+#     raw-sources/, templates/, CLAUDE.md, commits if anything is staged, and
+#     pushes. On push failure the helper records a masked entry in
+#     $OBSIDIAN_VAULT/.kioku-sync-retry.json which the next SessionStart drains
+#     automatically.
 #   - Normal coding sessions do NOT trigger a push because Hook only writes
 #     to session-logs/, which is gitignored. You'll only see commits after
 #     running the weekly Ingest command or manually editing wiki/ files.

--- a/tests/bases-renderer.test.mjs
+++ b/tests/bases-renderer.test.mjs
@@ -1,0 +1,499 @@
+// bases-renderer.test.mjs — Tests for mcp/lib/bases-renderer.mjs
+//
+// Sprint 4 Phase 1 PR A (plan/claude/26051301_v0-9-phase1-impl-plan.md §「PR A」).
+//
+// Test cases (10 BLUE-BASES-RENDERER-*):
+//   BLUE-BASES-RENDERER-1            (Task A-1 / A-3): filters.and 6 P0 operators
+//                                                       (folder / ext / name / negation
+//                                                       / equality / numeric)
+//   BLUE-BASES-RENDERER-2a           (Task A-2)      : parseYamlLike nested lists + strings
+//   BLUE-BASES-RENDERER-2            (Task A-4)      : formulas.age_days computed from mtime
+//   BLUE-BASES-RENDERER-3            (Task A-5)      : properties.displayName preserved
+//   BLUE-BASES-RENDERER-4            (Task A-6)      : views table + list types preserved
+//   BLUE-BASES-RENDERER-5            (Task A-6)      : limit truncates pages
+//   BLUE-BASES-RENDERER-6            (Task A-6)      : order by file.name ascending
+//   BLUE-BASES-RENDERER-7            (Task A-6)      : groupBy property type ASC
+//   BLUE-BASES-RENDERER-warning      (Task A-7)      : unknown expression surfaces warning
+//                                                       + page excluded from view
+//   BLUE-BASES-RENDERER-INTEGRATION  (Task A-8)      : templates/wiki/meta/dashboard.base
+//                                                       (10 views) renders without warnings
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, writeFile, rm, utimes, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  parseBaseFile,
+  renderBases,
+  BasesParseError,
+  _internals,
+} from '../mcp/lib/bases-renderer.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '../../..');
+const STATIC_FIXTURE_VAULT = resolve(__dirname, 'fixtures/visualizer-small-vault');
+const DASHBOARD_BASE_PATH = resolve(
+  REPO_ROOT,
+  'tools/claude-brain/templates/wiki/meta/dashboard.base',
+);
+
+// ---------------------------------------------------------------------------
+// Temp vault helper — gives each test isolated control over file content + mtime.
+// ---------------------------------------------------------------------------
+
+async function makeTempVault({ withStale = false } = {}) {
+  const root = await mkdtemp(join(tmpdir(), 'kioku-bases-test-'));
+  await mkdir(join(root, 'wiki', 'concepts'), { recursive: true });
+  await mkdir(join(root, 'wiki', 'projects'), { recursive: true });
+  await mkdir(join(root, 'wiki', 'summaries'), { recursive: true });
+  await mkdir(join(root, 'wiki', 'meta'), { recursive: true });
+
+  // Fresh files (mtime ≈ now).
+  await writeFile(
+    join(root, 'wiki', 'hot.md'),
+    '---\ntype: hot\nupdated: 2026-05-13\n---\n\n# Hot cache\n',
+  );
+  await writeFile(
+    join(root, 'wiki', 'index.md'),
+    '---\ntype: index\ntitle: Index\n---\n\n# Index\n',
+  );
+  await writeFile(
+    join(root, 'wiki', 'projects', 'kioku.md'),
+    '---\ntype: project\nstatus: active\nupdated: 2026-05-12\n---\n\n# KIOKU\n',
+  );
+  await writeFile(
+    join(root, 'wiki', 'concepts', 'jwt.md'),
+    '---\ntype: concept\nupdated: 2026-05-12\n---\n\n# JWT\n',
+  );
+  await writeFile(
+    join(root, 'wiki', 'concepts', 'oauth.md'),
+    '---\ntype: concept\nupdated: 2026-05-12\n---\n\n# OAuth\n',
+  );
+  // summary — used to test '!file.inFolder("wiki/summaries")' negation.
+  await writeFile(
+    join(root, 'wiki', 'summaries', 'rag.md'),
+    '---\ntype: summary\nupdated: 2026-05-12\n---\n\n# RAG\n',
+  );
+
+  if (withStale) {
+    await writeFile(
+      join(root, 'wiki', 'concepts', 'legacy.md'),
+      '---\ntype: concept\nstatus: archived\nupdated: 2024-01-01\n---\n\n# Legacy\n',
+    );
+    // Force mtime to 60 days before "now" for the stale test.
+    const oldDate = new Date('2026-03-13T00:00:00Z');
+    await utimes(join(root, 'wiki', 'concepts', 'legacy.md'), oldDate, oldDate);
+  }
+  return root;
+}
+
+async function cleanup(root) {
+  if (root) await rm(root, { recursive: true, force: true });
+}
+
+// ---------------------------------------------------------------------------
+// BLUE-BASES-RENDERER-2a (Task A-2): parseYamlLike nested lists + strings
+// ---------------------------------------------------------------------------
+
+test('BLUE-BASES-RENDERER-2a: parseYamlLike handles nested lists + strings', () => {
+  const text = `
+filters:
+  and:
+    - file.inFolder("wiki")
+    - 'file.ext == "md"'
+views:
+  - type: table
+    name: "Hot"
+    limit: 5
+`;
+  const { ast, warnings } = parseBaseFile(text);
+  assert.equal(warnings.length, 0);
+  assert.equal(ast.filters.and.length, 2);
+  assert.equal(ast.filters.and[0], 'file.inFolder("wiki")');
+  assert.equal(ast.filters.and[1], 'file.ext == "md"');
+  assert.equal(ast.views.length, 1);
+  assert.equal(ast.views[0].type, 'table');
+  assert.equal(ast.views[0].name, 'Hot');
+  assert.equal(ast.views[0].limit, 5);
+});
+
+// ---------------------------------------------------------------------------
+// BLUE-BASES-RENDERER-1 (Task A-3): 6 P0 filter operators
+// ---------------------------------------------------------------------------
+
+test('BLUE-BASES-RENDERER-1: 6 filter operators (folder/ext/name/negation/equality/numeric)', async () => {
+  const vault = await makeTempVault({ withStale: true });
+  try {
+    const baseText = `
+filters:
+  and:
+    - file.inFolder("wiki")
+    - 'file.ext == "md"'
+    - '!file.inFolder("wiki/summaries")'
+formulas:
+  age_days: '(now() - file.mtime).days'
+views:
+  - type: list
+    name: "hot only"
+    filters:
+      and:
+        - 'file.name == "hot"'
+  - type: list
+    name: "active projects"
+    filters:
+      and:
+        - 'status == "active"'
+  - type: list
+    name: "stale"
+    filters:
+      and:
+        - 'formula.age_days > 30'
+`;
+    const { ast, warnings } = parseBaseFile(baseText);
+    assert.equal(warnings.length, 0);
+    assert.equal(ast.filters.and.length, 3);
+
+    const { views, warnings: rwarn } = await renderBases(vault, ast, {
+      now: new Date('2026-05-13T00:00:00Z'),
+    });
+    assert.equal(rwarn.length, 0, `unexpected render warnings: ${rwarn.join('; ')}`);
+    assert.equal(views.length, 3);
+
+    // Negation: no summaries/* pages should appear under the global filter.
+    for (const v of views) {
+      for (const p of v.pages) {
+        assert.ok(!p.rel.startsWith('summaries/'), `expected to exclude ${p.rel}`);
+        assert.ok(p.rel.endsWith('.md'));
+      }
+    }
+
+    // file.name == "hot"
+    const hotView = views.find((v) => v.name === 'hot only');
+    assert.equal(hotView.pages.length, 1);
+    assert.equal(hotView.pages[0].name, 'hot');
+
+    // status == "active"
+    const activeView = views.find((v) => v.name === 'active projects');
+    assert.equal(activeView.pages.length, 1);
+    assert.equal(activeView.pages[0].frontmatter.status, 'active');
+
+    // formula.age_days > 30 → legacy.md only (mtime 60 days back).
+    const staleView = views.find((v) => v.name === 'stale');
+    assert.equal(staleView.pages.length, 1);
+    assert.equal(staleView.pages[0].name, 'legacy');
+    assert.ok(staleView.pages[0].computed.age_days > 30);
+  } finally {
+    await cleanup(vault);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// BLUE-BASES-RENDERER-2 (Task A-4): formulas.age_days computed from mtime
+// ---------------------------------------------------------------------------
+
+test('BLUE-BASES-RENDERER-2: formulas.age_days computed from mtime', async () => {
+  const vault = await makeTempVault();
+  try {
+    const baseText = `
+formulas:
+  age_days: '(now() - file.mtime).days'
+views:
+  - type: list
+    name: "all"
+`;
+    const { ast } = parseBaseFile(baseText);
+    const fixedNow = new Date('2026-05-13T12:00:00Z');
+    // utimes all wiki/*.md to a known past mtime so age_days is deterministic
+    // regardless of when the test runs. Without this, fixedNow could be in the
+    // past relative to file creation time, producing negative age_days.
+    const pastMtime = new Date('2026-05-10T00:00:00Z');
+    for (const rel of [
+      'wiki/hot.md',
+      'wiki/index.md',
+      'wiki/projects/kioku.md',
+      'wiki/concepts/jwt.md',
+      'wiki/concepts/oauth.md',
+      'wiki/summaries/rag.md',
+    ]) {
+      await utimes(join(vault, rel), pastMtime, pastMtime);
+    }
+    const { views, warnings } = await renderBases(vault, ast, { now: fixedNow });
+    assert.equal(warnings.length, 0);
+    assert.equal(views.length, 1);
+    for (const p of views[0].pages) {
+      assert.equal(typeof p.computed.age_days, 'number');
+      assert.ok(p.computed.age_days >= 0);
+    }
+  } finally {
+    await cleanup(vault);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// BLUE-BASES-RENDERER-3 (Task A-5): properties.displayName preserved
+// ---------------------------------------------------------------------------
+
+test('BLUE-BASES-RENDERER-3: properties.displayName preserved in ast', () => {
+  const baseText = `
+properties:
+  type:
+    displayName: "Type"
+  status:
+    displayName: "Status"
+  formula.age_days:
+    displayName: "Days Since Edit"
+views:
+  - type: table
+    name: "all"
+`;
+  const { ast, warnings } = parseBaseFile(baseText);
+  assert.equal(warnings.length, 0);
+  assert.equal(ast.properties.type.displayName, 'Type');
+  assert.equal(ast.properties.status.displayName, 'Status');
+  assert.equal(ast.properties['formula.age_days'].displayName, 'Days Since Edit');
+});
+
+// ---------------------------------------------------------------------------
+// BLUE-BASES-RENDERER-4 (Task A-6): views table + list types preserved
+// ---------------------------------------------------------------------------
+
+test('BLUE-BASES-RENDERER-4: views table + list types preserved', async () => {
+  const vault = await makeTempVault();
+  try {
+    const baseText = `
+views:
+  - type: table
+    name: "T1"
+  - type: list
+    name: "L1"
+`;
+    const { ast } = parseBaseFile(baseText);
+    const { views } = await renderBases(vault, ast);
+    assert.equal(views.length, 2);
+    assert.equal(views[0].type, 'table');
+    assert.equal(views[0].name, 'T1');
+    assert.equal(views[1].type, 'list');
+    assert.equal(views[1].name, 'L1');
+  } finally {
+    await cleanup(vault);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// BLUE-BASES-RENDERER-5 (Task A-6): limit truncates pages
+// ---------------------------------------------------------------------------
+
+test('BLUE-BASES-RENDERER-5: limit truncates pages', async () => {
+  const vault = await makeTempVault();
+  try {
+    const baseText = `
+views:
+  - type: list
+    name: "limited"
+    limit: 2
+`;
+    const { ast } = parseBaseFile(baseText);
+    const { views } = await renderBases(vault, ast);
+    assert.ok(views[0].pages.length <= 2);
+    assert.equal(views[0].pages.length, 2);
+  } finally {
+    await cleanup(vault);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// BLUE-BASES-RENDERER-6 (Task A-6): order by file.name ascending
+// ---------------------------------------------------------------------------
+
+test('BLUE-BASES-RENDERER-6: order by file.name ascending', async () => {
+  const vault = await makeTempVault();
+  try {
+    const baseText = `
+views:
+  - type: list
+    name: "ordered"
+    order:
+      - file.name
+`;
+    const { ast } = parseBaseFile(baseText);
+    const { views } = await renderBases(vault, ast);
+    const names = views[0].pages.map((p) => p.name);
+    const sorted = [...names].sort();
+    assert.deepEqual(names, sorted);
+  } finally {
+    await cleanup(vault);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// BLUE-BASES-RENDERER-7 (Task A-6): groupBy property type ASC
+// ---------------------------------------------------------------------------
+
+test('BLUE-BASES-RENDERER-7: groupBy property type ASC', async () => {
+  const vault = await makeTempVault();
+  try {
+    const baseText = `
+views:
+  - type: table
+    name: "grouped"
+    groupBy:
+      property: type
+      direction: ASC
+`;
+    const { ast } = parseBaseFile(baseText);
+    const { views } = await renderBases(vault, ast);
+    assert.ok(Array.isArray(views[0].groups));
+    assert.ok(views[0].groups.length > 0);
+    const keys = views[0].groups.map((g) => g.key);
+    const sortedKeys = [...keys].sort();
+    assert.deepEqual(keys, sortedKeys);
+    // Sanity: hot, index, project, concept, summary all present in temp vault.
+    assert.ok(keys.includes('hot'));
+    assert.ok(keys.includes('project'));
+  } finally {
+    await cleanup(vault);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// BLUE-BASES-RENDERER-warning (Task A-7): unknown expression → warning + exclude
+// ---------------------------------------------------------------------------
+
+test('BLUE-BASES-RENDERER-warning: unknown expression surfaces warning + page excluded', async () => {
+  const vault = await makeTempVault();
+  try {
+    const baseText = `
+views:
+  - type: list
+    name: "unknown filter"
+    filters:
+      and:
+        - 'unknown_func(x)'
+formulas:
+  weird: 'Math.sqrt(file.size)'
+`;
+    const { ast } = parseBaseFile(baseText);
+    const { views, warnings } = await renderBases(vault, ast);
+    assert.equal(views[0].pages.length, 0, 'unknown filter should exclude all pages');
+    assert.ok(
+      warnings.some((w) => w.includes('unknown filter expression: unknown_func(x)')),
+      `expected unknown-filter warning in: ${warnings.join('; ')}`,
+    );
+    assert.ok(
+      warnings.some((w) => w.includes('unknown formula expression: weird')),
+      `expected unknown-formula warning in: ${warnings.join('; ')}`,
+    );
+  } finally {
+    await cleanup(vault);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// BLUE-BASES-RENDERER-INTEGRATION (Task A-8): dashboard.base 10 views render
+// ---------------------------------------------------------------------------
+
+test('BLUE-BASES-RENDERER-INTEGRATION: dashboard.base 10 views render successfully', async () => {
+  const vault = await makeTempVault();
+  try {
+    const baseText = await readFile(DASHBOARD_BASE_PATH, 'utf8');
+    const { ast, warnings: parseWarnings } = parseBaseFile(baseText);
+    assert.equal(
+      parseWarnings.length,
+      0,
+      `parse warnings: ${parseWarnings.join('; ')}`,
+    );
+    assert.equal(ast.views.length, 10, 'dashboard.base should declare 10 views');
+
+    const { views, warnings: renderWarnings } = await renderBases(vault, ast, {
+      now: new Date('2026-05-13T00:00:00Z'),
+    });
+    assert.equal(views.length, 10);
+    assert.equal(
+      renderWarnings.length,
+      0,
+      `render warnings (dashboard.base is P0-only): ${renderWarnings.join('; ')}`,
+    );
+    for (const v of views) {
+      assert.equal(typeof v.name, 'string');
+      assert.ok(['table', 'list'].includes(v.type));
+      assert.ok(Array.isArray(v.pages));
+    }
+  } finally {
+    await cleanup(vault);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Static fixture cross-check — verify parseBaseFile + renderBases shape against
+// the small visualizer fixture so a future fixture rename surfaces here.
+// ---------------------------------------------------------------------------
+
+test('static fixture (visualizer-small-vault): basic filter + ext returns markdown pages', async () => {
+  const baseText = `
+filters:
+  and:
+    - file.inFolder("wiki")
+    - 'file.ext == "md"'
+views:
+  - type: list
+    name: "all md"
+`;
+  const { ast, warnings } = parseBaseFile(baseText);
+  assert.equal(warnings.length, 0);
+  const { views } = await renderBases(STATIC_FIXTURE_VAULT, ast);
+  assert.equal(views.length, 1);
+  assert.ok(views[0].pages.length >= 1, 'expected at least one .md page in static fixture');
+  for (const p of views[0].pages) {
+    assert.ok(p.rel.endsWith('.md'));
+  }
+});
+
+// ---------------------------------------------------------------------------
+// BasesParseError surface check.
+// ---------------------------------------------------------------------------
+
+test('parseBaseFile throws BasesParseError on filters without "and"', () => {
+  const text = `
+filters:
+  or:
+    - 'file.ext == "md"'
+`;
+  assert.throws(() => parseBaseFile(text), BasesParseError);
+});
+
+// ---------------------------------------------------------------------------
+// P1 Security boundary contract — RenderedView pages must NOT expose `abs`
+// (absolute filesystem path). Sprint 3 body 漏洩契約 + LEARN#9 inverse pinning
+// (assert on the *absence* of a field so a future walkPages widening surfaces here).
+// ---------------------------------------------------------------------------
+
+test('Security boundary: RenderedView pages do not expose `abs` or `body` (whitelist contract)', async () => {
+  const vault = await makeTempVault();
+  try {
+    const baseText = `
+views:
+  - type: list
+    name: "shape check"
+`;
+    const { ast } = parseBaseFile(baseText);
+    const { views } = await renderBases(vault, ast);
+    assert.ok(views[0].pages.length > 0);
+    const allowed = new Set(['rel', 'name', 'type', 'title', 'frontmatter', 'mtime', 'computed']);
+    for (const p of views[0].pages) {
+      for (const key of Object.keys(p)) {
+        assert.ok(
+          allowed.has(key),
+          `unexpected page field "${key}" leaked through RenderedView contract`,
+        );
+      }
+      assert.equal(p.abs, undefined, 'page.abs must not appear (filesystem layout leak)');
+      assert.equal(p.body, undefined, 'page.body must not appear (Sprint 3 contract)');
+      assert.equal(p.text, undefined, 'page.text must not appear');
+    }
+  } finally {
+    await cleanup(vault);
+  }
+});

--- a/tests/doctor.test.sh
+++ b/tests/doctor.test.sh
@@ -209,6 +209,30 @@ EOF
   (cd "${vault}" && git init --quiet 2>/dev/null) || true
 }
 
+# Same as init_full_vault, but adds an empty initial commit so
+# `check_sync_state` finds a `git log -1` timestamp. Sprint 4 Phase 4 PR B4.
+init_full_vault_with_commit() {
+  local vault="$1"
+  init_full_vault "${vault}"
+  (
+    cd "${vault}"
+    git -c user.email=test@local -c user.name=test \
+        commit --allow-empty -m "initial" --quiet 2>/dev/null
+  ) || true
+}
+
+# curl stub that always succeeds — used by EXIT-CODE-1/MODE-1 healthy-state
+# tests so the new check_sync_state network probe doesn't accidentally emit a
+# warn when the host happens to be offline. Sprint 4 Phase 4 PR B4.
+stub_curl_ok() {
+  local bin="$1"
+  cat >"${bin}/curl" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+  chmod +x "${bin}/curl"
+}
+
 # -----------------------------------------------------------------------------
 # BLUE-DOCTOR-ENV-1: OBSIDIAN_VAULT unset → fail
 # -----------------------------------------------------------------------------
@@ -616,7 +640,10 @@ test_exit_code_all_ok() {
   d="$(new_case "exit-all-ok")"
   stub_full_clis "${d}/bin"
   stub_node_18 "${d}/bin"
-  init_full_vault "${d}/vault"
+  stub_curl_ok "${d}/bin"
+  # Sprint 4 Phase 4 PR B4: check_sync_state now part of doctor flow — needs a
+  # real commit (for `git log -1`) and a curl stub (network probe).
+  init_full_vault_with_commit "${d}/vault"
 
   # Configure all hook configs and MCP configs so no fail/warn arises (other
   # than info-level checks that always pass).
@@ -769,6 +796,7 @@ test_install_mode_full() {
   d="$(new_case "mode-full")"
   stub_full_clis "${d}/bin"
   stub_node_18 "${d}/bin"
+  stub_curl_ok "${d}/bin"
   init_full_vault "${d}/vault"
 
   # Claude hook ok
@@ -935,6 +963,55 @@ EOF
 }
 
 # -----------------------------------------------------------------------------
+# BLUE-DOCTOR-SYNC-INT-1: check_sync_state is wired into the main flow
+#
+# Sprint 4 Phase 4 PR B4 integration assertion. Detailed scenario coverage
+# (healthy / pending-retry / network-unreachable) lives in
+# tests/sync-diagnostic.test.sh — this assertion exists solely to guard
+# against the `check_sync_state` call being dropped from doctor.sh's main()
+# in a future refactor (LEARN#5 cross-suite reference pinning).
+# -----------------------------------------------------------------------------
+test_sync_state_integrated() {
+  echo "BLUE-DOCTOR-SYNC-INT-1: check_sync_state lines appear in default doctor output"
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "  skip  jq not available"
+    return 0
+  fi
+  local d
+  d="$(new_case "sync-integrated")"
+  stub_full_clis "${d}/bin"
+  stub_node_18 "${d}/bin"
+  stub_curl_ok "${d}/bin"
+  init_full_vault_with_commit "${d}/vault"
+
+  # Pre-populate a retry queue with the production schema so the integration
+  # assertion also pins schema parity with hooks/sync-vault.mjs.
+  cat >"${d}/vault/.kioku-sync-retry.json" <<'EOF'
+{
+  "errorType": "auth",
+  "message": "permission denied (publickey)",
+  "firstAttempt": "2026-05-15T01:00:00.000Z",
+  "lastAttempt": "2026-05-15T02:00:00.000Z",
+  "retryCount": 1
+}
+EOF
+
+  local out
+  set +e
+  out="$(run_doctor "${d}" OBSIDIAN_VAULT="${d}/vault" 2>&1)"
+  set -e
+
+  assert_contains "${out}" "Last Vault commit:" \
+    "SYNC-INT-1: last commit line surfaces in integrated output"
+  assert_contains "${out}" "Pending sync retry queue" \
+    "SYNC-INT-1: pending retry line surfaces in integrated output"
+  assert_contains "${out}" "last error: auth" \
+    "SYNC-INT-1: errorType parsed from production-schema queue file"
+  assert_contains "${out}" "Network: github.com reachable" \
+    "SYNC-INT-1: network probe surfaces in integrated output"
+}
+
+# -----------------------------------------------------------------------------
 # Run all
 # -----------------------------------------------------------------------------
 test_env_unset
@@ -960,6 +1037,7 @@ test_install_mode_full
 test_install_mode_mcp_only
 test_install_mode_unknown
 test_install_mode_json
+test_sync_state_integrated
 
 echo ""
 echo "doctor.test.sh: ${PASS} passed, ${FAIL} failed"

--- a/tests/fixtures/test-helpers.mjs
+++ b/tests/fixtures/test-helpers.mjs
@@ -1,0 +1,195 @@
+// test-helpers.mjs — shared test fixtures across KIOKU test suites.
+//
+// Sprint 4 Phase 2 PR B2 (LEARN#8b N=3 extract: withoutQmd lived in 3 test files).
+// Sprint 4 Phase 3 PR C3 (LEARN#8b N=2 observation: mockMobileViewport shared
+//   across mobile-viz-simplified.test.mjs + mobile-performance-budget.test.mjs).
+// Sprint 4 Phase 4 PR B4 (LEARN#8b N=2 observation: mockGitPushFailure +
+//   readRetryQueue planned for sync-diagnostic.test.sh PATH-stub coverage +
+//   future hot-fix regression tests).
+
+import { existsSync } from 'node:fs';
+import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+/**
+ * Run `fn` with PATH neutralized so that the `qmd` binary is unreachable.
+ * Forces handleSearch (and any downstream that probes for qmd) to fall back
+ * to the in-process Node grep walker. Restores PATH in `finally` even on
+ * `fn` throw. Returns whatever `fn` returns.
+ *
+ * @template T
+ * @param {() => Promise<T>} fn
+ * @returns {Promise<T>}
+ */
+export async function withoutQmd(fn) {
+  const prev = process.env.PATH;
+  process.env.PATH = '/usr/bin:/bin:/usr/sbin:/sbin';
+  try {
+    return await fn();
+  } finally {
+    process.env.PATH = prev;
+  }
+}
+
+/**
+ * Install a Mobile viewport shim on globalThis (window + matchMedia) for tests
+ * that exercise viz-template.html JS in a Node 18+ stdlib-only environment.
+ * Returns a restore function — call it in `finally` to undo the shim.
+ *
+ * Note: this is a *minimal* shim, not a full DOM. It only provides
+ *   - global.window.innerWidth
+ *   - global.window.matchMedia(query) → { matches, addEventListener, removeEventListener }
+ * Tests that need DOM rendering should also load jsdom separately; but
+ * mockMobileViewport itself stays jsdom-free so quick `matchMedia` branch
+ * checks work without external deps.
+ *
+ * @param {number} width — viewport width in CSS px (default 375 = iPhone SE)
+ * @returns {() => void} restore function (idempotent)
+ */
+export function mockMobileViewport(width = 375) {
+  const prevWindow = globalThis.window;
+  const prevHasWindow = Object.prototype.hasOwnProperty.call(globalThis, 'window');
+  const shim = {
+    innerWidth: width,
+    matchMedia(query) {
+      const m = /\(\s*max-width:\s*(\d+)px\s*\)/i.exec(query || '');
+      const matches = m ? width <= Number(m[1]) : false;
+      return {
+        matches,
+        media: query,
+        addEventListener() {},
+        removeEventListener() {},
+        addListener() {},
+        removeListener() {},
+        onchange: null,
+        dispatchEvent() { return false; },
+      };
+    },
+  };
+  globalThis.window = shim;
+  let restored = false;
+  return function restore() {
+    if (restored) return;
+    restored = true;
+    if (prevHasWindow) {
+      globalThis.window = prevWindow;
+    } else {
+      delete globalThis.window;
+    }
+  };
+}
+
+/**
+ * PATH-stub that makes `git push` fail with a canned stderr matching one of
+ * the `classifyGitError` buckets. Other git subcommands (add/commit/diff/
+ * symbolic-ref/log/rev-parse/pull) are delegated to the real `git` so the
+ * test exercises the real `shouldRunPush` pre-flight + add/commit chain and
+ * only the terminal `push` fails.
+ *
+ * Usage:
+ *   const restore = await mockGitPushFailure('network');
+ *   try { await run(); } finally { await restore(); }
+ *
+ * @param {'network' | 'non-fast-forward' | 'auth'} errorType
+ * @returns {Promise<() => Promise<void>>} restore function (idempotent)
+ */
+export async function mockGitPushFailure(errorType) {
+  const errorMessages = {
+    'network': 'fatal: unable to access: Could not resolve host: github.com',
+    'non-fast-forward':
+      ' ! [rejected]        main -> main (non-fast-forward)\nerror: failed to push some refs',
+    'auth': 'fatal: Authentication failed for https://github.com/org/repo.git',
+  };
+  if (!Object.prototype.hasOwnProperty.call(errorMessages, errorType)) {
+    throw new Error(`mockGitPushFailure: unsupported errorType "${errorType}"`);
+  }
+
+  // Locate the real git binary BEFORE we shadow PATH so the stub can delegate
+  // every non-push subcommand. command -v inside the stub would otherwise loop
+  // back into the stub itself.
+  const realGit = await locateRealGit(process.env.PATH || '');
+  if (!realGit) {
+    throw new Error('mockGitPushFailure: real git not found on PATH');
+  }
+
+  const stubDir = await mkdtemp(join(tmpdir(), 'kioku-git-mock-'));
+  const stubGit = join(stubDir, 'git');
+  const stubScript = [
+    '#!/usr/bin/env bash',
+    `REAL_GIT=${shellQuote(realGit)}`,
+    'for arg in "$@"; do',
+    '  case "$arg" in',
+    '    push)',
+    `      echo ${shellQuote(errorMessages[errorType])} >&2`,
+    '      exit 1',
+    '      ;;',
+    '  esac',
+    'done',
+    'exec "$REAL_GIT" "$@"',
+    '',
+  ].join('\n');
+  await writeFile(stubGit, stubScript, 'utf8');
+  await chmod(stubGit, 0o755);
+
+  const prevPath = process.env.PATH;
+  process.env.PATH = `${stubDir}:${prevPath || ''}`;
+
+  let restored = false;
+  return async function restore() {
+    if (restored) return;
+    restored = true;
+    process.env.PATH = prevPath;
+    await rm(stubDir, { recursive: true, force: true });
+  };
+}
+
+/**
+ * Read and parse `.kioku-sync-retry.json` from a Vault path. Returns `null` if
+ * the file is missing or malformed (mirroring the contract of
+ * `readRetryQueue` in `hooks/sync-vault.mjs`). Thin wrapper so test code does
+ * not need to import the production helper just to peek at the queue file.
+ *
+ * @param {string} vaultPath — absolute path to the Vault directory
+ * @returns {Promise<object | null>}
+ */
+export async function readRetryQueue(vaultPath) {
+  const queuePath = join(vaultPath, '.kioku-sync-retry.json');
+  if (!existsSync(queuePath)) return null;
+  try {
+    const raw = await readFile(queuePath, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object') return parsed;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Quote a string for safe embedding in a single-quoted bash literal.
+ * Closes the quote, escapes a single quote, then reopens.
+ */
+function shellQuote(s) {
+  return "'" + String(s).replace(/'/g, "'\\''") + "'";
+}
+
+/**
+ * Walk PATH entries to find the first real `git` binary, ignoring directories
+ * we may have just injected (the stub dir starts with `kioku-git-mock-`).
+ */
+async function locateRealGit(pathEnv) {
+  const { stat: fsStat } = await import('node:fs/promises');
+  const entries = pathEnv.split(':').filter(Boolean);
+  for (const entry of entries) {
+    if (entry.includes('kioku-git-mock-')) continue;
+    const candidate = join(entry, 'git');
+    try {
+      const s = await fsStat(candidate);
+      if (s.isFile()) return candidate;
+    } catch {
+      // candidate absent — keep looking
+    }
+  }
+  return null;
+}

--- a/tests/fixtures/visualizer-vaults.mjs
+++ b/tests/fixtures/visualizer-vaults.mjs
@@ -15,7 +15,7 @@
 //   - LEARN#6 cross-boundary drift 回避: builder の output path は absolute、消費側は
 //     `await rm(vault, { recursive: true, force: true })` で必ず cleanup する責務。
 
-import { cp, mkdir, mkdtemp, readdir, writeFile, rm } from 'node:fs/promises';
+import { copyFile, cp, mkdir, mkdtemp, readdir, writeFile, rm } from 'node:fs/promises';
 import { spawn } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
@@ -24,6 +24,9 @@ import { fileURLToPath } from 'node:url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const EMPTY_FIXTURE_DIR = join(__dirname, 'visualizer-empty-vault');
 const SMALL_FIXTURE_DIR = join(__dirname, 'visualizer-small-vault');
+// Real repo source for dashboard.base — copied into small vault so shell
+// BLUE-WEBUI-SHELL-3 can render the canonical 10-view dashboard (Sprint 4 PR B).
+const DASHBOARD_BASE_SRC = join(__dirname, '..', '..', 'templates', 'wiki', 'meta', 'dashboard.base');
 
 // SAFE_CONFIG と同等の "侵害された .git/config を読まない" git 呼び出し。
 // builder は user vault 内で動かないので fsmonitor 脅威は低いが、CI / reviewer 安心のため
@@ -98,9 +101,22 @@ export async function cloneEmptyVault() {
 
 // Small vault: 5 wiki page + auto-lint report、2 commit (snapshot 切替確認可)。
 // 2nd commit は "concept の追記" として小さな update を加える (Diff view が空にならないため)。
+// Sprint 4 PR B: templates/wiki/meta/dashboard.base を vault 内に copy。
+// shell の Dashboard tab (PR A renderBases consumption) が fixture 上で動くようにする。
 export async function cloneSmallVault() {
   const vault = await bootstrapTmpVault(SMALL_FIXTURE_DIR, 'kioku-viz-fixture-small-');
   try {
+    // Copy dashboard.base into the fixture at the canonical location written by
+    // tools/claude-brain/scripts/setup-vault.sh:221-222 (`wiki/meta/dashboard.base`)
+    // so shell BLUE-WEBUI-SHELL-3 can render the canonical 10-view dashboard via
+    // PR A renderBases. Committed as a dedicated step between initial and the
+    // jwt update so downstream visualizer tests see a stable shape.
+    const baseDst = join(vault, 'wiki', 'meta', 'dashboard.base');
+    await mkdir(dirname(baseDst), { recursive: true });
+    await copyFile(DASHBOARD_BASE_SRC, baseDst);
+    await git(vault, ['add', 'wiki/meta/dashboard.base']);
+    await git(vault, ['commit', '-q', '-m', 'fixture: add dashboard.base for shell PR B']);
+
     // 2nd commit: jwt.md に小さい追記を加える (Diff 用)
     const jwtPath = join(vault, 'wiki', 'concepts', 'jwt.md');
     const updated = [

--- a/tests/install-hooks-codex.test.sh
+++ b/tests/install-hooks-codex.test.sh
@@ -114,10 +114,10 @@ else
   fail "IH-CODEX-GIT-SYNC-1: stage 1 unexpected: ${stage1_cmd}"
 fi
 
-if [[ "${stage2_cmd}" == *"git add wiki/ raw-sources/ templates/ CLAUDE.md"* ]]; then
-  ok "IH-CODEX-GIT-SYNC-1: stage 2 git-sync command present"
+if [[ "${stage2_cmd}" == *"sync-vault.mjs"*"--push"* ]]; then
+  ok "IH-CODEX-GIT-SYNC-1: stage 2 sync-vault.mjs --push invocation present"
 else
-  fail "IH-CODEX-GIT-SYNC-1: stage 2 missing expected git add pattern"
+  fail "IH-CODEX-GIT-SYNC-1: stage 2 missing expected sync-vault.mjs --push invocation"
 fi
 
 # single source of truth check (PM A3 指示): install-hooks.sh Claude SessionEnd

--- a/tests/install-hooks-gemini.test.sh
+++ b/tests/install-hooks-gemini.test.sh
@@ -99,12 +99,14 @@ else
   fail "IH-GEMINI-5: SessionEnd has ${session_end_count} hooks (expected 2)"
 fi
 
-# git add pattern が Claude install-hooks.sh と byte-identical (LEARN#9 single source of truth)
+# Sprint 4 Phase 4 PR A4: sync-vault.mjs --push invocation が Claude install-hooks.sh と
+# byte-identical (LEARN#9 single source of truth、git add/commit/push ロジック自体は
+# hooks/sync-vault.mjs に集約済)
 git_sync_cmd="$(jq -r '.hooks.SessionEnd[0].hooks[1].command' "${GEMINI_SETTINGS_FILE}")"
-if [[ "${git_sync_cmd}" == *"git add wiki/ raw-sources/ templates/ CLAUDE.md"* ]]; then
-  ok "IH-GEMINI-5: git-sync command matches install-hooks.sh Claude SessionEnd (single source of truth)"
+if [[ "${git_sync_cmd}" == *"sync-vault.mjs"*"--push"* ]]; then
+  ok "IH-GEMINI-5: sync-vault.mjs --push invocation matches install-hooks.sh Claude SessionEnd (single source of truth)"
 else
-  fail "IH-GEMINI-5: git-sync command diverged from Claude version"
+  fail "IH-GEMINI-5: sync-vault.mjs --push invocation diverged from Claude version"
 fi
 
 # -----------------------------------------------------------------------------

--- a/tests/install-hooks.test.sh
+++ b/tests/install-hooks.test.sh
@@ -115,26 +115,30 @@ else
   fail "SessionEnd should have two chained entries"
 fi
 
-# SessionStart should have 2 entries (git pull + wiki-context-injector)
+# SessionStart should have 2 entries (sync-vault --pull-and-retry + wiki-context-injector)
 if node -e "const j=require('${tmpjson}'); process.exit(j.hooks.SessionStart.length===2?0:1)"; then
   pass "SessionStart has two chained entries"
 else
-  fail "SessionStart should have two chained entries (git pull + injector)"
+  fail "SessionStart should have two chained entries (sync-vault --pull-and-retry + injector)"
 fi
 
-if node -e "const j=require('${tmpjson}'); const cmds=j.hooks.SessionStart.map(e=>e.hooks[0].command).join(' '); process.exit(/git pull/.test(cmds) && /wiki-context-injector\.mjs/.test(cmds) ? 0 : 1)"; then
-  pass "SessionStart includes git pull and wiki-context-injector.mjs"
+# Sprint 4 Phase 4 PR A4 (2026-05-15): inline `git pull` シェルは hooks/sync-vault.mjs
+# --pull-and-retry に migrate (retry queue drain を統合)。SessionStart 第 1 段は
+# sync-vault.mjs --pull-and-retry、第 2 段は従来通り wiki-context-injector.mjs。
+if node -e "const j=require('${tmpjson}'); const cmds=j.hooks.SessionStart.map(e=>e.hooks[0].command).join(' '); process.exit(/sync-vault\.mjs.*--pull-and-retry/.test(cmds) && /wiki-context-injector\.mjs/.test(cmds) ? 0 : 1)"; then
+  pass "SessionStart includes sync-vault.mjs --pull-and-retry and wiki-context-injector.mjs"
 else
-  fail "SessionStart should include both git pull and wiki-context-injector.mjs"
+  fail "SessionStart should include both sync-vault.mjs --pull-and-retry and wiki-context-injector.mjs"
 fi
 
-# v0.4.0 Tier A#2 (2026-04-21): SessionEnd の git one-liner に detached HEAD ガード
-# (git symbolic-ref -q HEAD) が含まれていること。detached 状態で commit が貯まって
-# push 失敗 → ローカル drift する regression を防ぐため。
-if node -e "const j=require('${tmpjson}'); const gitCmd=j.hooks.SessionEnd[1].hooks[0].command; process.exit(/git symbolic-ref -q HEAD/.test(gitCmd) ? 0 : 1)"; then
-  pass "SessionEnd git one-liner has detached HEAD guard (git symbolic-ref -q HEAD)"
+# v0.4.0 Tier A#2 (2026-04-21) + Sprint 4 Phase 4 PR A4 (2026-05-15): detached HEAD
+# ガードは hooks/sync-vault.mjs の shouldRunPush() に移行 (shell から Node 側へ集約)。
+# regression は unit test tests/sync-retry.test.mjs BLUE-SYNC-A4-4 で保護。
+# 本 install-hooks test は SessionEnd[1] が sync-vault.mjs --push を呼ぶことを確認する。
+if node -e "const j=require('${tmpjson}'); const gitCmd=j.hooks.SessionEnd[1].hooks[0].command; process.exit(/sync-vault\.mjs.*--push/.test(gitCmd) ? 0 : 1)"; then
+  pass "SessionEnd second hook invokes sync-vault.mjs --push (detached HEAD guard moved to shouldRunPush)"
 else
-  fail "SessionEnd git one-liner missing 'git symbolic-ref -q HEAD' guard (v0.4.0 Tier A#2 regression)"
+  fail "SessionEnd second hook should invoke sync-vault.mjs --push (Sprint 4 Phase 4 PR A4 migration)"
 fi
 
 # -----------------------------------------------------------------------------
@@ -244,7 +248,7 @@ JSON
   user_len=$(jq '.hooks.UserPromptSubmit | length' "${APPLY_TARGET}")
   assert_eq "2" "${user_len}" "--apply appended to existing UserPromptSubmit array (preserved user's entry)"
 
-  # SessionStart has 2 (git pull + injector)
+  # SessionStart has 2 (sync-vault --pull-and-retry + injector)
   ss_len=$(jq '.hooks.SessionStart | length' "${APPLY_TARGET}")
   assert_eq "2" "${ss_len}" "--apply SessionStart has 2 entries"
 

--- a/tests/mcp/tools-ingest-pdf.test.mjs
+++ b/tests/mcp/tools-ingest-pdf.test.mjs
@@ -210,11 +210,13 @@ describe('kioku_ingest_pdf', { skip: !HAS_POPPLER ? 'poppler not installed' : fa
     assert.ok(logStat.isFile(), 'per-vault detached log file should exist');
 
     // detached stub claude は shared stubClaudeLog に追記する。polling で確認。
+    // env section は ARGV の後に書かれるので、`--- end env ---` marker で wait する
+    // (ARGV: -p で break すると env がまだ flush されておらず race で fail する)。
     let sharedLog = '';
-    for (let i = 0; i < 40; i++) {
+    for (let i = 0; i < 80; i++) {
       await new Promise((r) => setTimeout(r, 25));
       sharedLog = await readFile(stubClaudeLog, 'utf8');
-      if (sharedLog.includes('ARGV: -p')) break;
+      if (sharedLog.includes('--- end env ---')) break;
     }
     assert.match(sharedLog, /ARGV: -p/,
       `detached claude stub should log its invocation, got: ${sharedLog.slice(0, 200)}`);

--- a/tests/mcp/tools-search.test.mjs
+++ b/tests/mcp/tools-search.test.mjs
@@ -128,4 +128,45 @@ echo "[]"
       assert.deepEqual(r.results, []);
     });
   });
+
+  // Sprint 4 Phase 2 PR A2: intent param (qmd disambiguation hint)。
+  // qmd subprocess の argv を file 経由で capture して --intent flag の presence/absence を verify。
+  test('MCP11 passes intent flag to qmd subprocess when provided', async () => {
+    const argvLog = join(await mkdtemp(join(tmpdir(), 'kioku-argv-')), 'argv.log');
+    const stub = `#!/usr/bin/env bash
+printf '%s\\n' "$@" > "${argvLog}"
+echo "[]"
+`;
+    await withQmdStub(stub, async () => {
+      await handleSearch(vault, { query: 'foo', mode: 'lex', intent: 'optimize for recent docs' });
+    });
+    const { readFile } = await import('node:fs/promises');
+    const captured = await readFile(argvLog, 'utf8');
+    assert.match(captured, /--intent/);
+    assert.match(captured, /optimize for recent docs/);
+    // positional query は最後の line
+    const lines = captured.trim().split('\n');
+    assert.equal(lines[lines.length - 1], 'foo');
+  });
+
+  test('MCP12 omits intent flag when intent param is undefined or empty', async () => {
+    const argvLog = join(await mkdtemp(join(tmpdir(), 'kioku-argv-')), 'argv.log');
+    const stub = `#!/usr/bin/env bash
+printf '%s\\n' "$@" > "${argvLog}"
+echo "[]"
+`;
+    await withQmdStub(stub, async () => {
+      await handleSearch(vault, { query: 'foo', mode: 'lex' }); // no intent
+    });
+    const { readFile } = await import('node:fs/promises');
+    const captured = await readFile(argvLog, 'utf8');
+    assert.doesNotMatch(captured, /--intent/);
+
+    // empty string も skip 扱い
+    await withQmdStub(stub, async () => {
+      await handleSearch(vault, { query: 'foo', mode: 'lex', intent: '   ' });
+    });
+    const captured2 = await readFile(argvLog, 'utf8');
+    assert.doesNotMatch(captured2, /--intent/);
+  });
 });

--- a/tests/mcp/visualizer.test.mjs
+++ b/tests/mcp/visualizer.test.mjs
@@ -337,6 +337,116 @@ describe('kioku_generate_viz (Phase D α V-2)', () => {
     }
   });
 
+  test('VIZ-T11: mode=shell generates KIOKU Web UI shell HTML (Sprint 4 Phase 1)', async () => {
+    if (!gitAvailable) return;
+    const root = await makeFixtureVault();
+    try {
+      // Install the default .base so the shell Dashboard tab has source content.
+      await mkdir(join(root, 'wiki', 'meta'), { recursive: true });
+      await writeFile(
+        join(root, 'wiki', 'meta', 'dashboard.base'),
+        'views:\n  - type: list\n    name: "All pages"\n',
+        'utf8',
+      );
+      const result = await handleGenerateViz(root, { mode: 'shell' });
+      assert.equal(result.mode, 'shell');
+      assert.match(result.path, /\.cache\/viz\/wiki-graph\.html$/);
+      const html = await readFile(result.path, 'utf8');
+      // shell-specific markers (mirrors web-ui-shell + shell-template contract)
+      assert.match(html, /id="kioku-shell-data"/, 'shell-data script block present');
+      assert.match(html, /id="tab-dashboard"/, 'Dashboard tab control present');
+      // shell embeds the visualizer body inline via the <template id="kioku-viz-body">
+      assert.match(html, /id="kioku-viz-body"/, 'embedded viz body template present');
+      // Verify the inline shell JSON has mode=snapshot + default_tab=dashboard
+      const m = html.match(/<script id="kioku-shell-data" type="application\/json">([\s\S]*?)<\/script>/);
+      assert.ok(m, 'kioku-shell-data inline JSON missing');
+      const parsed = JSON.parse(m[1]);
+      assert.equal(parsed.shell_meta.default_tab, 'dashboard');
+      assert.equal(parsed.shell_meta.mode, 'snapshot');
+      // visualizer data layer is bundled inside the shell JSON
+      assert.ok(parsed.visualizer && Array.isArray(parsed.visualizer.snapshots));
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('VIZ-T12: mode=snapshot (default) preserves Sprint 3 backward compat', async () => {
+    if (!gitAvailable) return;
+    const root = await makeFixtureVault();
+    try {
+      const result = await handleGenerateViz(root, {});
+      // Sprint 3 既存 caller は mode field を含まない返り値を期待 (additive な field 追加は OK)
+      assert.ok(!result.mode || result.mode === 'snapshot');
+      assert.deepEqual(result.views, ['overview', 'timeline-player', 'diff-viewer', 'lineage']);
+      const html = await readFile(result.path, 'utf8');
+      // Sprint 3 marker (Phase 4 Quality notes drawer)
+      assert.match(html, /id="ov-quality-notes"/);
+      // shell-only markers MUST NOT leak into snapshot HTML
+      assert.ok(!html.includes('id="kioku-shell-data"'), 'shell-data block must not appear in snapshot mode');
+      assert.ok(!html.includes('id="tab-dashboard"'), 'Dashboard tab must not appear in snapshot mode');
+      // Sprint 3 inline JSON marker is preserved
+      assert.match(html, /<script type="application\/json" id="kioku-data">/);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('VIZ-T13: mode=shell with base_source override loads custom .base file', async () => {
+    if (!gitAvailable) return;
+    const root = await makeFixtureVault();
+    try {
+      await mkdir(join(root, 'wiki', 'custom-views'), { recursive: true });
+      await writeFile(
+        join(root, 'wiki', 'custom-views', 'custom.base'),
+        'views:\n  - type: list\n    name: "Custom override view"\n',
+        'utf8',
+      );
+      const result = await handleGenerateViz(root, {
+        mode: 'shell',
+        base_source: 'wiki/custom-views/custom.base',
+      });
+      assert.equal(result.mode, 'shell');
+      const html = await readFile(result.path, 'utf8');
+      const m = html.match(/<script id="kioku-shell-data" type="application\/json">([\s\S]*?)<\/script>/);
+      assert.ok(m, 'shell-data inline JSON missing');
+      const parsed = JSON.parse(m[1]);
+      assert.equal(parsed.dashboard.base_source, 'wiki/custom-views/custom.base',
+        'dashboard.base_source reflects override');
+      // The override path must NOT collide with the default — proves the override took effect
+      assert.notEqual(parsed.dashboard.base_source, 'wiki/meta/dashboard.base');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('VIZ-T14: existing path 100% regression — mode unset and mode="snapshot" produce bit-equal HTML (zero regression critical gate)', async () => {
+    if (!gitAvailable) return;
+    const root = await makeFixtureVault();
+    try {
+      // Generate twice via the same vault: once without mode (Sprint 3 caller), once with explicit 'snapshot'.
+      // The two callers MUST hit the same code path → byte-equal HTML after normalizing the wall-clock timestamp.
+      const r1 = await handleGenerateViz(root, {});
+      const html1 = await readFile(r1.path, 'utf8');
+      const r2 = await handleGenerateViz(root, { mode: 'snapshot' });
+      const html2 = await readFile(r2.path, 'utf8');
+
+      // Only "generated_at" (top-level wall clock at function entry) is allowed to drift between calls.
+      // All other fields are derived from the same fixture state → must be byte-identical.
+      const normalize = (s) => s.replace(/"generated_at":"[^"]+"/g, '"generated_at":"<NORMALIZED>"');
+      assert.equal(
+        normalize(html1),
+        normalize(html2),
+        'mode unset and mode="snapshot" must produce byte-equal HTML (zero regression for existing callers)',
+      );
+
+      // Belt-and-suspenders: shell-mode markers must not bleed into snapshot output on either side.
+      assert.ok(!html1.includes('id="kioku-shell-data"'));
+      assert.ok(!html2.includes('id="kioku-shell-data"'));
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   test('VIZ-T10: Phase 3 lineage graph embeds 3-layer nodes + 5 edge kinds + HTML tab/CSS', async () => {
     if (!gitAvailable) return;
     const root = await makeFixtureVault();
@@ -398,6 +508,66 @@ describe('kioku_generate_viz (Phase D α V-2)', () => {
       // JS render path
       assert.match(html, /renderLineage\s*\(/, 'renderLineage JS function called');
       assert.match(html, /estimated lineage/, 'best-effort disclosure text in JS');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('VIZ-T15: viz-template.html に applySearchHighlight 関数 + kioku-viz-highlighted CSS + hashchange listener が含まれる (Sprint 4 Phase 2 PR C2)', async () => {
+    if (!gitAvailable) return;
+    const root = await makeFixtureVault();
+    try {
+      const result = await handleGenerateViz(root, {});
+      const html = await readFile(result.path, 'utf8');
+      // helper function name の literal 存在 (impl が削除されたら red)
+      assert.match(html, /function applySearchHighlight\b/, 'applySearchHighlight helper function must be defined in snapshot HTML');
+      // highlight CSS class が CSS section に存在
+      assert.match(html, /\.kioku-viz-highlighted\b/, 'kioku-viz-highlighted CSS rule must be present');
+      // hashchange listener が登録される
+      assert.match(html, /addEventListener\(["']hashchange["']/, 'hashchange listener must be wired');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('VIZ-T16: URL fragment #q=<query> で highlight ロジックが適切な node を選ぶ (string-level verify、jsdom 不要)', async () => {
+    if (!gitAvailable) return;
+    const root = await makeFixtureVault();
+    try {
+      const result = await handleGenerateViz(root, {});
+      const html = await readFile(result.path, 'utf8');
+      // helper 本体が SVG `g.node` selector を使う (実コードと整合)
+      assert.match(html, /querySelectorAll\(["']g\.node["']\)/, 'applySearchHighlight must select g.node elements');
+      // label includes match logic を含む
+      assert.match(html, /label\.toLowerCase\(\)\.includes\(needle\)/, 'case-insensitive substring match logic must be present');
+      // highlight class toggle
+      assert.match(html, /classList\.add\(["']kioku-viz-highlighted["']\)/, 'kioku-viz-highlighted class toggle must be present');
+      // clear prior highlights so hashchange does not accumulate stale matches (PR C2 code review fix)
+      assert.match(html, /classList\.remove\(["']kioku-viz-highlighted["']\)/, 'previous kioku-viz-highlighted must be cleared on each apply (hashchange stale-state guard)');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('VIZ-T17: shell-template.html の Search tab result item に "view in graph" deep-link が含まれる (Sprint 4 Phase 2 PR C2)', async () => {
+    if (!gitAvailable) return;
+    const root = await makeFixtureVault();
+    try {
+      // Install dashboard.base so shell mode renders fully
+      await mkdir(join(root, 'wiki', 'meta'), { recursive: true });
+      await writeFile(
+        join(root, 'wiki', 'meta', 'dashboard.base'),
+        'views:\n  - type: list\n    name: "All pages"\n',
+        'utf8',
+      );
+      const result = await handleGenerateViz(root, { mode: 'shell' });
+      const html = await readFile(result.path, 'utf8');
+      // deep-link to viz HTML with fragment query encoding
+      assert.match(html, /visualizer-graph\.html#q=/, 'deep-link to visualizer-graph.html#q= must be in shell renderSearch');
+      // anchor element with class for styling
+      assert.match(html, /['"]search-view-graph['"]/, 'search-view-graph class must be present on the link');
+      // encodeURIComponent must be used to safely pass query
+      assert.match(html, /encodeURIComponent\(q\.query\)/, 'q.query must be URL-encoded');
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/tests/mobile-performance-budget.test.mjs
+++ b/tests/mobile-performance-budget.test.mjs
@@ -1,0 +1,126 @@
+// tests/mobile-performance-budget.test.mjs — Sprint 4 Phase 3 PR C3
+//   Performance budget + VIZ-T14 bit-equal contract (production code 0 line 変更)
+//
+// plan 26051405 §「Performance budget 削減」 (L374-380) + §「VIZ-T14 bit-equal
+// contract と Phase 3 互換性」 (L425-430) canonical impl spec を test に codify。
+//
+// Test prefixes (BLUE-MOBILE-C3-* namespace、LEARN#8a per-file scope = F1 から、
+// 続番 C3-4..5 は plan の test ID 体系に対応):
+//   - BLUE-MOBILE-C3-4 : shell-template.html + viz-template.html が performance
+//                        budget (300KB target) を満たす
+//   - BLUE-MOBILE-C3-5 : VIZ-T14 bit-equal contract 物理保証 = Mobile 系追加が
+//                        production code (visualizer.mjs / web-ui-shell.mjs)
+//                        に 1 行も染み出していない (mockMobileViewport /
+//                        renderMobileFallback / window.matchMedia いずれも
+//                        production code に存在しない)
+//
+// 設計方針:
+//   - Node 18+ stdlib のみ (fs/promises + path)
+//   - LEARN#5 cross-suite: tests/fixtures/test-helpers.mjs の mockMobileViewport
+//     を import せず name-only string check で済ます (= helper 移動・rename にも
+//     production code "境界外" 性質が壊れないこと自体を pinning)
+//   - LEARN#13: regex literal は ASCII のみ、U+2028/2029/200B/FEFF 不使用
+//
+// note: PR A3 段階で shell HTML 30KB / viz HTML 73KB に着地済、300KB target に
+// 対して大幅 headroom。本 budget test は「将来の minification 撤回 / 大型機能で
+// budget を超過しないこと」の regression guard として機能する。
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile, stat } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
+
+const moduleFilePath = fileURLToPath(import.meta.url);
+const moduleDir = dirname(moduleFilePath);
+const CB_ROOT = resolve(moduleDir, '..');
+
+const PATHS = {
+  shellTemplate: join(CB_ROOT, 'mcp', 'templates', 'shell-template.html'),
+  vizTemplate: join(CB_ROOT, 'mcp', 'templates', 'viz-template.html'),
+  visualizerMjs: join(CB_ROOT, 'mcp', 'tools', 'visualizer.mjs'),
+  webUiShellMjs: join(CB_ROOT, 'mcp', 'lib', 'web-ui-shell.mjs'),
+};
+
+// plan 26051405 §Performance budget canonical target (461KB → 300KB)
+const BUDGET_BYTES = 300 * 1024; // 307200
+
+describe('Sprint 4 Phase 3 PR C3 — Performance budget + VIZ-T14 bit-equal contract', () => {
+  test('BLUE-MOBILE-C3-4: shell + viz templates are within 300KB performance budget', async () => {
+    const shellStat = await stat(PATHS.shellTemplate);
+    const vizStat = await stat(PATHS.vizTemplate);
+
+    assert.ok(
+      shellStat.size < BUDGET_BYTES,
+      'expected: shell-template.html size < ' + BUDGET_BYTES + ' bytes (300KB target)\n' +
+        'found: ' + shellStat.size + ' bytes (' + (shellStat.size / 1024).toFixed(1) + 'KB)\n' +
+        'fix: trim shell-template.html per plan 26051405 §Performance budget 削減'
+    );
+    assert.ok(
+      vizStat.size < BUDGET_BYTES,
+      'expected: viz-template.html size < ' + BUDGET_BYTES + ' bytes (300KB target)\n' +
+        'found: ' + vizStat.size + ' bytes (' + (vizStat.size / 1024).toFixed(1) + 'KB)\n' +
+        'fix: trim viz-template.html per plan 26051405 §Performance budget 削減'
+    );
+
+    // 合算 budget も明示 (両 HTML が同 wiki view で隣接 load される運用想定)
+    const combined = shellStat.size + vizStat.size;
+    assert.ok(
+      combined < BUDGET_BYTES * 2,
+      'expected: shell + viz combined size < ' + (BUDGET_BYTES * 2) + ' bytes (2x budget)\n' +
+        'found: ' + combined + ' bytes (' + (combined / 1024).toFixed(1) + 'KB)\n' +
+        'fix: investigate if both templates grew jointly'
+    );
+  });
+
+  test('BLUE-MOBILE-C3-5: VIZ-T14 bit-equal contract preserved = Mobile additions did not leak into production code (visualizer.mjs / web-ui-shell.mjs)', async () => {
+    const vizMjs = await readFile(PATHS.visualizerMjs, 'utf-8');
+    const shellMjs = await readFile(PATHS.webUiShellMjs, 'utf-8');
+
+    // PR C3 で導入した Mobile 専用 identifier 群が production code に染み出して
+    // いないことを shape-level で pinning。これにより
+    //   - VIZ-T14 (tests/mcp/visualizer.test.mjs L422) の "mode unset と
+    //     mode='snapshot' で bit-equal HTML" 契約が物理的に保証される
+    //   - 将来 Mobile 機能を template から production code に押し戻す refactor が
+    //     入った時、本 test が失敗 → VIZ-T14 baseline 更新 / 影響評価を促す
+    //
+    // production code に対する forbidden keyword list (PR C3 scope の Mobile 系):
+    const FORBIDDEN_IN_PRODUCTION = [
+      'renderMobileFallback',         // viz-template 専用関数
+      'mockMobileViewport',           // test helper 専用
+      'visualizer-graph-mobile-fallback', // CSS class、template scope のみ
+      'kioku-mobile-menu-button',     // shell-template の hamburger button class (PR A3)
+    ];
+
+    for (const keyword of FORBIDDEN_IN_PRODUCTION) {
+      assert.ok(
+        !vizMjs.includes(keyword),
+        'expected: 0 occurrence of "' + keyword + '" in mcp/tools/visualizer.mjs\n' +
+          'found: keyword leaked into production code\n' +
+          'fix: keep Mobile logic in templates only per VIZ-T14 bit-equal contract\n' +
+          '     (plan 26051405 §VIZ-T14 bit-equal contract と Phase 3 互換性 line 430)'
+      );
+      assert.ok(
+        !shellMjs.includes(keyword),
+        'expected: 0 occurrence of "' + keyword + '" in mcp/lib/web-ui-shell.mjs\n' +
+          'found: keyword leaked into production code\n' +
+          'fix: keep Mobile logic in templates only per VIZ-T14 bit-equal contract'
+      );
+    }
+
+    // window.matchMedia は production code (Node 上で eval される code path) では
+    // 意味が無い (window 不在の Node runtime)。template に閉じていることを別途確認。
+    assert.ok(
+      !vizMjs.includes('window.matchMedia'),
+      'expected: 0 occurrence of "window.matchMedia" in mcp/tools/visualizer.mjs\n' +
+        'found: browser-only API present in Node-side module\n' +
+        'fix: matchMedia is browser-only, keep it in viz-template.html <script>'
+    );
+    assert.ok(
+      !shellMjs.includes('window.matchMedia'),
+      'expected: 0 occurrence of "window.matchMedia" in mcp/lib/web-ui-shell.mjs\n' +
+        'found: browser-only API present in Node-side module\n' +
+        'fix: matchMedia is browser-only, keep it in shell-template.html <script>'
+    );
+  });
+});

--- a/tests/mobile-responsive.test.mjs
+++ b/tests/mobile-responsive.test.mjs
@@ -1,0 +1,165 @@
+// tests/mobile-responsive.test.mjs — Sprint 4 Phase 3 PR A3 Mobile responsive CSS + Layout
+//
+// Targets: shell-template.html + viz-template.html の responsive 化を機械的に verify。
+//          plan 26051405 §「PR A3」L120-235 の canonical impl spec を test に codify。
+//
+// Test prefixes (BLUE-MOBILE-A3-* namespace, per LEARN#8a per-file scope = F1 から):
+//   - BLUE-MOBILE-A3-1 : shell-template.html に viewport meta tag が存在
+//   - BLUE-MOBILE-A3-2 : shell-template.html + viz-template.html に
+//                        @media (max-width: 767px) query が存在
+//   - BLUE-MOBILE-A3-3 : tap target 44pt+ CSS が全 interactive element
+//                        (button, a, input, select) に適用
+//   - BLUE-MOBILE-A3-4 : hamburger menu button (.kioku-mobile-menu-button) が
+//                        shell-template.html に存在、aria-label + aria-expanded 付き
+//   - BLUE-MOBILE-A3-5 : viz-template.html に .visualizer-graph-mobile-fallback
+//                        section が存在
+//
+// 設計方針:
+//   - Node 18+ stdlib のみ (外部依存なし、jsdom 不要)
+//   - file content の string check (regex match) で OK、Mobile rendering test は
+//     PR C3 で test-helpers.mjs に mockMobileViewport 追加後
+//   - error message は「expected: X / found: Y / fix: Z」形式
+//
+// LEARN#13 注意: regex literal に U+2028 / U+2029 / U+200B / U+FEFF を直接書かない。
+// 本 file は ASCII のみで constructed regex を使う。
+// LEARN#14: import 経由で test framework が load する → ESM entry gate 不要。
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
+
+const moduleFilePath = fileURLToPath(import.meta.url);
+const moduleDir = dirname(moduleFilePath);
+const CB_ROOT = resolve(moduleDir, '..'); // tools/claude-brain/
+
+const PATHS = {
+  shellTemplate: join(CB_ROOT, 'mcp', 'templates', 'shell-template.html'),
+  vizTemplate: join(CB_ROOT, 'mcp', 'templates', 'viz-template.html'),
+};
+
+async function readShell() {
+  return readFile(PATHS.shellTemplate, 'utf-8');
+}
+
+async function readViz() {
+  return readFile(PATHS.vizTemplate, 'utf-8');
+}
+
+describe('Sprint 4 Phase 3 PR A3 — Mobile responsive CSS + Layout', () => {
+  test('BLUE-MOBILE-A3-1: shell-template.html has viewport meta tag', async () => {
+    const html = await readShell();
+    // viewport meta tag は head 内に必須
+    // 期待 pattern: <meta name="viewport" content="...width=device-width...">
+    const viewportRe = /<meta\s+name=["']viewport["']\s+content=["'][^"']*width=device-width[^"']*["']\s*\/?>/i;
+    assert.ok(
+      viewportRe.test(html),
+      'expected: <meta name="viewport" content="width=device-width, ...">\n' +
+        'found: no viewport meta tag matching pattern\n' +
+        'fix: add viewport meta to shell-template.html <head> per plan 26051405 §PR A3'
+    );
+  });
+
+  test('BLUE-MOBILE-A3-2: shell + viz templates have @media (max-width: 767px) query', async () => {
+    const shellHtml = await readShell();
+    const vizHtml = await readViz();
+    // breakpoint < 768px = max-width: 767px、CSS spec 上 hot path
+    const mediaRe = /@media\s*\(\s*max-width:\s*767px\s*\)/;
+    assert.ok(
+      mediaRe.test(shellHtml),
+      'expected: @media (max-width: 767px) in shell-template.html\n' +
+        'found: no Mobile breakpoint media query\n' +
+        'fix: add @media (max-width: 767px) { ... } per plan 26051405 §PR A3 line 141'
+    );
+    assert.ok(
+      mediaRe.test(vizHtml),
+      'expected: @media (max-width: 767px) in viz-template.html\n' +
+        'found: no Mobile breakpoint media query\n' +
+        'fix: add @media (max-width: 767px) { ... } per plan 26051405 §PR A3 line 186'
+    );
+  });
+
+  test('BLUE-MOBILE-A3-3: tap target 44pt+ enforcement on button/a/input/select', async () => {
+    const html = await readShell();
+    // plan canonical pattern: `button, a, input, select { min-width: 44px; min-height: 44px; }`
+    // tolerate whitespace / minor ordering variations.
+    // 検出: 4 selector を含む rule で min-width:44px + min-height:44px が同居
+    // selector の順不同を許容するため、interactive element を一つずつ assert
+    const interactiveSelectors = ['button', 'a', 'input', 'select'];
+    // 期待: 1 rule で button, a, input, select 全部含む selector list + 44px tap target
+    const tapTargetRuleRe =
+      /(?:button|a|input|select)\s*,\s*(?:button|a|input|select)\s*,\s*(?:button|a|input|select)\s*,\s*(?:button|a|input|select)\s*\{[^}]*min-width:\s*44px[^}]*min-height:\s*44px[^}]*\}/;
+    const altRe =
+      /(?:button|a|input|select)\s*,\s*(?:button|a|input|select)\s*,\s*(?:button|a|input|select)\s*,\s*(?:button|a|input|select)\s*\{[^}]*min-height:\s*44px[^}]*min-width:\s*44px[^}]*\}/;
+    assert.ok(
+      tapTargetRuleRe.test(html) || altRe.test(html),
+      'expected: rule like `button, a, input, select { min-width: 44px; min-height: 44px; }`\n' +
+        'found: no combined tap target rule covering 4 interactive elements\n' +
+        'fix: add tap target enforcement rule per plan 26051405 §PR A3 line 169-172'
+    );
+    // sanity: 各 interactive selector が CSS に登場するか個別確認
+    for (const sel of interactiveSelectors) {
+      // sel 単体での CSS 出現 (rule 内 selector list の一員として)
+      const selPresenceRe = new RegExp(`(^|[,\\s\\{])${sel}(\\s*,|\\s*\\{)`, 'm');
+      assert.ok(
+        selPresenceRe.test(html),
+        `expected: '${sel}' selector present in shell-template.html CSS\n` +
+          `found: no occurrence\n` +
+          `fix: include '${sel}' in tap target rule`
+      );
+    }
+  });
+
+  test('BLUE-MOBILE-A3-4: hamburger menu button exists with aria-label + aria-expanded', async () => {
+    const html = await readShell();
+    // class="kioku-mobile-menu-button" を持つ <button> element
+    const buttonRe = /<button[^>]*class=["'][^"']*kioku-mobile-menu-button[^"']*["'][^>]*>/i;
+    assert.ok(
+      buttonRe.test(html),
+      'expected: <button class="kioku-mobile-menu-button" ...>\n' +
+        'found: no hamburger menu button\n' +
+        'fix: add hamburger button per plan 26051405 §PR A3 line 175-178'
+    );
+    // aria-label 属性
+    const ariaLabelRe = /<button[^>]*class=["'][^"']*kioku-mobile-menu-button[^"']*["'][^>]*aria-label=/i;
+    const ariaLabelAltRe = /<button[^>]*aria-label=[^>]*class=["'][^"']*kioku-mobile-menu-button/i;
+    assert.ok(
+      ariaLabelRe.test(html) || ariaLabelAltRe.test(html),
+      'expected: aria-label attribute on hamburger button\n' +
+        'found: button without aria-label\n' +
+        'fix: add aria-label="Toggle menu" per plan 26051405 §PR A3'
+    );
+    // aria-expanded 属性 (初期 false)
+    const ariaExpandedRe = /<button[^>]*class=["'][^"']*kioku-mobile-menu-button[^"']*["'][^>]*aria-expanded=/i;
+    const ariaExpandedAltRe = /<button[^>]*aria-expanded=[^>]*class=["'][^"']*kioku-mobile-menu-button/i;
+    assert.ok(
+      ariaExpandedRe.test(html) || ariaExpandedAltRe.test(html),
+      'expected: aria-expanded attribute on hamburger button\n' +
+        'found: button without aria-expanded\n' +
+        'fix: add aria-expanded="false" per plan 26051405 §PR A3'
+    );
+  });
+
+  test('BLUE-MOBILE-A3-5: viz-template.html has .visualizer-graph-mobile-fallback section', async () => {
+    const html = await readViz();
+    // section element with class visualizer-graph-mobile-fallback OR
+    // div with that class (plan is flexible: "section 配置のみ")
+    const fallbackRe =
+      /<(?:section|div)[^>]*class=["'][^"']*visualizer-graph-mobile-fallback[^"']*["'][^>]*>/i;
+    assert.ok(
+      fallbackRe.test(html),
+      'expected: <section class="visualizer-graph-mobile-fallback"> or <div ...> in viz-template.html\n' +
+        'found: no Mobile fallback section\n' +
+        'fix: add fallback section per plan 26051405 §PR A3 line 190-200 (PR C3 で renderMobileFallback で content 注入)'
+    );
+    // CSS rule for the fallback class should exist (display: block on Mobile)
+    const fallbackCssRe = /\.visualizer-graph-mobile-fallback\s*\{[^}]*display:\s*block[^}]*\}/;
+    assert.ok(
+      fallbackCssRe.test(html),
+      'expected: .visualizer-graph-mobile-fallback { display: block; ... } CSS rule\n' +
+        'found: no fallback CSS rule\n' +
+        'fix: add fallback CSS rule inside @media (max-width: 767px) per plan 26051405 §PR A3'
+    );
+  });
+});

--- a/tests/mobile-search-ux.test.mjs
+++ b/tests/mobile-search-ux.test.mjs
@@ -1,0 +1,230 @@
+// tests/mobile-search-ux.test.mjs — Sprint 4 Phase 3 PR B3 Search tab Mobile UX
+//
+// Targets: shell-template.html の Search tab Mobile UX 強化を機械的に verify。
+//          plan 26051405 §「PR B3」L276-289 の canonical CSS spec を test に codify。
+//
+// Test prefixes (BLUE-MOBILE-B3-* namespace, per LEARN#8a per-file scope = F1 から):
+//   - BLUE-MOBILE-B3-5 : Search input font-size 16px が Mobile media query 内に存在
+//                        (iOS Safari < 16px で input focus 時 auto-zoom 発生、UX 阻害)。
+//                        kioku-search-input class が JS 内で element に代入されていること。
+//   - BLUE-MOBILE-B3-6 : Search results scroll behavior
+//                        (overflow-y: auto + -webkit-overflow-scrolling: touch +
+//                         max-height: calc(100vh - <px>)) が Mobile media query 内に存在。
+//                        kioku-search-results class が JS 内で element に代入されていること。
+//   - BLUE-MOBILE-B3-7 : virtual keyboard 対応
+//                        (max-height calc(100vh - 200px) + kioku-tier2-search-btn の
+//                         min-height 44px + width 100%) が Mobile media query 内に存在。
+//
+// 設計方針:
+//   - Node 18+ stdlib のみ (外部依存なし、jsdom 不要)
+//   - file content の string check (regex match) で OK、Mobile rendering test は
+//     PR C3 で test-helpers.mjs に mockMobileViewport 追加後
+//   - error message は「expected: X / found: Y / fix: Z」形式
+//   - Mobile media query 内側の宣言を verify するため、bracket balance counter で
+//     @media (max-width: 767px) { ... } の中身を抽出する helper を用いる
+//     (lazy quantifier では nested { } を取り違える)
+//
+// LEARN#13 注意: regex literal に U+2028 / U+2029 / U+200B / U+FEFF を直接書かない。
+// 本 file は ASCII のみで constructed regex を使う。
+// LEARN#14: import 経由で test framework が load する → ESM entry gate 不要。
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
+
+const moduleFilePath = fileURLToPath(import.meta.url);
+const moduleDir = dirname(moduleFilePath);
+const CB_ROOT = resolve(moduleDir, '..'); // tools/claude-brain/
+
+const PATHS = {
+  shellTemplate: join(CB_ROOT, 'mcp', 'templates', 'shell-template.html'),
+};
+
+async function readShell() {
+  return readFile(PATHS.shellTemplate, 'utf-8');
+}
+
+// @media (max-width: 767px) { ... } の中身を bracket balance で抽出する。
+// nested { } (e.g. selector rule の中括弧) を正しく扱うため、lazy regex ではなく
+// open/close brace の depth counter で抽出位置を決める。
+function extractMobileMediaBlock(html) {
+  const headerRe = /@media\s*\(\s*max-width:\s*767px\s*\)\s*\{/;
+  const m = html.match(headerRe);
+  if (!m) return '';
+  const start = m.index;
+  const openIdx = html.indexOf('{', start);
+  if (openIdx < 0) return '';
+  let depth = 1;
+  let i = openIdx + 1;
+  while (i < html.length && depth > 0) {
+    if (html[i] === '{') depth++;
+    else if (html[i] === '}') {
+      depth--;
+      if (depth === 0) return html.slice(openIdx + 1, i);
+    }
+    i++;
+  }
+  return html.slice(openIdx + 1); // unmatched (defensive)
+}
+
+describe('Sprint 4 Phase 3 PR B3 — Search tab Mobile UX', () => {
+  test('BLUE-MOBILE-B3-5: Search input font-size 16px in Mobile media query (iOS auto-zoom prevention)', async () => {
+    const html = await readShell();
+    const mediaBlock = extractMobileMediaBlock(html);
+    assert.ok(
+      mediaBlock.length > 0,
+      'expected: @media (max-width: 767px) { ... } block in shell-template.html\n' +
+        'found: no Mobile media query block\n' +
+        'fix: add @media (max-width: 767px) { ... } per plan 26051405 §PR A3 line 141'
+    );
+
+    // .kioku-search-input または #kioku-search-input selector が Mobile block 内に存在
+    const selectorRe = /(?:\.|#)kioku-search-input\b/;
+    assert.ok(
+      selectorRe.test(mediaBlock),
+      'expected: .kioku-search-input or #kioku-search-input selector inside @media (max-width: 767px) block\n' +
+        'found: no Search input selector in Mobile block\n' +
+        'fix: add .kioku-search-input rule per plan 26051405 §PR B3 line 276-289'
+    );
+
+    // 同じ Mobile block 内に font-size: 16px が宣言されている
+    // (selector と同一 rule 内であることまでは strict には verify しないが、
+    //  Mobile block 内 substring search で実用上十分。drift 検出の guard として機能)
+    const fontSizeRe = /font-size\s*:\s*16px/;
+    assert.ok(
+      fontSizeRe.test(mediaBlock),
+      'expected: `font-size: 16px` declaration inside @media (max-width: 767px) block\n' +
+        'found: no `font-size: 16px` in Mobile block\n' +
+        'fix: add `font-size: 16px` to .kioku-search-input rule per plan 26051405 §PR B3 (iOS Safari auto-zoom 防止、16px 以上必須)'
+    );
+
+    // kioku-search-input class が JS 内で element に代入されている (input.className = 'kioku-search-input')
+    const classAssignRe = /\binput\.className\s*=\s*['"]kioku-search-input['"]/;
+    assert.ok(
+      classAssignRe.test(html),
+      'expected: `input.className = \'kioku-search-input\'` in shell-template.html JS\n' +
+        'found: no class assignment for Search input element\n' +
+        'fix: assign className = \'kioku-search-input\' to the search <input> in renderSearch() per plan 26051405 §PR B3'
+    );
+  });
+
+  test('BLUE-MOBILE-B3-6: Search results scroll behavior (overflow-y + -webkit-overflow-scrolling + max-height)', async () => {
+    const html = await readShell();
+    const mediaBlock = extractMobileMediaBlock(html);
+    assert.ok(
+      mediaBlock.length > 0,
+      'expected: @media (max-width: 767px) { ... } block in shell-template.html\n' +
+        'found: no Mobile media query block\n' +
+        'fix: add @media (max-width: 767px) { ... } per plan 26051405 §PR A3 line 141'
+    );
+
+    // .kioku-search-results または #kioku-search-results selector が Mobile block 内に存在
+    const selectorRe = /(?:\.|#)kioku-search-results\b/;
+    assert.ok(
+      selectorRe.test(mediaBlock),
+      'expected: .kioku-search-results or #kioku-search-results selector inside @media (max-width: 767px) block\n' +
+        'found: no Search results selector in Mobile block\n' +
+        'fix: add .kioku-search-results rule per plan 26051405 §PR B3 line 276-289'
+    );
+
+    // overflow-y: auto が Mobile block 内に宣言されている
+    const overflowRe = /overflow-y\s*:\s*auto/;
+    assert.ok(
+      overflowRe.test(mediaBlock),
+      'expected: `overflow-y: auto` declaration inside @media (max-width: 767px) block\n' +
+        'found: no `overflow-y: auto` in Mobile block\n' +
+        'fix: add `overflow-y: auto` to .kioku-search-results rule per plan 26051405 §PR B3 (virtual keyboard 開時 scroll)'
+    );
+
+    // -webkit-overflow-scrolling: touch が Mobile block 内に宣言されている (iOS momentum scroll)
+    const webkitScrollRe = /-webkit-overflow-scrolling\s*:\s*touch/;
+    assert.ok(
+      webkitScrollRe.test(mediaBlock),
+      'expected: `-webkit-overflow-scrolling: touch` declaration inside @media (max-width: 767px) block\n' +
+        'found: no `-webkit-overflow-scrolling: touch` in Mobile block\n' +
+        'fix: add `-webkit-overflow-scrolling: touch` to .kioku-search-results rule per plan 26051405 §PR B3 (iOS momentum scroll 維持)'
+    );
+
+    // max-height: calc(100vh - <px>) が Mobile block 内に存在 (viewport-relative height)
+    const maxHeightRe = /max-height\s*:\s*calc\(\s*100vh\s*-\s*\d+px\s*\)/;
+    assert.ok(
+      maxHeightRe.test(mediaBlock),
+      'expected: `max-height: calc(100vh - <px>)` declaration inside @media (max-width: 767px) block\n' +
+        'found: no viewport-relative max-height in Mobile block\n' +
+        'fix: add `max-height: calc(100vh - 200px)` to .kioku-search-results rule per plan 26051405 §PR B3 (virtual keyboard 縮小追随)'
+    );
+
+    // kioku-search-results class が JS 内で element に代入されている
+    // (resultsRoot.className = 'kioku-search-results')
+    const classAssignRe = /\bresultsRoot\.className\s*=\s*['"]kioku-search-results['"]/;
+    assert.ok(
+      classAssignRe.test(html),
+      'expected: `resultsRoot.className = \'kioku-search-results\'` in shell-template.html JS\n' +
+        'found: no class assignment for Search results element\n' +
+        'fix: assign className = \'kioku-search-results\' to the results <div> in renderSearch() per plan 26051405 §PR B3'
+    );
+  });
+
+  test('BLUE-MOBILE-B3-7: virtual keyboard support (max-height calc + Tier 2 button full-width 44pt tap target)', async () => {
+    const html = await readShell();
+    const mediaBlock = extractMobileMediaBlock(html);
+    assert.ok(
+      mediaBlock.length > 0,
+      'expected: @media (max-width: 767px) { ... } block in shell-template.html\n' +
+        'found: no Mobile media query block\n' +
+        'fix: add @media (max-width: 767px) { ... } per plan 26051405 §PR A3 line 141'
+    );
+
+    // max-height: calc(100vh - 200px) (canonical) または相当する calc(100vh - <px>) 形式
+    // canonical を優先 verify、tolerance として generic form も許容
+    const canonicalRe = /max-height\s*:\s*calc\(\s*100vh\s*-\s*200px\s*\)/;
+    const genericRe = /max-height\s*:\s*calc\(\s*100vh\s*-\s*\d+px\s*\)/;
+    assert.ok(
+      canonicalRe.test(mediaBlock) || genericRe.test(mediaBlock),
+      'expected: `max-height: calc(100vh - 200px)` (or calc(100vh - <px>)) inside @media (max-width: 767px) block\n' +
+        'found: no viewport-relative max-height in Mobile block\n' +
+        'fix: add `max-height: calc(100vh - 200px)` per plan 26051405 §PR B3 line 276-289 (virtual keyboard 開時 viewport 縮小追随)'
+    );
+
+    // kioku-tier2-search-btn selector rule が Mobile block 内に存在
+    const tier2SelectorRe = /\.kioku-tier2-search-btn\b/;
+    assert.ok(
+      tier2SelectorRe.test(mediaBlock),
+      'expected: .kioku-tier2-search-btn selector inside @media (max-width: 767px) block\n' +
+        'found: no Tier 2 deep-link button selector in Mobile block\n' +
+        'fix: add .kioku-tier2-search-btn rule inside @media (max-width: 767px) per plan 26051405 §PR B3 line 276-289'
+    );
+
+    // Mobile block 内の kioku-tier2-search-btn rule の中身 (selector { ... }) を抽出
+    // 単純化: Mobile block 内で .kioku-tier2-search-btn の出現位置 + 続く { ... } の中身を取得
+    const tier2RuleRe = /\.kioku-tier2-search-btn\s*\{([^}]*)\}/;
+    const tier2Match = mediaBlock.match(tier2RuleRe);
+    assert.ok(
+      tier2Match && tier2Match[1],
+      'expected: .kioku-tier2-search-btn { ... } rule body inside @media (max-width: 767px) block\n' +
+        'found: selector present but no rule body extracted\n' +
+        'fix: ensure .kioku-tier2-search-btn rule has { ... } body in Mobile block per plan 26051405 §PR B3'
+    );
+    const tier2Body = tier2Match[1];
+
+    // width: 100% が Tier 2 button Mobile rule 内に宣言 (full-width button、指タップ範囲拡大)
+    const widthRe = /width\s*:\s*100%/;
+    assert.ok(
+      widthRe.test(tier2Body),
+      'expected: `width: 100%` inside .kioku-tier2-search-btn rule body (Mobile block)\n' +
+        'found: no `width: 100%` declaration in Tier 2 button Mobile rule\n' +
+        'fix: add `width: 100%` to .kioku-tier2-search-btn Mobile rule per plan 26051405 §PR B3 (full-width button、virtual keyboard 開時の指タップ範囲拡大)'
+    );
+
+    // min-height: 44px が Tier 2 button Mobile rule 内に宣言 (tap target)
+    const minHeightRe = /min-height\s*:\s*44px/;
+    assert.ok(
+      minHeightRe.test(tier2Body),
+      'expected: `min-height: 44px` inside .kioku-tier2-search-btn rule body (Mobile block)\n' +
+        'found: no `min-height: 44px` declaration in Tier 2 button Mobile rule\n' +
+        'fix: add `min-height: 44px` to .kioku-tier2-search-btn Mobile rule per plan 26051405 §PR B3 (tap target、virtual keyboard 表示時 tap 可)'
+    );
+  });
+});

--- a/tests/mobile-tier2-deeplink.test.mjs
+++ b/tests/mobile-tier2-deeplink.test.mjs
@@ -1,0 +1,238 @@
+// tests/mobile-tier2-deeplink.test.mjs — Sprint 4 Phase 3 PR B3 Tier 2 Mobile deep-link
+//
+// Targets: shell-template.html に追加された openTier2Search function +
+//          claude:// URI scheme attempt + 1.5s timeout で claude.ai/new web fallback +
+//          CSP navigate-to policy を機械的に verify。
+//          plan 26051405 §「PR B3」L238-329 の canonical impl spec を test に codify。
+//
+// Test prefixes (BLUE-MOBILE-B3-* namespace, per LEARN#8a per-file scope = F1 から):
+//   - BLUE-MOBILE-B3-1 : openTier2Search function + Mobile 判定 (matchMedia) +
+//                        claude:// URI scheme prefix が shell-template.html に存在
+//   - BLUE-MOBILE-B3-2 : claude:// → 1.5s timeout → web fallback の構造
+//                        (setTimeout 1500 + visibilitychange listener + clearTimeout)
+//   - BLUE-MOBILE-B3-3 : claude.ai/new web fallback URL + encodeURIComponent escape
+//                        (user input は escape mandatory、plan §「セキュリティ contract」L319)
+//   - BLUE-MOBILE-B3-4 : desktop path 不変 (既存 narrative 維持) + CSP navigate-to policy
+//                        (claude: + https://claude.ai whitelist)
+//
+// 設計方針:
+//   - Node 18+ stdlib のみ (外部依存なし、jsdom 不要)
+//   - file content の string check (regex match) で OK、actual Mobile rendering test は
+//     PR C3 で test-helpers.mjs に mockMobileViewport 追加後
+//   - error message は「expected: X / found: Y / fix: Z」形式
+//   - regex は whitespace tolerance (\s*) を持たせ minor formatting drift に耐性
+//
+// LEARN#13 注意: regex literal に U+2028 / U+2029 / U+200B / U+FEFF を直接書かない。
+// 本 file は ASCII のみで constructed regex を使う。
+// LEARN#14: import 経由で test framework が load する → ESM entry gate 不要。
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
+
+const moduleFilePath = fileURLToPath(import.meta.url);
+const moduleDir = dirname(moduleFilePath);
+const CB_ROOT = resolve(moduleDir, '..'); // tools/claude-brain/
+
+const PATHS = {
+  shellTemplate: join(CB_ROOT, 'mcp', 'templates', 'shell-template.html'),
+};
+
+async function readShell() {
+  return readFile(PATHS.shellTemplate, 'utf-8');
+}
+
+// Extract the openTier2Search function body for scoped assertions.
+// 戻り値: function 本体 string (見つからなければ '')
+function extractOpenTier2SearchBody(html) {
+  // function openTier2Search(query) { ... } を抜き出す。
+  // brace balancing は html 構造上 simple な範囲で済むので regex で sufficient:
+  // 最初の `function openTier2Search` から、最も近い `function copyMcpToolPrompt` 直前まで取る
+  // (本 PR B3 の impl 上は両者が連続定義されている前提、plan 26051405 §「PR B3」L240-274)。
+  const start = html.indexOf('function openTier2Search');
+  if (start < 0) return '';
+  const next = html.indexOf('function copyMcpToolPrompt', start);
+  if (next < 0) return html.slice(start);
+  return html.slice(start, next);
+}
+
+// Extract the renderSearch function body for desktop-path regression assertions.
+function extractRenderSearchBody(html) {
+  const start = html.indexOf('function renderSearch');
+  if (start < 0) return '';
+  // renderSearch の終端は次の top-level function 定義 (function applyFilter は内部 nested なので、
+  // 次の top-level として function showTab / function renderRest 等が来るのを期待するが、
+  // safe-side: 5000 char window で十分 desktop description text を含む)。
+  return html.slice(start, start + 5000);
+}
+
+describe('Sprint 4 Phase 3 PR B3 — Tier 2 Mobile deep-link', () => {
+  test('BLUE-MOBILE-B3-1: openTier2Search function + matchMedia + claude:// URI scheme exist', async () => {
+    const html = await readShell();
+
+    // 検証 1: function openTier2Search definition が存在
+    const fnRe = /function\s+openTier2Search\s*\(/;
+    assert.ok(
+      fnRe.test(html),
+      'expected: function openTier2Search(query) { ... } definition in shell-template.html\n' +
+        'found: no openTier2Search function definition\n' +
+        'fix: add openTier2Search per plan 26051405 §PR B3 L240-274'
+    );
+
+    // 検証 2: window.matchMedia('(max-width: 767px)') 呼び出しが function 本体に存在
+    const body = extractOpenTier2SearchBody(html);
+    assert.ok(
+      body.length > 0,
+      'expected: openTier2Search function body extractable\n' +
+        'found: function body empty (extraction failed)\n' +
+        'fix: ensure openTier2Search and copyMcpToolPrompt are co-located per plan 26051405'
+    );
+    const matchMediaRe = /window\.matchMedia\s*\(\s*['"]\(max-width:\s*767px\)['"]\s*\)/;
+    assert.ok(
+      matchMediaRe.test(body),
+      'expected: window.matchMedia(\'(max-width: 767px)\') call inside openTier2Search\n' +
+        'found: no matchMedia Mobile detection call\n' +
+        'fix: add Mobile detection via matchMedia per plan 26051405 §PR B3 L240-274'
+    );
+
+    // 検証 3: claude://chat?prompt= URI scheme prefix が JS string literal として存在
+    const claudeSchemeRe = /['"]claude:\/\/chat\?prompt=/;
+    assert.ok(
+      claudeSchemeRe.test(body),
+      'expected: \'claude://chat?prompt=...\' URI scheme string literal in openTier2Search\n' +
+        'found: no claude:// URI scheme prefix\n' +
+        'fix: add claude://chat?prompt= deep-link per plan 26051405 §PR B3 L240-274'
+    );
+  });
+
+  test('BLUE-MOBILE-B3-2: claude:// -> 1.5s timeout -> web fallback structure', async () => {
+    const html = await readShell();
+    const body = extractOpenTier2SearchBody(html);
+    assert.ok(body.length > 0, 'openTier2Search body must be extractable');
+
+    // 検証 1: setTimeout(..., 1500) が openTier2Search 内に存在 (1.5s timeout literal)
+    const setTimeoutRe = /setTimeout\s*\([\s\S]*?,\s*1500\s*\)/;
+    assert.ok(
+      setTimeoutRe.test(body),
+      'expected: setTimeout(..., 1500) inside openTier2Search (1.5s web fallback timer)\n' +
+        'found: no 1500ms setTimeout\n' +
+        'fix: add setTimeout(() => window.location.href = claudeWebUrl, 1500) per plan 26051405 §PR B3 L240-274'
+    );
+
+    // 検証 2: visibilitychange listener が存在 (app 起動成功時 timeout cancel)
+    const visChangeRe = /['"]visibilitychange['"]/;
+    assert.ok(
+      visChangeRe.test(body),
+      'expected: \'visibilitychange\' event listener in openTier2Search\n' +
+        'found: no visibilitychange listener\n' +
+        'fix: add document.addEventListener(\'visibilitychange\', ...) to cancel timeout when claude:// app launches (plan 26051405 §PR B3 L260-268)'
+    );
+
+    // 検証 3: clearTimeout 呼び出しが存在
+    const clearTimeoutRe = /clearTimeout\s*\(/;
+    assert.ok(
+      clearTimeoutRe.test(body),
+      'expected: clearTimeout(timeoutId) call inside openTier2Search\n' +
+        'found: no clearTimeout call\n' +
+        'fix: add clearTimeout(timeoutId) inside visibilitychange handler per plan 26051405 §PR B3 L260-268'
+    );
+  });
+
+  test('BLUE-MOBILE-B3-3: claude.ai/new web fallback URL + encodeURIComponent escape', async () => {
+    const html = await readShell();
+    const body = extractOpenTier2SearchBody(html);
+    assert.ok(body.length > 0, 'openTier2Search body must be extractable');
+
+    // 検証 1: https://claude.ai/new?q= URL prefix が JS string literal として存在
+    const webFallbackRe = /['"]https:\/\/claude\.ai\/new\?q=/;
+    assert.ok(
+      webFallbackRe.test(body),
+      'expected: \'https://claude.ai/new?q=...\' web fallback URL string literal in openTier2Search\n' +
+        'found: no claude.ai/new fallback URL\n' +
+        'fix: add web fallback URL per plan 26051405 §PR B3 L240-274'
+    );
+
+    // 検証 2: encodeURIComponent 呼び出しが openTier2Search 内に存在
+    // (user input escape mandatory、plan §「セキュリティ contract」L319)
+    const encodeRe = /encodeURIComponent\s*\(/;
+    assert.ok(
+      encodeRe.test(body),
+      'expected: encodeURIComponent(query) call inside openTier2Search\n' +
+        'found: no encodeURIComponent call\n' +
+        'fix: escape user input via encodeURIComponent per plan 26051405 §PR B3 セキュリティ contract L319 (XSS / URL injection 防止)'
+    );
+  });
+
+  test('BLUE-MOBILE-B3-4: desktop path narrative preserved + CSP navigate-to policy', async () => {
+    const html = await readShell();
+    const renderSearchBody = extractRenderSearchBody(html);
+    assert.ok(
+      renderSearchBody.length > 0,
+      'expected: renderSearch function body extractable\n' +
+        'found: function body empty (extraction failed)\n' +
+        'fix: ensure renderSearch is defined in shell-template.html'
+    );
+
+    // 検証 1: 既存 description text "Claude conversation で" が renderSearch 内に維持
+    // (desktop 不変 regression guard)
+    assert.ok(
+      renderSearchBody.indexOf('Claude conversation で') >= 0,
+      'expected: existing description text "Claude conversation で" preserved in renderSearch\n' +
+        'found: description text missing (PR B3 should not regress desktop narrative)\n' +
+        'fix: keep existing deepDive textContent intact per plan 26051405 §PR B3 (desktop path 不変)'
+    );
+
+    // 検証 2: 既存 code element textContent `kioku_search` が renderSearch 内に維持
+    const kiokuSearchRe = /['"]kioku_search['"]/;
+    assert.ok(
+      kiokuSearchRe.test(renderSearchBody),
+      'expected: \'kioku_search\' string literal preserved in renderSearch (MCP tool name reference)\n' +
+        'found: kioku_search reference missing\n' +
+        'fix: keep existing ddCode.textContent = \'kioku_search\' intact per plan 26051405 §PR B3'
+    );
+
+    // 検証 3: <meta http-equiv="Content-Security-Policy" ...> with navigate-to directive 存在
+    // 注意: content 属性 (double-quoted) 内に CSP keyword 'self' などの single quote が含まれるため、
+    //       content 値 capture は [^"] (single quote 許容) で、quote は double-quote 限定で照合する。
+    const cspRe =
+      /<meta\s+http-equiv="Content-Security-Policy"\s+content="[^"]*navigate-to[^"]*"\s*\/?>/i;
+    assert.ok(
+      cspRe.test(html),
+      'expected: <meta http-equiv="Content-Security-Policy" content="...navigate-to..."> in shell-template.html <head>\n' +
+        'found: no CSP meta tag with navigate-to directive\n' +
+        'fix: add CSP navigate-to policy per plan 26051405 §PR B3 セキュリティ contract L314-318'
+    );
+
+    // 検証 4: navigate-to directive content に `claude:` scheme-source 含む
+    const cspContentMatch = html.match(
+      /<meta\s+http-equiv="Content-Security-Policy"\s+content="([^"]*)"\s*\/?>/i
+    );
+    assert.ok(
+      cspContentMatch && cspContentMatch[1],
+      'expected: CSP meta tag content attribute extractable\n' +
+        'found: CSP meta tag without content attribute\n' +
+        'fix: ensure <meta http-equiv="Content-Security-Policy" content="..."> has content per plan 26051405'
+    );
+    const cspContent = cspContentMatch[1];
+    assert.ok(
+      /\bclaude:/.test(cspContent),
+      'expected: "claude:" scheme-source in CSP navigate-to directive content\n' +
+        'found: CSP content = "' +
+        cspContent +
+        '"\n' +
+        'fix: include claude: scheme-source per plan 26051405 §PR B3 セキュリティ contract L314-318'
+    );
+
+    // 検証 5: navigate-to directive content に `https://claude.ai` host-source 含む
+    assert.ok(
+      cspContent.indexOf('https://claude.ai') >= 0,
+      'expected: "https://claude.ai" host-source in CSP navigate-to directive content\n' +
+        'found: CSP content = "' +
+        cspContent +
+        '"\n' +
+        'fix: include https://claude.ai host-source per plan 26051405 §PR B3 セキュリティ contract L314-318'
+    );
+  });
+});

--- a/tests/mobile-viz-simplified.test.mjs
+++ b/tests/mobile-viz-simplified.test.mjs
@@ -1,0 +1,167 @@
+// tests/mobile-viz-simplified.test.mjs — Sprint 4 Phase 3 PR C3
+//   Visualizer β Mobile simplified view (text page list、innerHTML 不使用)
+//
+// plan 26051405 §「Visualizer β Mobile simplified view」 (L343-372) canonical
+// impl spec を test に codify。viz-template.html 内 renderMobileFallback の
+// shape + safe-DOM contract を assert する。
+//
+// Test prefixes (BLUE-MOBILE-C3-* namespace、LEARN#8a per-file scope = F1 から):
+//   - BLUE-MOBILE-C3-1 : renderMobileFallback 関数が viz-template.html に存在
+//   - BLUE-MOBILE-C3-2 : renderMobileFallback は textContent + createElement のみ使用
+//                        (innerHTML / outerHTML 代入 / legacy doc-write は 0 hit)
+//   - BLUE-MOBILE-C3-3 : Mobile breakpoint (max-width: 767px) で
+//                        renderMobileFallback がデータと共に呼ばれる分岐が存在、
+//                        かつ mockMobileViewport helper が同 query で match する
+//
+// 設計方針:
+//   - Node 18+ stdlib のみ (jsdom 不要、file content の string check + mockMobileViewport)
+//   - LEARN#13: regex literal の U+2028/2029/200B/FEFF 禁止、本 file は ASCII のみ
+//   - LEARN#14: import 経由で test framework が load → ESM entry gate 不要
+//   - LEARN#5 cross-suite: renderMobileFallback / mockMobileViewport を別 test
+//     file (performance-budget) でも参照するため、helper 名一致を維持
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
+import { mockMobileViewport } from './fixtures/test-helpers.mjs';
+
+const moduleFilePath = fileURLToPath(import.meta.url);
+const moduleDir = dirname(moduleFilePath);
+const CB_ROOT = resolve(moduleDir, '..');
+
+const VIZ_TEMPLATE_PATH = join(CB_ROOT, 'mcp', 'templates', 'viz-template.html');
+
+async function readViz() {
+  return readFile(VIZ_TEMPLATE_PATH, 'utf-8');
+}
+
+describe('Sprint 4 Phase 3 PR C3 — Visualizer β Mobile simplified view', () => {
+  test('BLUE-MOBILE-C3-1: renderMobileFallback function exists in viz-template.html', async () => {
+    const html = await readViz();
+    // 関数定義: `function renderMobileFallback(...)` のいずれか
+    const fnDeclRe = /function\s+renderMobileFallback\s*\(/;
+    assert.ok(
+      fnDeclRe.test(html),
+      'expected: `function renderMobileFallback(...)` defined in viz-template.html <script>\n' +
+        'found: no renderMobileFallback function declaration\n' +
+        'fix: add renderMobileFallback per plan 26051405 §Visualizer β Mobile simplified view'
+    );
+    // 関数本体で .visualizer-graph-mobile-fallback container を取得する handle
+    const containerRe = /querySelector\s*\(\s*['"]\s*\.visualizer-graph-mobile-fallback\s*['"]\s*\)/;
+    assert.ok(
+      containerRe.test(html),
+      'expected: querySelector(".visualizer-graph-mobile-fallback") inside renderMobileFallback\n' +
+        'found: no container lookup matching plan canonical pattern\n' +
+        'fix: query .visualizer-graph-mobile-fallback per plan 26051405 line 348'
+    );
+  });
+
+  test('BLUE-MOBILE-C3-2: renderMobileFallback uses textContent + createElement only (no innerHTML / outerHTML / legacy doc-write)', async () => {
+    const html = await readViz();
+    // renderMobileFallback 関数本体を抽出 (関数開始から最初の終端 `}` までを greedy 取得)。
+    // viz-template.html 全体に対する self-grep は branch-wide self-grep (Path C+β
+    // boundary) で別途実施するため、本 test は関数本体 scope に絞った契約確認。
+    const fnBodyMatch = html.match(/function\s+renderMobileFallback\s*\([^)]*\)\s*\{([\s\S]*?)\n\s{0,4}\}\n/);
+    assert.ok(
+      fnBodyMatch,
+      'expected: extractable renderMobileFallback function body\n' +
+        'found: no balanced body match (function may have nested unbalanced braces)\n' +
+        'fix: ensure renderMobileFallback ends with a top-level closing brace on its own line'
+    );
+    const body = fnBodyMatch[1];
+
+    // textContent 経由の書き込み 必須 (intro paragraph + a.textContent)
+    const textContentRe = /\.textContent\s*=/;
+    assert.ok(
+      textContentRe.test(body),
+      'expected: textContent assignment(s) inside renderMobileFallback\n' +
+        'found: no textContent usage\n' +
+        'fix: assign user-visible strings via .textContent per safe DOM contract'
+    );
+    // createElement 経由の要素生成 必須 (ul / li / a / p のいずれか)
+    const createElementRe = /document\.createElement\s*\(/;
+    assert.ok(
+      createElementRe.test(body),
+      'expected: document.createElement(...) inside renderMobileFallback\n' +
+        'found: no createElement usage\n' +
+        'fix: build DOM via createElement per plan 26051405 line 355-364'
+    );
+    // 禁止 API: innerHTML / outerHTML 代入 / legacy doc-write は本関数で 0 hit
+    const innerHTMLAssignRe = /\.innerHTML\s*=/;
+    assert.ok(
+      !innerHTMLAssignRe.test(body),
+      'expected: 0 innerHTML assignment inside renderMobileFallback\n' +
+        'found: innerHTML assignment present (XSS injection surface)\n' +
+        'fix: replace with textContent + createElement per Path C+β boundary'
+    );
+    const outerHTMLAssignRe = /\.outerHTML\s*=/;
+    assert.ok(
+      !outerHTMLAssignRe.test(body),
+      'expected: 0 outerHTML assignment inside renderMobileFallback\n' +
+        'found: outerHTML assignment present (XSS injection surface)\n' +
+        'fix: replace with createElement + appendChild per Path C+β boundary'
+    );
+    // legacy doc-write API は分割書きでも禁止 (document . write の任意 whitespace)
+    const docWriteRe = /document\s*\.\s*write\s*\(/;
+    assert.ok(
+      !docWriteRe.test(body),
+      'expected: 0 legacy doc-write API call inside renderMobileFallback\n' +
+        'found: legacy doc-write API call present (deprecated + XSS surface)\n' +
+        'fix: remove legacy API per Path C+β boundary forbidden keyword list'
+    );
+  });
+
+  test('BLUE-MOBILE-C3-3: Mobile breakpoint branch invokes renderMobileFallback, mockMobileViewport matches same query', async () => {
+    const html = await readViz();
+    // 起動分岐: window.matchMedia('(max-width: 767px)') を条件にして renderMobileFallback(data) を call。
+    // selector / call の隣接は許容 (改行 + 中間処理あり) のため 2 段で assert。
+    const mqDetectRe = /window\.matchMedia\s*\(\s*['"]\(\s*max-width:\s*767px\s*\)['"]/;
+    assert.ok(
+      mqDetectRe.test(html),
+      'expected: window.matchMedia("(max-width: 767px)") detection branch\n' +
+        'found: no Mobile breakpoint detection matching plan canonical pattern\n' +
+        'fix: add matchMedia branch per plan 26051405 line 368'
+    );
+    const invokeRe = /renderMobileFallback\s*\(\s*data\s*\)/;
+    assert.ok(
+      invokeRe.test(html),
+      'expected: renderMobileFallback(data) invocation inside Mobile breakpoint branch\n' +
+        'found: function defined but never called with embedded vault data\n' +
+        'fix: call renderMobileFallback(data) inside if (mobileMQ.matches) per plan 26051405 line 370'
+    );
+
+    // mockMobileViewport が同じ breakpoint query で `.matches === true` を返すことを verify
+    // (test infrastructure の意図一致 = 「test 上 Mobile を再現したら production と同条件で発火」)
+    const restore = mockMobileViewport(375);
+    try {
+      const mq = globalThis.window.matchMedia('(max-width: 767px)');
+      assert.equal(
+        mq.matches,
+        true,
+        'expected: mockMobileViewport(375) → matchMedia("(max-width: 767px)").matches === true\n' +
+          'found: matches=' + mq.matches + '\n' +
+          'fix: ensure mockMobileViewport parses (max-width: Npx) and compares width <= N'
+      );
+      // 反例側: tablet 以上 (width=1024) では非 match (Mobile 専用化が tablet を汚染しないこと)
+      restore();
+      const restoreTablet = mockMobileViewport(1024);
+      try {
+        const mqTablet = globalThis.window.matchMedia('(max-width: 767px)');
+        assert.equal(
+          mqTablet.matches,
+          false,
+          'expected: mockMobileViewport(1024) → matchMedia("(max-width: 767px)").matches === false\n' +
+            'found: matches=' + mqTablet.matches + '\n' +
+            'fix: ensure mockMobileViewport does NOT match when width exceeds breakpoint'
+        );
+      } finally {
+        restoreTablet();
+      }
+    } finally {
+      // 二重 restore は idempotent (test-helpers.mjs の restore 関数仕様)
+      restore();
+    }
+  });
+});

--- a/tests/qmd-search-index.test.mjs
+++ b/tests/qmd-search-index.test.mjs
@@ -1,0 +1,466 @@
+// qmd-search-index.test.mjs — Sprint 4 Phase 2 PR A2 BLUE-QMD-INDEX-1..5 + PR B2 BLUE-QMD-INDEX-6..9
+//
+// Plan: tools/claude-brain/plan/claude/26051402_v0-9-phase2-qmd-search-impl-plan.md §「PR A2」 + §「PR B2」
+//
+// F-number scope: per-file (NEW file = F1 から)
+//
+// Test 観点:
+//   - F1 (BLUE-QMD-INDEX-1): buildSearchIndex shape (schema_version / generated_at / queries[])
+//   - F2 (BLUE-QMD-INDEX-2): normalizeResults が body / abs_path を drop (security boundary)
+//   - F3 (BLUE-QMD-INDEX-3): discoverQueries が wiki/log.md tag refs を extract
+//   - F4 (BLUE-QMD-INDEX-snippet-escape): snippet 内 <script> / </script> / U+2028 を string で扱う
+//   - F5 (BLUE-QMD-INDEX-empty-vault): empty vault でも空 SearchIndex を返す (no throw)
+//   - F6 (BLUE-QMD-INDEX-6): raw-sources/ headings (h1 + h2) extraction (weight 2)
+//   - F7 (BLUE-QMD-INDEX-7): git commit headlines (subject 中の ATX-like single-line) extraction + 非 git repo は graceful (weight 1.5)
+//     - 7a: isGitRepo === false short-circuit (early-return path)
+//     - 7b: getFileHistory が `{ commits: [], error: 'not_a_git_repo' }` shape を返した second-layer guard (defense-in-depth)
+//   - F8 (BLUE-QMD-INDEX-8): wiki/hot.md content scan で ATX heading + 単独行 #tag 抽出 (weight 2.5)
+//   - F9 (BLUE-QMD-INDEX-9): empty PM-Vault-like fixture (no log tags, no index wikilinks, no concept files) でも raw-sources + git + hot.md から >= 3 query 産出 (regression guard)
+
+import { test, describe, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { spawn } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { withoutQmd as withMissingQmd } from './fixtures/test-helpers.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const LIB_PATH = join(__dirname, '..', 'mcp', 'lib', 'qmd-search-index.mjs');
+
+const {
+  buildSearchIndex,
+  SEARCH_INDEX_SCHEMA_VERSION,
+  __test__,
+} = await import(LIB_PATH);
+
+let workspace, vault;
+
+before(async () => {
+  workspace = await mkdtemp(join(tmpdir(), 'kioku-qmd-search-index-'));
+  vault = join(workspace, 'vault');
+  await mkdir(join(vault, 'wiki'), { recursive: true });
+  await writeFile(
+    join(vault, 'wiki', 'log.md'),
+    [
+      '---',
+      'title: Log',
+      '---',
+      '',
+      '# Log',
+      '',
+      '- 2026-05-14 #hot-cache について整理 #wiki',
+      '- 2026-05-13 #visualizer の design 更新 #ui',
+      '- 2026-05-12 #hot-cache の dogfood #wiki #ux',
+      '- 2026-05-11 #doctor MVP land #release',
+      '- 2026-05-10 #wiki の rotting check #drift',
+      '',
+    ].join('\n'),
+  );
+  await writeFile(
+    join(vault, 'wiki', 'index.md'),
+    '# Index\n\n- [[hot-cache]]\n- [[visualizer]]\n- [[doctor]]\n',
+  );
+});
+
+after(() => rm(workspace, { recursive: true, force: true }));
+
+// qmd を見えなくして fallback Node grep path で kioku_search を回す helper は
+// fixtures/test-helpers.mjs の withoutQmd を再利用 (LEARN#8b N=3 shared extract、
+// PR B2 sibling: web-ui-shell.test.mjs / xss-search-result-escape.test.mjs).
+// 旧 local 実装は /nonexistent-bin-only 単発 path だったが shared 版は
+// /usr/bin:/bin:/usr/sbin:/sbin で git を残しつつ qmd を hide する (F7 git 操作互換).
+
+// SAFE git invoke for fixtures (visualizer-vaults.mjs と同 pattern、test-local helper)
+// - GIT_CONFIG_NOSYSTEM=1 + core.fsmonitor=false + core.hooksPath=/dev/null
+// - inline AUTHOR / COMMITTER identity (user global config 継承しない reproducibility)
+const GIT_SAFE_ARGS = ['-c', 'core.fsmonitor=false', '-c', 'core.hooksPath=/dev/null', '-c', 'protocol.version=2'];
+const GIT_SAFE_ENV = {
+  GIT_CONFIG_NOSYSTEM: '1',
+  GIT_TERMINAL_PROMPT: '0',
+  GIT_OPTIONAL_LOCKS: '0',
+  GIT_AUTHOR_NAME: 'qmd-search-index-test',
+  GIT_AUTHOR_EMAIL: 'qmd-test@test.local',
+  GIT_COMMITTER_NAME: 'qmd-search-index-test',
+  GIT_COMMITTER_EMAIL: 'qmd-test@test.local',
+};
+async function runGitTest(cwd, args) {
+  return new Promise((resolve, reject) => {
+    const proc = spawn('git', [...GIT_SAFE_ARGS, ...args], {
+      cwd,
+      env: { ...process.env, ...GIT_SAFE_ENV },
+      stdio: ['ignore', 'ignore', 'pipe'],
+    });
+    let settled = false;
+    let stderr = '';
+    proc.stderr.on('data', (chunk) => { stderr += chunk.toString(); });
+    proc.on('error', (err) => {
+      if (settled) return;
+      settled = true;
+      reject(err);
+    });
+    proc.on('close', (code) => {
+      if (settled) return;
+      settled = true;
+      if (code === 0) resolve();
+      else reject(new Error(`git ${args.join(' ')} failed (code ${code}): ${stderr.trim()}`));
+    });
+  });
+}
+
+async function isGitAvailable() {
+  return new Promise((resolve) => {
+    const proc = spawn('git', ['--version'], { stdio: ['ignore', 'ignore', 'ignore'] });
+    proc.on('error', () => resolve(false));
+    proc.on('close', (code) => resolve(code === 0));
+  });
+}
+
+describe('qmd-search-index', () => {
+  test('BLUE-QMD-INDEX-1 (F1): buildSearchIndex shape', async () => {
+    await withMissingQmd(async () => {
+      const idx = await buildSearchIndex(vault, { topQueries: 3, resultsPer: 5 });
+      assert.equal(typeof idx, 'object');
+      assert.equal(idx.schema_version, SEARCH_INDEX_SCHEMA_VERSION);
+      assert.equal(idx.schema_version, 1);
+      assert.match(idx.generated_at, /^\d{4}-\d{2}-\d{2}T/);
+      assert.ok(Array.isArray(idx.queries));
+      assert.ok(idx.queries.length <= 3);
+      for (const q of idx.queries) {
+        assert.equal(typeof q.query, 'string');
+        assert.ok(q.query.length > 0);
+        assert.equal(typeof q.mode, 'string');
+        assert.ok(['lex', 'vec', 'hybrid'].includes(q.mode));
+        assert.ok(Array.isArray(q.results));
+      }
+    });
+  });
+
+  test('BLUE-QMD-INDEX-2 (F2): normalizeResults drops body and abs_path', () => {
+    assert.ok(__test__, '__test__ export must be available for internal verify');
+    const { normalizeResults } = __test__;
+    const raw = [
+      {
+        title: 'Safe Title',
+        rel: 'concepts/foo.md',
+        snippet: 'safe snippet',
+        score: 0.9,
+        body: 'SECRET BODY MUST NOT LEAK',
+        abs_path: '/Users/secret/vault/wiki/concepts/foo.md',
+      },
+      {
+        title: 'Path Fallback',
+        path: 'concepts/bar.md',
+        snippet: 'another',
+        score: 0.5,
+        body: 'BODY LEAK',
+        abs_path: '/abs/leak.md',
+      },
+    ];
+    const out = normalizeResults(raw);
+    assert.equal(out.length, 2);
+    for (const r of out) {
+      assert.ok(!('body' in r), 'body must be dropped');
+      assert.ok(!('abs_path' in r), 'abs_path must be dropped');
+      assert.equal(typeof r.title, 'string');
+      assert.equal(typeof r.rel, 'string');
+      assert.equal(typeof r.snippet, 'string');
+    }
+    assert.equal(out[0].rel, 'concepts/foo.md');
+    // path fallback (when rel is absent)
+    assert.equal(out[1].rel, 'concepts/bar.md');
+  });
+
+  test('BLUE-QMD-INDEX-3 (F3): discoverQueries extracts wiki/log.md tag refs', async () => {
+    assert.ok(__test__, '__test__ export must be available');
+    const { discoverQueries } = __test__;
+    const queries = await discoverQueries(vault, 10);
+    assert.ok(Array.isArray(queries));
+    assert.ok(queries.length > 0, 'queries must not be empty');
+    // log.md fixture has #hot-cache (freq 2) which should rank高
+    const lowered = queries.map((q) => q.toLowerCase());
+    assert.ok(
+      lowered.some((q) => q.includes('hot-cache')),
+      `expected hot-cache in queries, got: ${queries.join(', ')}`,
+    );
+    // no duplicate
+    const uniq = new Set(queries);
+    assert.equal(uniq.size, queries.length, 'discoverQueries must dedupe');
+    // limit honored
+    assert.ok(queries.length <= 10);
+  });
+
+  test('BLUE-QMD-INDEX-snippet-escape (F4): snippet preserves dangerous chars as strings', () => {
+    assert.ok(__test__);
+    const { normalizeResults } = __test__;
+    // U+2028 = LINE SEPARATOR. LEARN#13: regex literal は禁止、string literal は parser-safe。
+    // escape sequence で表記して source readability を確保。
+    const u2028 = '\u2028';
+    const dangerous = `foo <script>alert(1)</script> bar${u2028}baz </script> end`;
+    const out = normalizeResults([
+      { title: 't', rel: 'r', snippet: dangerous, score: 0.5 },
+    ]);
+    assert.equal(out.length, 1);
+    // String 型で保持されている (downstream で textContent rendering される前提)
+    assert.equal(typeof out[0].snippet, 'string');
+    // 文字列内容は変化していない (escape は render layer の責務、normalize 層では type-cast のみ)
+    assert.ok(out[0].snippet.includes('<script>'));
+    assert.ok(out[0].snippet.includes('</script>'));
+    assert.ok(out[0].snippet.includes(u2028));
+  });
+
+  test('BLUE-QMD-INDEX-5 (F5): empty vault returns empty SearchIndex without throw', async () => {
+    const emptyWorkspace = await mkdtemp(join(tmpdir(), 'kioku-empty-vault-'));
+    const emptyVault = join(emptyWorkspace, 'vault');
+    await mkdir(join(emptyVault, 'wiki'), { recursive: true });
+    try {
+      await withMissingQmd(async () => {
+        const idx = await buildSearchIndex(emptyVault, { topQueries: 5 });
+        assert.equal(idx.schema_version, 1);
+        assert.ok(Array.isArray(idx.queries));
+        // empty vault → no queries discovered → empty queries array
+        assert.equal(idx.queries.length, 0);
+      });
+    } finally {
+      await rm(emptyWorkspace, { recursive: true, force: true });
+    }
+  });
+
+  test('validates vault arg', async () => {
+    await assert.rejects(buildSearchIndex(''), /vault/);
+    await assert.rejects(buildSearchIndex(null), /vault/);
+  });
+
+  test('clamp options honor MAX_TOP_QUERIES and MAX_RESULTS_PER_QUERY', () => {
+    assert.ok(__test__);
+    const { clamp } = __test__;
+    assert.equal(clamp(100, 1, 30), 30);
+    assert.equal(clamp(-5, 1, 30), 1);
+    assert.equal(clamp(15, 1, 30), 15);
+    assert.equal(clamp(undefined, 1, 30), 1);
+  });
+
+  // ─── Sprint 4 Phase 2 PR B2: BLUE-QMD-INDEX-6..9 (discoverQueries 戦略拡張) ───
+  //
+  // 背景: PR A2 land 後の PM Vault dogfood で `discoverQueries` が 1 query しか返さず Tier 1 UX が
+  // hollow になる risk が発覚 (wiki/log.md は ATX heading 113 個 vs inline #tag 0)。
+  // PR B2 で source を 3 → 7 に拡張:
+  //   4. raw-sources/ headings (h1 + h2) — weight 2
+  //   5. git commit subjects (直近 100 commits) — weight 1.5
+  //   6. wiki/hot.md ATX headings + 単独行 #tag — weight 2.5
+  //   7. wiki/*.md broadly-referenced headings (>= 2 files に出現) — bonus weight 1.2 * (file_count - 1)
+
+  test('BLUE-QMD-INDEX-6 (F6): discoverQueries extracts raw-sources/ headings (h1+h2)', async () => {
+    assert.ok(__test__);
+    const { discoverQueries } = __test__;
+    const ws = await mkdtemp(join(tmpdir(), 'kioku-qmd-f6-'));
+    const v = join(ws, 'vault');
+    try {
+      await mkdir(join(v, 'wiki'), { recursive: true });
+      await mkdir(join(v, 'raw-sources'), { recursive: true });
+      await writeFile(
+        join(v, 'raw-sources', 'article.md'),
+        [
+          '# Hot Cache Design',
+          '',
+          '## Memory Layout',
+          '',
+          'body content here',
+          '',
+          '### Deeply Nested Heading Should Not Appear',
+          '',
+          '## Disk Persistence',
+          '',
+        ].join('\n'),
+      );
+      const queries = await discoverQueries(v, 20);
+      assert.ok(Array.isArray(queries));
+      assert.ok(queries.length >= 2, `expected >= 2 queries from raw-sources, got: ${queries.join(', ')}`);
+      const lowered = queries.map((q) => q.toLowerCase());
+      assert.ok(lowered.includes('hot cache design'), `h1 missing in: ${queries.join(', ')}`);
+      assert.ok(
+        lowered.includes('memory layout') || lowered.includes('disk persistence'),
+        `h2 missing in: ${queries.join(', ')}`,
+      );
+      // h3 (#### ...) は対象外 (spec: top-level + h2 only)
+      assert.ok(
+        !lowered.includes('deeply nested heading should not appear'),
+        `h3 must not be included in: ${queries.join(', ')}`,
+      );
+    } finally {
+      await rm(ws, { recursive: true, force: true });
+    }
+  });
+
+  test('BLUE-QMD-INDEX-7 (F7): discoverQueries extracts git commit subjects + graceful on non-git-repo', async () => {
+    assert.ok(__test__);
+    const { discoverQueries } = __test__;
+
+    // (a) graceful: 非 git repo (no .git dir) は throw せず、git source 0 contribution
+    const wsNoGit = await mkdtemp(join(tmpdir(), 'kioku-qmd-f7-nogit-'));
+    const vNoGit = join(wsNoGit, 'vault');
+    try {
+      await mkdir(join(vNoGit, 'wiki'), { recursive: true });
+      const queriesNoGit = await discoverQueries(vNoGit, 10);
+      // throw しない、空配列 (or 他 source 由来) を返すこと
+      assert.ok(Array.isArray(queriesNoGit));
+      // 何も無い vault → 空のはず (sanity)
+      assert.equal(queriesNoGit.length, 0, `non-git empty vault should yield 0 queries, got: ${queriesNoGit.join(', ')}`);
+    } finally {
+      await rm(wsNoGit, { recursive: true, force: true });
+    }
+
+    // (b) git repo: commit subject が query 候補に入る
+    if (!(await isGitAvailable())) {
+      // 開発環境に git が無い場合は assertion skip (test 自体は pass、graceful path のみで verify 済)
+      return;
+    }
+    const ws = await mkdtemp(join(tmpdir(), 'kioku-qmd-f7-git-'));
+    const v = join(ws, 'vault');
+    try {
+      await mkdir(join(v, 'wiki'), { recursive: true });
+      // 何も file が無い状態で commit (allow-empty) して subject だけ生やす
+      await runGitTest(v, ['init', '-q', '-b', 'main']);
+      await runGitTest(v, ['commit', '-q', '--allow-empty', '-m', 'claude-brain: implement Search tab UI']);
+      await runGitTest(v, ['commit', '-q', '--allow-empty', '-m', 'visualizer: add graph snapshot mode']);
+      const queries = await discoverQueries(v, 20);
+      assert.ok(Array.isArray(queries));
+      assert.ok(queries.length >= 1, `expected >= 1 query from git subjects, got: ${queries.join(', ')}`);
+      const lowered = queries.map((q) => q.toLowerCase());
+      // subject の一部 (substring match) が query に含まれること
+      const hasSearchTab = lowered.some((q) => q.includes('search tab') || q.includes('implement search'));
+      const hasVisualizer = lowered.some((q) => q.includes('visualizer') || q.includes('graph snapshot'));
+      assert.ok(
+        hasSearchTab || hasVisualizer,
+        `expected at least one commit-derived query, got: ${queries.join(', ')}`,
+      );
+    } finally {
+      await rm(ws, { recursive: true, force: true });
+    }
+
+    // (c) BLUE-QMD-INDEX-7b: defense-in-depth — second-layer guard で getFileHistory が
+    // `{ commits: [], error: 'not_a_git_repo' }` shape (web-ui-shell.mjs:128 で visible) を返した時、
+    // ingestGitSubjects が throw せず counts に 0 contribution であること。
+    // F7 (a) は isGitRepo === false で early-return path を verify するが、isGitRepo が true を
+    // 返した上で getFileHistory が error shape を返す race / borderline ケース (例: .git dir 自体は
+    // あるが本物の repo として init されていない) を直接 verify する。
+    // 実 file system では race を組みづらいため、__test__ 経由で historyProvider を injection する。
+    assert.ok(__test__.ingestGitSubjects, 'ingestGitSubjects must be exposed via __test__');
+    const { ingestGitSubjects } = __test__;
+    const counts = new Map();
+    let providerCalled = 0;
+    const stubHistoryProvider = async () => {
+      providerCalled++;
+      return { commits: [], truncated: false, error: 'not_a_git_repo' };
+    };
+    const stubIsRepoProvider = async () => true; // bypass real isGitRepo check
+    await assert.doesNotReject(
+      ingestGitSubjects('/nonexistent-vault-path-fixture', counts, {
+        isRepoProvider: stubIsRepoProvider,
+        historyProvider: stubHistoryProvider,
+      }),
+      'ingestGitSubjects must not throw when getFileHistory returns not_a_git_repo error shape',
+    );
+    assert.equal(providerCalled, 1, 'historyProvider should be invoked once (isRepo gate passed)');
+    assert.equal(counts.size, 0, `counts must receive 0 contribution from not_a_git_repo shape, got: ${counts.size}`);
+  });
+
+  test('BLUE-QMD-INDEX-8 (F8): discoverQueries extracts wiki/hot.md ATX headings + 単独行 #tag', async () => {
+    assert.ok(__test__);
+    const { discoverQueries } = __test__;
+    const ws = await mkdtemp(join(tmpdir(), 'kioku-qmd-f8-'));
+    const v = join(ws, 'vault');
+    try {
+      await mkdir(join(v, 'wiki'), { recursive: true });
+      await writeFile(
+        join(v, 'wiki', 'hot.md'),
+        [
+          '# Recent Context',
+          '',
+          '#hot-cache',
+          '#wiki-rotting',
+          '',
+          '## Other Heading',
+          '',
+          'body line mentions #embedded-tag inline which should NOT be picked up as 単独行 tag',
+          '',
+          '### h3 heading also OK',
+          '',
+        ].join('\n'),
+      );
+      const queries = await discoverQueries(v, 20);
+      assert.ok(Array.isArray(queries));
+      assert.ok(queries.length >= 3, `expected >= 3 queries from hot.md, got: ${queries.join(', ')}`);
+      const lowered = queries.map((q) => q.toLowerCase());
+      // ATX heading (h1/h2/h3 all in scope per spec)
+      assert.ok(lowered.includes('recent context'), `h1 missing in: ${queries.join(', ')}`);
+      assert.ok(lowered.includes('other heading'), `h2 missing in: ${queries.join(', ')}`);
+      // 単独行 #tag
+      assert.ok(lowered.includes('hot-cache'), `standalone tag #hot-cache missing in: ${queries.join(', ')}`);
+      assert.ok(lowered.includes('wiki-rotting'), `standalone tag #wiki-rotting missing in: ${queries.join(', ')}`);
+      // body 中の inline tag は 単独行 ではないため除外 (spec: 「単独行に出る #tag」)
+      assert.ok(
+        !lowered.includes('embedded-tag'),
+        `inline body #tag must not be picked up as 単独行: ${queries.join(', ')}`,
+      );
+    } finally {
+      await rm(ws, { recursive: true, force: true });
+    }
+  });
+
+  test('BLUE-QMD-INDEX-9 (F9): empty PM-Vault-like fixture (no log tags / no index wikilinks / no concept files) yields >= 3 queries from raw-sources + git + hot.md', async () => {
+    assert.ok(__test__);
+    const { discoverQueries } = __test__;
+    if (!(await isGitAvailable())) {
+      // git absent: regression guard を verify する fixture が組めないので skip 相当
+      // (発火 condition: git source は PM vault では常に存在前提なので、開発環境で git 無い場合のみ)
+      return;
+    }
+    const ws = await mkdtemp(join(tmpdir(), 'kioku-qmd-f9-'));
+    const v = join(ws, 'vault');
+    try {
+      await mkdir(join(v, 'wiki'), { recursive: true });
+      await mkdir(join(v, 'raw-sources'), { recursive: true });
+
+      // ※ 意図的に空 / inline #tag 無し / [[wikilink]] 無し / concept file 無し:
+      // PM Vault dogfood で再現した「discoverQueries が 1 query しか返さない」condition を guard
+      await writeFile(
+        join(v, 'wiki', 'log.md'),
+        ['# Log', '', '## 2026-05-14', '## 2026-05-13', ''].join('\n'),
+      );
+      await writeFile(
+        join(v, 'wiki', 'index.md'),
+        ['# Index', '', 'plain text only, no wikilinks.', ''].join('\n'),
+      );
+
+      // raw-sources/ から 2 heading
+      await writeFile(
+        join(v, 'raw-sources', 'article-a.md'),
+        ['# Quantum Computing Intro', '', '## Qubit Basics', ''].join('\n'),
+      );
+      // hot.md から 2 heading
+      await writeFile(
+        join(v, 'wiki', 'hot.md'),
+        ['# Sprint 4 Phase 2', '', '## Phase 2 Goals', ''].join('\n'),
+      );
+
+      // git history で 2 commit
+      await runGitTest(v, ['init', '-q', '-b', 'main']);
+      await runGitTest(v, ['commit', '-q', '--allow-empty', '-m', 'kioku: precompute search index']);
+      await runGitTest(v, ['commit', '-q', '--allow-empty', '-m', 'docs: update phase 2 plan']);
+
+      const queries = await discoverQueries(v, 20);
+      assert.ok(Array.isArray(queries));
+      assert.ok(
+        queries.length >= 3,
+        `PM-Vault-like fixture regression guard: expected >= 3 queries, got ${queries.length}: ${queries.join(', ')}`,
+      );
+      // duplicate なし
+      const uniq = new Set(queries);
+      assert.equal(uniq.size, queries.length, 'discoverQueries must dedupe');
+    } finally {
+      await rm(ws, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/sync-diagnostic.test.sh
+++ b/tests/sync-diagnostic.test.sh
@@ -1,0 +1,318 @@
+#!/usr/bin/env bash
+#
+# sync-diagnostic.test.sh — Sprint 4 Phase 4 PR B4 (BLUE-DOCTOR-SYNC-1..3)
+#
+# Target: scripts/doctor.sh の check_sync_state section
+#
+# Test ID: BLUE-DOCTOR-SYNC-* (LEARN#8a per-file scope、本 file 内 unique)
+#
+# 方針:
+#   - 既存 doctor.test.sh と同 env-isolated pattern: env -i + temp HOME/Vault + PATH stub
+#   - 新規 curl stub で network reachability の ok / fail を切り替え
+#   - retry queue JSON は production schema (errorType/message/firstAttempt/
+#     lastAttempt/retryCount) と pin させて、schema drift で test が落ちるよう
+#     forcing function を入れる
+#   - 実 HOME / 実 Vault / 実 ~/.claude 等は absolutely touch しない
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+DOCTOR="${REPO_ROOT}/tools/claude-brain/scripts/doctor.sh"
+
+if [[ ! -f "${DOCTOR}" ]]; then
+  echo "FATAL: doctor.sh not found at ${DOCTOR}" >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "WARN: jq is not installed; sync-diagnostic tests rely on jq, will be skipped" >&2
+fi
+
+TMPROOT="$(mktemp -d)"
+trap 'rm -rf "${TMPROOT}"' EXIT
+
+PASS=0
+FAIL=0
+
+pass() {
+  PASS=$((PASS + 1))
+  echo "  ok  $1"
+}
+
+fail() {
+  FAIL=$((FAIL + 1))
+  echo "  NG  $1" >&2
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local msg="$3"
+  if printf '%s' "${haystack}" | grep -q -F -- "${needle}"; then
+    pass "${msg}"
+  else
+    fail "${msg} (substring not found: ${needle})"
+  fi
+}
+
+assert_not_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local msg="$3"
+  if printf '%s' "${haystack}" | grep -q -F -- "${needle}"; then
+    fail "${msg} (unexpected substring found: ${needle})"
+  else
+    pass "${msg}"
+  fi
+}
+
+# -----------------------------------------------------------------------------
+# Test scaffolding (mirrors doctor.test.sh patterns)
+# -----------------------------------------------------------------------------
+
+new_case() {
+  local name="$1"
+  local case_dir="${TMPROOT}/cases/${name}"
+  mkdir -p "${case_dir}/home" "${case_dir}/vault" "${case_dir}/bin"
+  echo "${case_dir}"
+}
+
+write_stub() {
+  local bin_dir="$1"
+  local name="$2"
+  local output="${3:-}"
+  cat >"${bin_dir}/${name}" <<EOF
+#!/usr/bin/env bash
+$( [[ -n "${output}" ]] && echo "echo '${output}'" )
+exit 0
+EOF
+  chmod +x "${bin_dir}/${name}"
+}
+
+# Build a PATH that includes the case-specific bin/ + curated system dirs.
+# `git` and `jq` must resolve to real binaries; `curl` is stubbed per-case.
+build_path() {
+  local case_bin="$1"
+  local extras=""
+  local p
+  for p in /usr/bin /bin /usr/sbin /sbin /opt/homebrew/bin /usr/local/bin; do
+    [[ -d "${p}" ]] && extras="${extras}:${p}"
+  done
+  printf '%s%s' "${case_bin}" "${extras}"
+}
+
+stub_full_clis() {
+  local bin="$1"
+  write_stub "${bin}" "claude"
+  write_stub "${bin}" "codex"
+  write_stub "${bin}" "gemini"
+  write_stub "${bin}" "qmd"
+  write_stub "${bin}" "pdfinfo"
+  write_stub "${bin}" "pdftotext"
+}
+
+stub_node_18() {
+  local bin="$1"
+  cat >"${bin}/node" <<'EOF'
+#!/usr/bin/env bash
+case "${1:-}" in
+  --version|-v) echo "v18.20.0" ;;
+  *) exit 0 ;;
+esac
+EOF
+  chmod +x "${bin}/node"
+}
+
+# curl stub that always succeeds (network ok scenario)
+stub_curl_ok() {
+  local bin="$1"
+  cat >"${bin}/curl" <<'EOF'
+#!/usr/bin/env bash
+# stub curl: success regardless of args
+exit 0
+EOF
+  chmod +x "${bin}/curl"
+}
+
+# curl stub that always fails (network unreachable scenario)
+stub_curl_fail() {
+  local bin="$1"
+  cat >"${bin}/curl" <<'EOF'
+#!/usr/bin/env bash
+# stub curl: failure regardless of args (simulates network down)
+exit 6
+EOF
+  chmod +x "${bin}/curl"
+}
+
+# Vault setup: full Vault with one initial commit so `git log -1` works
+init_full_vault_with_commit() {
+  local vault="$1"
+  mkdir -p "${vault}/wiki" "${vault}/session-logs" "${vault}/raw-sources" "${vault}/templates"
+  cat >"${vault}/.gitignore" <<'EOF'
+session-logs/
+.cache/
+.obsidian/
+EOF
+  (
+    cd "${vault}"
+    git init --quiet 2>/dev/null
+    git -c user.email=test@local -c user.name=test \
+        commit --allow-empty -m "initial" --quiet 2>/dev/null
+  ) || true
+}
+
+# Run doctor with overridden env. Mirrors run_doctor() in doctor.test.sh but
+# allows the caller to pre-stub curl ok/fail before invocation.
+run_doctor_with_env() {
+  local case_dir="$1"; shift
+  local home="${case_dir}/home"
+  local vault="${case_dir}/vault"
+  local case_bin="${case_dir}/bin"
+  local path
+  path="$(build_path "${case_bin}")"
+
+  env -i \
+    HOME="${home}" \
+    PATH="${path}" \
+    TMPDIR="${TMPDIR:-/tmp}" \
+    OBSIDIAN_VAULT="${vault}" \
+    "$@" \
+    bash "${DOCTOR}"
+}
+
+# -----------------------------------------------------------------------------
+# BLUE-DOCTOR-SYNC-1: healthy state
+#   Vault is Git repo, has a commit, no retry queue, network ok
+# -----------------------------------------------------------------------------
+test_sync_state_healthy() {
+  echo "BLUE-DOCTOR-SYNC-1: healthy sync state → ok lines (last commit + no retry + network ok)"
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "  skip  jq not available"
+    return 0
+  fi
+  local d
+  d="$(new_case "sync-healthy")"
+  stub_full_clis "${d}/bin"
+  stub_node_18 "${d}/bin"
+  stub_curl_ok "${d}/bin"
+  init_full_vault_with_commit "${d}/vault"
+
+  local out
+  set +e
+  out="$(run_doctor_with_env "${d}" 2>&1)"
+  set -e
+
+  assert_contains "${out}" "[ok]   Last Vault commit:" \
+    "SYNC-1: last commit timestamp printed"
+  assert_contains "${out}" "[ok]   No pending sync retry" \
+    "SYNC-1: no pending retry → ok line"
+  assert_contains "${out}" "[ok]   Network: github.com reachable" \
+    "SYNC-1: network reachable → ok line"
+  assert_not_contains "${out}" "[warn] Pending sync retry queue" \
+    "SYNC-1: no pending retry warn line"
+}
+
+# -----------------------------------------------------------------------------
+# BLUE-DOCTOR-SYNC-2: pending retry queue
+#   .kioku-sync-retry.json exists with retryCount=3 + errorType=network
+#   Network is also unreachable (composed scenario) — but the focus is the
+#   pending retry warn line with parsed details.
+# -----------------------------------------------------------------------------
+test_sync_state_pending_retry() {
+  echo "BLUE-DOCTOR-SYNC-2: pending retry queue → warn with retryCount + errorType + firstAttempt"
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "  skip  jq not available"
+    return 0
+  fi
+  local d
+  d="$(new_case "sync-pending-retry")"
+  stub_full_clis "${d}/bin"
+  stub_node_18 "${d}/bin"
+  stub_curl_ok "${d}/bin"
+  init_full_vault_with_commit "${d}/vault"
+
+  # Write a realistic retry queue file matching sync-vault.mjs schema
+  cat >"${d}/vault/.kioku-sync-retry.json" <<'EOF'
+{
+  "errorType": "network",
+  "message": "Could not resolve host: github.com",
+  "firstAttempt": "2026-05-14T10:00:00.000Z",
+  "lastAttempt": "2026-05-15T03:00:00.000Z",
+  "retryCount": 3
+}
+EOF
+
+  local out
+  set +e
+  out="$(run_doctor_with_env "${d}" 2>&1)"
+  set -e
+
+  assert_contains "${out}" "[warn] Pending sync retry queue" \
+    "SYNC-2: pending retry warn line emitted"
+  assert_contains "${out}" "3 attempts" \
+    "SYNC-2: retryCount=3 surfaced in detail"
+  assert_contains "${out}" "last error: network" \
+    "SYNC-2: errorType=network surfaced in detail"
+  assert_contains "${out}" "since: 2026-05-14T10:00:00.000Z" \
+    "SYNC-2: firstAttempt surfaced in detail"
+  assert_contains "${out}" "Next Claude session will retry automatically" \
+    "SYNC-2: next_action suggested (retry mechanism)"
+  # credential-leak negative assertion: schema must not embed ghp_/token/Bearer
+  # since masking happens at write-time. We embedded only a clean stderr so the
+  # diagnostic output must not contain any token-like literal either.
+  assert_not_contains "${out}" "ghp_" \
+    "SYNC-2: diagnostic output never contains ghp_ token literal"
+  assert_not_contains "${out}" "Bearer " \
+    "SYNC-2: diagnostic output never contains Bearer header literal"
+}
+
+# -----------------------------------------------------------------------------
+# BLUE-DOCTOR-SYNC-3: network unreachable
+#   curl stub exits non-zero → diagnostic emits the unreachable warn line.
+# -----------------------------------------------------------------------------
+test_sync_state_network_unreachable() {
+  echo "BLUE-DOCTOR-SYNC-3: github.com unreachable → warn with reconnect hint"
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "  skip  jq not available"
+    return 0
+  fi
+  local d
+  d="$(new_case "sync-network-unreachable")"
+  stub_full_clis "${d}/bin"
+  stub_node_18 "${d}/bin"
+  stub_curl_fail "${d}/bin"
+  init_full_vault_with_commit "${d}/vault"
+
+  local out
+  set +e
+  out="$(run_doctor_with_env "${d}" 2>&1)"
+  set -e
+
+  assert_contains "${out}" "[warn] Network: github.com unreachable" \
+    "SYNC-3: network unreachable warn line emitted"
+  assert_contains "${out}" "auto-sync will queue until reconnected" \
+    "SYNC-3: user notice mentions auto-queue + reconnect"
+  # Even when network is down, the other two sync axes should still report ok
+  # for a healthy Vault with no retry queue. This guards against the
+  # diagnostic short-circuiting on the first non-ok finding.
+  assert_contains "${out}" "[ok]   Last Vault commit:" \
+    "SYNC-3: last commit still surfaced when only network fails"
+  assert_contains "${out}" "[ok]   No pending sync retry" \
+    "SYNC-3: no-pending-retry still surfaced when only network fails"
+}
+
+# -----------------------------------------------------------------------------
+# Run all
+# -----------------------------------------------------------------------------
+test_sync_state_healthy
+test_sync_state_pending_retry
+test_sync_state_network_unreachable
+
+echo ""
+echo "sync-diagnostic.test.sh: ${PASS} passed, ${FAIL} failed"
+if [[ ${FAIL} -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/tests/sync-retry.test.mjs
+++ b/tests/sync-retry.test.mjs
@@ -1,0 +1,533 @@
+// tests/sync-retry.test.mjs — Sprint 4 Phase 4 PR A4 (BLUE-SYNC-A4-1..5)
+//
+// Target: hooks/sync-vault.mjs
+//
+// Test prefixes:
+//   - BLUE-SYNC-A4-1   classifyGitError buckets (network / non-fast-forward / auth / unknown)
+//   - BLUE-SYNC-A4-2   maskCredentials scrubs ghp_*, github_pat_*, Bearer, embedded URL creds
+//   - BLUE-SYNC-A4-3   retry queue write/read round-trip + atomic rename + malformed-tolerant
+//   - BLUE-SYNC-A4-4   syncToRemote on push failure enqueues masked entry (firstAttempt set)
+//   - BLUE-SYNC-A4-5   checkAndRetrySync drains queue on success / increments on re-failure
+//
+// Design notes:
+//   - We inject a `spawn` mock into the public helpers (no PATH stub needed).
+//     PR B4 introduces a PATH-based mockGitPushFailure for end-to-end coverage;
+//     for PR A4 the in-process injection is sufficient and faster.
+//   - Every test uses mkdtemp + rm to keep the real Vault untouched.
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  buildRetryQueueEntry,
+  checkAndRetrySync,
+  classifyGitError,
+  clearRetryQueue,
+  maskCredentials,
+  readRetryQueue,
+  retryQueuePathFor,
+  syncToRemote,
+  writeRetryQueue,
+} from '../hooks/sync-vault.mjs';
+
+// -----------------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------------
+
+async function makeVault() {
+  const dir = await mkdtemp(join(tmpdir(), 'kioku-sync-vault-'));
+  // mimic the pre-flight gates so shouldRunPush returns true
+  await writeFile(join(dir, '.gitignore'), 'session-logs/\n.obsidian/\n', 'utf8');
+  return dir;
+}
+
+/**
+ * Build a stub spawn function that mimics spawnSync's return shape. Routes
+ * `git <args>` to a per-test scripted table. Unknown commands return status=0
+ * with empty stdout/stderr so add/diff probes are inert by default.
+ */
+function makeGitStub(table) {
+  return (cmd, args) => {
+    if (cmd !== 'git') return { status: 0, stdout: '', stderr: '' };
+    const key = args.join(' ');
+    if (table[key] !== undefined) return table[key];
+    // wildcard prefix support for `add <paths...>`, `commit -m <msg> --quiet`
+    for (const prefix of Object.keys(table)) {
+      if (prefix.endsWith(' *') && key.startsWith(prefix.slice(0, -2))) {
+        return table[prefix];
+      }
+    }
+    return { status: 0, stdout: '', stderr: '' };
+  };
+}
+
+// -----------------------------------------------------------------------------
+// BLUE-SYNC-A4-1: classifyGitError buckets
+// -----------------------------------------------------------------------------
+
+describe('BLUE-SYNC-A4-1 classifyGitError', () => {
+  test('network: DNS failure', () => {
+    assert.equal(
+      classifyGitError('fatal: unable to access: Could not resolve host: github.com'),
+      'network'
+    );
+  });
+
+  test('network: connection refused', () => {
+    assert.equal(classifyGitError('ssh: connect to host github.com port 22: Connection refused'), 'network');
+  });
+
+  test('network: operation timed out', () => {
+    assert.equal(classifyGitError('fatal: unable to access: Operation timed out'), 'network');
+  });
+
+  test('non-fast-forward: rejected push', () => {
+    assert.equal(
+      classifyGitError(' ! [rejected]        main -> main (non-fast-forward)\nerror: failed to push some refs'),
+      'non-fast-forward'
+    );
+  });
+
+  test('non-fast-forward: tip behind remote', () => {
+    assert.equal(
+      classifyGitError("hint: Updates were rejected because the tip of your current branch is behind"),
+      'non-fast-forward'
+    );
+  });
+
+  test('auth: ssh public key denied', () => {
+    assert.equal(classifyGitError('git@github.com: Permission denied (publickey).'), 'auth');
+  });
+
+  test('auth: HTTPS 403', () => {
+    assert.equal(classifyGitError('remote: 403 Forbidden\nfatal: unable to access'), 'network');
+    // ^ note: also matches "unable to access" → network bucket wins by ordering.
+    // Pure 403 without unable-to-access should still hit auth:
+    assert.equal(classifyGitError('remote: 403 Forbidden'), 'auth');
+  });
+
+  test('unknown: empty + unrecognized', () => {
+    assert.equal(classifyGitError(''), 'unknown');
+    assert.equal(classifyGitError(null), 'unknown');
+    assert.equal(classifyGitError('some unrelated git diagnostic'), 'unknown');
+  });
+});
+
+// -----------------------------------------------------------------------------
+// BLUE-SYNC-A4-2: maskCredentials (delegates to maskText)
+// -----------------------------------------------------------------------------
+
+describe('BLUE-SYNC-A4-2 maskCredentials', () => {
+  test('masks ghp_ classic token', () => {
+    const input = 'fatal: Authentication failed for https://ghp_ABCDEFGHIJ1234567890abcdefg@github.com/org/repo.git';
+    const masked = maskCredentials(input);
+    assert.equal(masked.includes('ghp_ABCDEFGHIJ1234567890'), false, 'ghp_ literal must not leak');
+    assert.equal(masked.includes('ghp_***'), true);
+  });
+
+  test('masks github_pat_ fine-grained token', () => {
+    const input = 'remote: github_pat_11ABCDEFG0abcdefghijklmnopqrstuvwxyz fail';
+    const masked = maskCredentials(input);
+    assert.equal(/github_pat_11ABCDEFG0abcdefghijklm/.test(masked), false);
+    assert.equal(masked.includes('github_pat_***'), true);
+  });
+
+  test('masks Bearer header', () => {
+    const input = 'Authorization: Bearer abc.DEF.GHIjklmnop123';
+    const masked = maskCredentials(input);
+    assert.equal(masked.includes('abc.DEF.GHIjklmnop123'), false);
+    assert.equal(masked.includes('Bearer ***'), true);
+  });
+
+  test('masks embedded URL credentials', () => {
+    const input = 'fatal: unable to access https://user123:pass456@github.com/repo.git';
+    const masked = maskCredentials(input);
+    assert.equal(masked.includes('user123:pass456'), false);
+    assert.equal(masked.includes('://***:***@'), true);
+  });
+
+  test('non-string input returns empty string', () => {
+    assert.equal(maskCredentials(null), '');
+    assert.equal(maskCredentials(undefined), '');
+    assert.equal(maskCredentials(42), '');
+  });
+
+  test('plain text without secrets passes through', () => {
+    const input = 'network is unreachable';
+    assert.equal(maskCredentials(input), input);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// BLUE-SYNC-A4-3: retry queue write/read round-trip + atomic + malformed
+// -----------------------------------------------------------------------------
+
+describe('BLUE-SYNC-A4-3 retry queue I/O', () => {
+  test('write then read returns the same entry', async () => {
+    const vault = await makeVault();
+    try {
+      const qPath = retryQueuePathFor(vault);
+      const entry = buildRetryQueueEntry({
+        errorType: 'network',
+        stderr: 'Could not resolve host: github.com',
+        now: () => '2026-05-15T10:00:00.000Z',
+      });
+      await writeRetryQueue(qPath, entry);
+      assert.equal(existsSync(qPath), true);
+      const round = await readRetryQueue(qPath);
+      assert.deepEqual(round, entry);
+      assert.equal(entry.retryCount, 0);
+      assert.equal(entry.firstAttempt, '2026-05-15T10:00:00.000Z');
+      assert.equal(entry.lastAttempt, '2026-05-15T10:00:00.000Z');
+    } finally {
+      await rm(vault, { recursive: true, force: true });
+    }
+  });
+
+  test('subsequent buildRetryQueueEntry preserves firstAttempt and increments retryCount', () => {
+    const previous = buildRetryQueueEntry({
+      errorType: 'network',
+      stderr: 'first failure',
+      now: () => '2026-05-15T10:00:00.000Z',
+    });
+    const next = buildRetryQueueEntry({
+      errorType: 'network',
+      stderr: 'second failure',
+      previous,
+      now: () => '2026-05-15T11:00:00.000Z',
+    });
+    assert.equal(next.firstAttempt, '2026-05-15T10:00:00.000Z', 'firstAttempt preserved across retries');
+    assert.equal(next.lastAttempt, '2026-05-15T11:00:00.000Z');
+    assert.equal(next.retryCount, 1, 'retryCount increments by 1');
+  });
+
+  test('readRetryQueue returns null for missing file', async () => {
+    const vault = await makeVault();
+    try {
+      const round = await readRetryQueue(retryQueuePathFor(vault));
+      assert.equal(round, null);
+    } finally {
+      await rm(vault, { recursive: true, force: true });
+    }
+  });
+
+  test('readRetryQueue tolerates malformed JSON (returns null)', async () => {
+    const vault = await makeVault();
+    try {
+      const qPath = retryQueuePathFor(vault);
+      await writeFile(qPath, '{ not valid json', 'utf8');
+      const round = await readRetryQueue(qPath);
+      assert.equal(round, null, 'malformed JSON must not throw');
+    } finally {
+      await rm(vault, { recursive: true, force: true });
+    }
+  });
+
+  test('clearRetryQueue idempotent (missing file is not an error)', async () => {
+    const vault = await makeVault();
+    try {
+      const qPath = retryQueuePathFor(vault);
+      await clearRetryQueue(qPath); // should not throw
+      await writeRetryQueue(qPath, { errorType: 'network', message: '', firstAttempt: 't', lastAttempt: 't', retryCount: 0 });
+      assert.equal(existsSync(qPath), true);
+      await clearRetryQueue(qPath);
+      assert.equal(existsSync(qPath), false);
+      await clearRetryQueue(qPath); // second time still no throw
+    } finally {
+      await rm(vault, { recursive: true, force: true });
+    }
+  });
+
+  test('serialized queue file content never includes raw token literal', async () => {
+    const vault = await makeVault();
+    try {
+      const qPath = retryQueuePathFor(vault);
+      const entry = buildRetryQueueEntry({
+        errorType: 'auth',
+        stderr: 'fatal: Authentication failed for https://ghp_VeryRealLookingTokenLiteral1234567890@github.com/org/repo.git',
+        now: () => '2026-05-15T10:00:00.000Z',
+      });
+      await writeRetryQueue(qPath, entry);
+      const raw = await readFile(qPath, 'utf8');
+      assert.equal(
+        raw.includes('ghp_VeryRealLookingTokenLiteral1234567890'),
+        false,
+        'token literal must never appear in serialized queue file'
+      );
+      assert.equal(raw.includes('ghp_***'), true, 'masked replacement must be present');
+    } finally {
+      await rm(vault, { recursive: true, force: true });
+    }
+  });
+});
+
+// -----------------------------------------------------------------------------
+// BLUE-SYNC-A4-4: syncToRemote on push failure → enqueue masked entry
+// -----------------------------------------------------------------------------
+
+describe('BLUE-SYNC-A4-4 syncToRemote push failure flow', () => {
+  test('push failure writes retry queue with classified error + masked stderr', async () => {
+    const vault = await makeVault();
+    try {
+      const stderrLines = [];
+      const spawn = makeGitStub({
+        'symbolic-ref -q HEAD': { status: 0, stdout: 'refs/heads/main\n', stderr: '' },
+        'add wiki/ raw-sources/ templates/ CLAUDE.md': { status: 0, stdout: '', stderr: '' },
+        'diff --cached --quiet': { status: 1, stdout: '', stderr: '' }, // 1 = there are staged changes
+        'commit *': { status: 0, stdout: '', stderr: '' },
+        'push --quiet': {
+          status: 1,
+          stdout: '',
+          stderr: 'fatal: unable to access https://ghp_LeakedTokenLiteral12345678901234@github.com/org/repo.git: Could not resolve host: github.com',
+        },
+      });
+      const result = await syncToRemote({
+        vaultPath: vault,
+        env: { KIOKU_NO_LOG: '0' },
+        spawn,
+        stderr: (msg) => stderrLines.push(msg),
+        now: () => '2026-05-15T10:00:00.000Z',
+      });
+      assert.equal(result.status, 'queued');
+      assert.equal(result.errorType, 'network');
+      assert.equal(result.retryCount, 0, 'first failure starts at retryCount=0');
+
+      const qPath = retryQueuePathFor(vault);
+      assert.equal(existsSync(qPath), true);
+      const raw = await readFile(qPath, 'utf8');
+      assert.equal(raw.includes('ghp_LeakedTokenLiteral12345678901234'), false, 'no token literal in queue file');
+      assert.equal(raw.includes('ghp_***'), true);
+
+      assert.equal(stderrLines.length, 1, 'user notice emitted once');
+      assert.equal(
+        /クラウド同期できませんでした.*network/.test(stderrLines[0]),
+        true,
+        'Japanese user notice mentions classified error type'
+      );
+      assert.equal(stderrLines[0].includes('ghp_'), false, 'user notice never includes token-like literal');
+    } finally {
+      await rm(vault, { recursive: true, force: true });
+    }
+  });
+
+  test('successful push clears stale retry queue', async () => {
+    const vault = await makeVault();
+    try {
+      const qPath = retryQueuePathFor(vault);
+      await writeRetryQueue(qPath, {
+        errorType: 'network',
+        message: 'old failure',
+        firstAttempt: '2026-05-14T10:00:00.000Z',
+        lastAttempt: '2026-05-14T11:00:00.000Z',
+        retryCount: 3,
+      });
+      const spawn = makeGitStub({
+        'symbolic-ref -q HEAD': { status: 0, stdout: 'refs/heads/main\n', stderr: '' },
+        'add wiki/ raw-sources/ templates/ CLAUDE.md': { status: 0, stdout: '', stderr: '' },
+        'diff --cached --quiet': { status: 1, stdout: '', stderr: '' },
+        'commit *': { status: 0, stdout: '', stderr: '' },
+        'push --quiet': { status: 0, stdout: '', stderr: '' },
+      });
+      const result = await syncToRemote({
+        vaultPath: vault,
+        env: { KIOKU_NO_LOG: '0' },
+        spawn,
+        stderr: () => {},
+      });
+      assert.equal(result.status, 'pushed');
+      assert.equal(existsSync(qPath), false, 'stale retry queue cleared on success');
+    } finally {
+      await rm(vault, { recursive: true, force: true });
+    }
+  });
+
+  test('KIOKU_NO_LOG=1 short-circuits before any git invocation', async () => {
+    const vault = await makeVault();
+    try {
+      let calls = 0;
+      const spawn = (cmd, args) => {
+        calls += 1;
+        return { status: 0, stdout: '', stderr: '' };
+      };
+      const result = await syncToRemote({
+        vaultPath: vault,
+        env: { KIOKU_NO_LOG: '1' },
+        spawn,
+        stderr: () => {},
+      });
+      assert.equal(result.status, 'skipped');
+      assert.equal(calls, 0, 'no git calls when KIOKU_NO_LOG=1');
+    } finally {
+      await rm(vault, { recursive: true, force: true });
+    }
+  });
+
+  test('detached HEAD blocks push (v0.4.0 Tier A#2 regression, migrated from install-hooks.test.sh)', async () => {
+    const vault = await makeVault();
+    try {
+      let pushCalls = 0;
+      const spawn = (cmd, args) => {
+        if (args[0] === 'symbolic-ref') {
+          return { status: 1, stdout: '', stderr: 'fatal: ref HEAD is not a symbolic ref\n' };
+        }
+        if (args[0] === 'push') pushCalls += 1;
+        return { status: 0, stdout: '', stderr: '' };
+      };
+      const result = await syncToRemote({
+        vaultPath: vault,
+        env: { KIOKU_NO_LOG: '0' },
+        spawn,
+        stderr: () => {},
+      });
+      assert.equal(result.status, 'skipped', 'detached HEAD must short-circuit before push');
+      assert.equal(pushCalls, 0, 'git push must not be invoked on detached HEAD');
+    } finally {
+      await rm(vault, { recursive: true, force: true });
+    }
+  });
+
+  test('missing session-logs/ in .gitignore blocks push (mis-installed vault guard)', async () => {
+    const vault = await mkdtemp(join(tmpdir(), 'kioku-sync-vault-bad-'));
+    try {
+      // .gitignore deliberately lacks session-logs/ entry
+      await writeFile(join(vault, '.gitignore'), '.obsidian/\n', 'utf8');
+      let calls = 0;
+      const spawn = (cmd, args) => {
+        calls += 1;
+        if (args[0] === 'symbolic-ref') return { status: 0, stdout: 'refs/heads/main\n', stderr: '' };
+        return { status: 0, stdout: '', stderr: '' };
+      };
+      const result = await syncToRemote({
+        vaultPath: vault,
+        env: { KIOKU_NO_LOG: '0' },
+        spawn,
+        stderr: () => {},
+      });
+      assert.equal(result.status, 'skipped');
+      // shouldRunPush bails before symbolic-ref check, so no calls at all
+      assert.equal(calls, 0, 'no git calls when .gitignore lacks session-logs/');
+    } finally {
+      await rm(vault, { recursive: true, force: true });
+    }
+  });
+});
+
+// -----------------------------------------------------------------------------
+// BLUE-SYNC-A4-5: checkAndRetrySync drains queue / increments on re-failure
+// -----------------------------------------------------------------------------
+
+describe('BLUE-SYNC-A4-5 checkAndRetrySync flow', () => {
+  test('no queue → pulls and returns no-retry-needed', async () => {
+    const vault = await makeVault();
+    try {
+      const pullCalls = [];
+      const spawn = makeGitStub({
+        'pull --rebase --quiet': { status: 0, stdout: '', stderr: '' },
+      });
+      // wrap spawn to record pull invocation
+      const trackedSpawn = (cmd, args, opts) => {
+        if (cmd === 'git' && args[0] === 'pull') pullCalls.push(args.join(' '));
+        return spawn(cmd, args, opts);
+      };
+      const result = await checkAndRetrySync({
+        vaultPath: vault,
+        env: { KIOKU_NO_LOG: '0' },
+        spawn: trackedSpawn,
+        stderr: () => {},
+        stdout: () => {},
+      });
+      assert.equal(result.status, 'no-retry-needed');
+      assert.equal(pullCalls.length, 1, 'pull --rebase --quiet invoked once');
+      assert.equal(pullCalls[0], 'pull --rebase --quiet');
+    } finally {
+      await rm(vault, { recursive: true, force: true });
+    }
+  });
+
+  test('queue present + push succeeds → clears queue + emits success notice', async () => {
+    const vault = await makeVault();
+    try {
+      const qPath = retryQueuePathFor(vault);
+      await writeRetryQueue(qPath, {
+        errorType: 'network',
+        message: 'prior failure',
+        firstAttempt: '2026-05-14T10:00:00.000Z',
+        lastAttempt: '2026-05-14T11:00:00.000Z',
+        retryCount: 2,
+      });
+
+      const stdoutLines = [];
+      const spawn = makeGitStub({
+        'pull --rebase --quiet': { status: 0, stdout: '', stderr: '' },
+        'symbolic-ref -q HEAD': { status: 0, stdout: 'refs/heads/main\n', stderr: '' },
+        'push --quiet': { status: 0, stdout: '', stderr: '' },
+      });
+      const result = await checkAndRetrySync({
+        vaultPath: vault,
+        env: { KIOKU_NO_LOG: '0' },
+        spawn,
+        stderr: () => {},
+        stdout: (msg) => stdoutLines.push(msg),
+      });
+      assert.equal(result.status, 'retry-success');
+      assert.equal(result.retryCount, 3, 'reports retryCount incremented (2 prior + 1 retry attempt)');
+      assert.equal(existsSync(qPath), false, 'queue cleared on retry success');
+      assert.equal(stdoutLines.length, 1);
+      assert.equal(/クラウド同期が再開しました/.test(stdoutLines[0]), true);
+    } finally {
+      await rm(vault, { recursive: true, force: true });
+    }
+  });
+
+  test('queue present + push still fails → updates queue with incremented count + preserves firstAttempt', async () => {
+    const vault = await makeVault();
+    try {
+      const qPath = retryQueuePathFor(vault);
+      await writeRetryQueue(qPath, {
+        errorType: 'network',
+        message: 'prior',
+        firstAttempt: '2026-05-14T10:00:00.000Z',
+        lastAttempt: '2026-05-14T11:00:00.000Z',
+        retryCount: 1,
+      });
+
+      const stderrLines = [];
+      const spawn = makeGitStub({
+        'pull --rebase --quiet': { status: 0, stdout: '', stderr: '' },
+        'symbolic-ref -q HEAD': { status: 0, stdout: 'refs/heads/main\n', stderr: '' },
+        'push --quiet': {
+          status: 1,
+          stdout: '',
+          stderr: ' ! [rejected]        main -> main (non-fast-forward)\nerror: failed to push some refs',
+        },
+      });
+      const result = await checkAndRetrySync({
+        vaultPath: vault,
+        env: { KIOKU_NO_LOG: '0' },
+        spawn,
+        stderr: (msg) => stderrLines.push(msg),
+        stdout: () => {},
+        now: () => '2026-05-15T12:00:00.000Z',
+      });
+      assert.equal(result.status, 'retry-failed');
+      assert.equal(result.errorType, 'non-fast-forward');
+      assert.equal(result.retryCount, 2, 'increments to 2 (was 1)');
+
+      const updated = await readRetryQueue(qPath);
+      assert.equal(updated.firstAttempt, '2026-05-14T10:00:00.000Z', 'firstAttempt preserved');
+      assert.equal(updated.lastAttempt, '2026-05-15T12:00:00.000Z');
+      assert.equal(updated.errorType, 'non-fast-forward');
+      assert.equal(updated.retryCount, 2);
+
+      assert.equal(stderrLines.length, 1);
+      assert.equal(/クラウド同期に再失敗/.test(stderrLines[0]), true);
+      assert.equal(/non-fast-forward/.test(stderrLines[0]), true);
+    } finally {
+      await rm(vault, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/web-ui-shell.test.mjs
+++ b/tests/web-ui-shell.test.mjs
@@ -1,0 +1,402 @@
+// web-ui-shell.test.mjs — Tests for mcp/lib/web-ui-shell.mjs
+//
+// Sprint 4 Phase 1 PR B (plan/claude/26051301_v0-9-phase1-impl-plan.md §「PR B」 L1070-1769) +
+// Sprint 4 Phase 2 PR B2 (plan/claude/26051402_v0-9-phase2-qmd-search-impl-plan.md §「PR B2」).
+//
+// Test cases (10 BLUE-WEBUI-SHELL-* + INTEGRATION):
+//   BLUE-WEBUI-SHELL-1   (Task B-1, Phase 2 update): shell_meta has 8 tabs
+//                                    (6 enabled incl. Search + 2 placeholder)
+//   BLUE-WEBUI-SHELL-2   (Task B-2): visualizer field = first_view + lineage + snapshots
+//                                    (Sprint 3 data inline integration)
+//   BLUE-WEBUI-SHELL-3   (Task B-3/B-4): dashboard field = 10 views from dashboard.base
+//                                        (PR A renderBases consumption)
+//   BLUE-WEBUI-SHELL-4   (Task B-5): buildShellHtml placeholder replacement +
+//                                    security escape (`</script>` injection guard)
+//   BLUE-WEBUI-SHELL-5   (Task B-6): shell HTML inlines Visualizer β 4 view
+//                                    (Overview/Timeline/Diff/Lineage)
+//   BLUE-WEBUI-SHELL-6   (Phase 2 PR B2): buildShellData includes search_index field
+//   BLUE-WEBUI-SHELL-7   (Phase 2 PR B2): SHELL_TABS Search tab enabled === true
+//   BLUE-WEBUI-SHELL-8   (Phase 2 PR B2): shell HTML contains tab-search +
+//                                          Option C Tier 1/Tier 2 narrative
+//   BLUE-WEBUI-SHELL-9   (Phase 2 PR B2): JSON island search_index strips body / abs_path
+//   BLUE-WEBUI-SHELL-10  (Phase 2 PR B2): shell HTML self-contained (no fetch/XHR/etc.)
+//   BLUE-WEBUI-SHELL-INTEGRATION    : end-to-end buildShellHtml on fixture vault
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildShellData,
+  buildShellHtml,
+  _internals,
+} from '../mcp/lib/web-ui-shell.mjs';
+import { cloneSmallVault, disposeFixtureVault } from './fixtures/visualizer-vaults.mjs';
+import { withoutQmd } from './fixtures/test-helpers.mjs';
+
+// Phase 2 PR B2: buildShellData now invokes buildSearchIndex → handleSearch,
+// which spawns the `qmd` CLI when present. On developer machines with qmd
+// installed (operating on the user's brain-wiki collection, not the test
+// fixture vault), each subprocess can take 5-35 seconds, ballooning the
+// suite to 10+ minutes. We scope a PATH neutralization around the actual
+// buildShellData/buildShellHtml calls so qmd is invisible (handleSearch
+// falls through to the in-process Node walker) but system `git` remains
+// reachable for getFileHistory inside buildVisualizerData.
+//
+// withoutQmd は fixtures/test-helpers.mjs に統合 (LEARN#8b N=3 shared extract、
+// PR B2 sibling: qmd-search-index.test.mjs / xss-search-result-escape.test.mjs).
+
+// ---------------------------------------------------------------------------
+// BLUE-WEBUI-SHELL-1: shell_meta has 8 tabs (6 enabled + 2 placeholder)
+// (Phase 2 PR B2: Search tab promoted from placeholder to enabled.)
+// ---------------------------------------------------------------------------
+
+test('BLUE-WEBUI-SHELL-1: shell_meta has 8 tabs (6 enabled + 2 placeholder)', async () => {
+  const vault = await cloneSmallVault();
+  try {
+    const data = await withoutQmd(() => buildShellData(vault, { mode: 'snapshot' }));
+    assert.equal(data.schema_version, 1);
+    assert.equal(data.shell_meta.mode, 'snapshot');
+    assert.equal(data.shell_meta.default_tab, 'dashboard');
+    assert.equal(data.shell_meta.tabs.length, 8);
+    const enabled = data.shell_meta.tabs.filter((t) => t.enabled);
+    assert.equal(enabled.length, 6);
+    const enabledIds = enabled.map((t) => t.id).sort();
+    assert.deepEqual(enabledIds, ['dashboard', 'diff', 'lineage', 'overview', 'search', 'timeline']);
+    const placeholders = data.shell_meta.tabs.filter((t) => !t.enabled);
+    assert.equal(placeholders.length, 2);
+    const placeholderIds = placeholders.map((t) => t.id).sort();
+    assert.deepEqual(placeholderIds, ['navigation', 'wikilink-graph']);
+    for (const p of placeholders) {
+      assert.ok(typeof p.gate === 'string' && p.gate.length > 0,
+        `placeholder tab "${p.id}" must declare gate (phaseN)`);
+    }
+    assert.ok(/^\d{4}-\d{2}-\d{2}T/.test(data.shell_meta.generated_at),
+      'generated_at must be ISO timestamp');
+    assert.ok(typeof data.shell_meta.vault_name === 'string' && data.shell_meta.vault_name.length > 0);
+  } finally {
+    await disposeFixtureVault(vault);
+  }
+});
+
+test('BLUE-WEBUI-SHELL-1b: mode defaults to snapshot when unspecified', async () => {
+  const vault = await cloneSmallVault();
+  try {
+    const data = await withoutQmd(() => buildShellData(vault));
+    assert.equal(data.shell_meta.mode, 'snapshot');
+  } finally {
+    await disposeFixtureVault(vault);
+  }
+});
+
+test('BLUE-WEBUI-SHELL-1c: mode=served accepted as opaque flag (Phase 2 placeholder)', async () => {
+  const vault = await cloneSmallVault();
+  try {
+    const data = await withoutQmd(() => buildShellData(vault, { mode: 'served' }));
+    assert.equal(data.shell_meta.mode, 'served');
+  } finally {
+    await disposeFixtureVault(vault);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// BLUE-WEBUI-SHELL-2: visualizer field contains first_view + lineage + snapshots
+// ---------------------------------------------------------------------------
+
+test('BLUE-WEBUI-SHELL-2: visualizer field contains first_view + lineage + snapshots', async () => {
+  const vault = await cloneSmallVault();
+  try {
+    const data = await withoutQmd(() => buildShellData(vault, { mode: 'snapshot', max_commits: 5 }));
+    assert.equal(data.visualizer.schema_version, 4);
+    assert.ok('first_view' in data.visualizer);
+    assert.ok('lineage' in data.visualizer);
+    assert.ok(Array.isArray(data.visualizer.snapshots),
+      'visualizer.snapshots must be an array');
+    assert.ok(data.visualizer.snapshots.length >= 1,
+      'small fixture vault has >= 1 commit so snapshots should not be empty');
+    assert.equal(typeof data.visualizer.since, 'string');
+    assert.equal(typeof data.visualizer.commits_total, 'number');
+    // graceful degrade contract: if first_view is null, error must be string
+    if (data.visualizer.first_view === null) {
+      assert.ok(typeof data.visualizer.first_view_error === 'string',
+        'when first_view is null, first_view_error must be string');
+    }
+    if (data.visualizer.lineage === null) {
+      assert.ok(typeof data.visualizer.lineage_error === 'string',
+        'when lineage is null, lineage_error must be string');
+    }
+  } finally {
+    await disposeFixtureVault(vault);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// BLUE-WEBUI-SHELL-3: dashboard field renders 10 views from dashboard.base
+// (relies on Task B-4 fixture extension copying dashboard.base into vault)
+// ---------------------------------------------------------------------------
+
+test('BLUE-WEBUI-SHELL-3: dashboard field renders 10 views from dashboard.base', async () => {
+  const vault = await cloneSmallVault();
+  try {
+    const data = await withoutQmd(() => buildShellData(vault, { mode: 'snapshot' }));
+    assert.equal(data.dashboard.base_source, 'wiki/meta/dashboard.base');
+    assert.equal(data.dashboard.base_error, null,
+      `dashboard.base must render without error (got: ${data.dashboard.base_error})`);
+    assert.ok(Array.isArray(data.dashboard.views));
+    assert.equal(data.dashboard.views.length, 10,
+      'wiki/meta/dashboard.base declares 10 views');
+    assert.ok(Array.isArray(data.dashboard.warnings));
+    for (const view of data.dashboard.views) {
+      assert.ok(typeof view.name === 'string' && view.name.length > 0);
+      assert.ok(['table', 'list'].includes(view.type));
+    }
+  } finally {
+    await disposeFixtureVault(vault);
+  }
+});
+
+test('BLUE-WEBUI-SHELL-3b: dashboard field graceful degrade when base_source missing', async () => {
+  const vault = await cloneSmallVault();
+  try {
+    const data = await withoutQmd(() => buildShellData(vault, {
+      mode: 'snapshot',
+      base_source: 'does/not/exist.base',
+    }));
+    assert.equal(data.dashboard.base_source, 'does/not/exist.base');
+    assert.ok(typeof data.dashboard.base_error === 'string');
+    assert.ok(data.dashboard.base_error.startsWith('file_not_found:'));
+    assert.deepEqual(data.dashboard.views, []);
+  } finally {
+    await disposeFixtureVault(vault);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// BLUE-WEBUI-SHELL-4: buildShellHtml produces HTML with placeholder replaced
+// + security escape (</script> injection guard)
+// ---------------------------------------------------------------------------
+
+test('BLUE-WEBUI-SHELL-4: buildShellHtml replaces __KIOKU_SHELL_DATA__ + security escape', async () => {
+  const vault = await cloneSmallVault();
+  try {
+    const html = await withoutQmd(() => buildShellHtml(vault, { mode: 'snapshot' }));
+    assert.ok(typeof html === 'string' && html.length > 0);
+    assert.ok(html.includes('KIOKU Web UI'),
+      'shell title must appear in rendered HTML');
+    assert.ok(!html.includes('__KIOKU_SHELL_DATA__'),
+      'placeholder must be replaced');
+    assert.ok(html.includes('"schema_version":1'),
+      'inline JSON data must be present');
+    assert.ok(html.includes('"default_tab":"dashboard"'),
+      'shell_meta.default_tab=dashboard must serialize');
+    // security: no external network handles
+    const fetchHits = (html.match(/\bfetch\s*\(/g) || []).length;
+    const xhrHits = (html.match(/XMLHttpRequest|sendBeacon/g) || []).length;
+    assert.equal(fetchHits, 0, 'snapshot mode must not contain fetch() calls');
+    assert.equal(xhrHits, 0, 'snapshot mode must not contain XHR/sendBeacon');
+    const linkHrefHits = (html.match(/<link[^>]+href=/gi) || []).length;
+    assert.equal(linkHrefHits, 0, 'snapshot mode must not contain external <link href>');
+    // <script src=...> external loads must be 0; inline <script> with no src is fine
+    const scriptSrcHits = (html.match(/<script[^>]+\bsrc=/gi) || []).length;
+    assert.equal(scriptSrcHits, 0, 'snapshot mode must not contain external <script src>');
+    // </script> escape guard: data JSON must not contain raw </script>
+    const dataBlobMatch = html.match(/<script id="kioku-shell-data"[^>]*>([\s\S]*?)<\/script>/);
+    assert.ok(dataBlobMatch, 'kioku-shell-data <script> block must exist');
+    const dataBlob = dataBlobMatch[1];
+    assert.ok(!/<\/script>/i.test(dataBlob),
+      'inline JSON must not contain raw </script>');
+  } finally {
+    await disposeFixtureVault(vault);
+  }
+});
+
+test('BLUE-WEBUI-SHELL-4b: safeJsonForScript escapes injection vectors', () => {
+  const { safeJsonForScript } = _internals;
+  // Use String.fromCharCode for invisible separators so the test source stays
+  // reviewable (CLAUDE.md `.claude/rules/code-style.md` LEARN#13 spirit).
+  const U2028 = String.fromCharCode(0x2028);
+  const U2029 = String.fromCharCode(0x2029);
+  const evil = {
+    payload: '</script><img src=x onerror=alert(1)>',
+    sep2028: U2028,
+    sep2029: U2029,
+  };
+  const out = safeJsonForScript(evil);
+  assert.ok(!out.includes('</script>'),
+    'safeJsonForScript must escape literal </script>');
+  assert.ok(out.includes('\\u003c/script>'),
+    'safeJsonForScript must escape </ to \\u003c/');
+  assert.ok(!out.includes(U2028),
+    'safeJsonForScript must escape U+2028');
+  assert.ok(!out.includes(U2029),
+    'safeJsonForScript must escape U+2029');
+  assert.ok(out.includes('\\u2028'));
+  assert.ok(out.includes('\\u2029'));
+});
+
+// ---------------------------------------------------------------------------
+// BLUE-WEBUI-SHELL-5: shell HTML inlines Visualizer β 4 view from viz-template.html
+// ---------------------------------------------------------------------------
+
+test('BLUE-WEBUI-SHELL-5: shell HTML inlines Visualizer β 4 view (overview/timeline/diff/lineage)', async () => {
+  const vault = await cloneSmallVault();
+  try {
+    const html = await withoutQmd(() => buildShellHtml(vault, { mode: 'snapshot' }));
+    // Tab content containers must exist
+    assert.ok(html.includes('id="tab-overview"'),
+      'tab-overview section must be present in shell HTML');
+    assert.ok(html.includes('id="tab-timeline"'),
+      'tab-timeline section must be present');
+    assert.ok(html.includes('id="tab-diff"'),
+      'tab-diff section must be present');
+    assert.ok(html.includes('id="tab-lineage"'),
+      'tab-lineage section must be present');
+    // Inline data reference: shell JS exposes data.visualizer for tabs to consume
+    assert.ok(html.includes('data.visualizer'),
+      'shell template must reference data.visualizer for β tabs');
+    // viz-template inline body has key Sprint 3 markers; the inline placeholder
+    // must have been replaced (not raw __KIOKU_VIZ_INLINE__)
+    assert.ok(!html.includes('__KIOKU_VIZ_INLINE__'),
+      'viz inline placeholder must be replaced');
+  } finally {
+    await disposeFixtureVault(vault);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// BLUE-WEBUI-SHELL-INTEGRATION: end-to-end shell HTML build + render contract
+// ---------------------------------------------------------------------------
+
+test('BLUE-WEBUI-SHELL-INTEGRATION: end-to-end buildShellHtml produces self-contained HTML', async () => {
+  const vault = await cloneSmallVault();
+  try {
+    const html = await withoutQmd(() => buildShellHtml(vault, { mode: 'snapshot' }));
+    // doctype + html + body must be present (well-formed)
+    assert.ok(/^<!DOCTYPE html>/i.test(html.trim()),
+      'shell HTML must start with <!DOCTYPE html>');
+    assert.ok(html.includes('</html>'), 'shell HTML must close </html>');
+    // 8 tabs visible (data-tab-id attribute count) — JS-rendered, so check JSON has 8 tabs
+    const data = await withoutQmd(() => buildShellData(vault, { mode: 'snapshot' }));
+    assert.equal(data.shell_meta.tabs.length, 8);
+    // dashboard rendered with 10 views (LEARN#6 boundary: PR A → shell)
+    assert.equal(data.dashboard.views.length, 10);
+    // visualizer integrated (LEARN#6 boundary: Sprint 3 → shell)
+    assert.ok(Array.isArray(data.visualizer.snapshots));
+    // schema_version drift guard: shell schema (1) vs viz schema (4) independent
+    assert.equal(data.schema_version, 1);
+    assert.equal(data.visualizer.schema_version, 4);
+  } finally {
+    await disposeFixtureVault(vault);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// BLUE-WEBUI-SHELL-6: buildShellData includes search_index with valid shape
+// ---------------------------------------------------------------------------
+
+test('BLUE-WEBUI-SHELL-6: buildShellData includes search_index field with valid shape', async () => {
+  const vault = await cloneSmallVault();
+  try {
+    const data = await withoutQmd(() => buildShellData(vault, { mode: 'snapshot' }));
+    assert.ok(data.search_index, 'search_index must be present');
+    assert.equal(data.search_index.schema_version, 1);
+    assert.match(data.search_index.generated_at, /^\d{4}-\d{2}-\d{2}T/);
+    assert.ok(Array.isArray(data.search_index.queries));
+    assert.ok(data.shell_meta.search, 'shell_meta.search summary must be present');
+    assert.equal(typeof data.shell_meta.search.precomputed, 'number');
+    assert.equal(data.shell_meta.search.precomputed, data.search_index.queries.length);
+  } finally {
+    await disposeFixtureVault(vault);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// BLUE-WEBUI-SHELL-7: Search tab now enabled (Phase 2 promotion)
+// ---------------------------------------------------------------------------
+
+test('BLUE-WEBUI-SHELL-7: SHELL_TABS Search tab enabled === true with no gate', async () => {
+  const vault = await cloneSmallVault();
+  try {
+    const data = await withoutQmd(() => buildShellData(vault, { mode: 'snapshot' }));
+    const searchTab = data.shell_meta.tabs.find((t) => t.id === 'search');
+    assert.ok(searchTab, 'search tab must exist');
+    assert.equal(searchTab.enabled, true);
+    assert.ok(!('gate' in searchTab) || searchTab.gate === undefined,
+      'enabled search tab must not retain Phase 2 gate field');
+  } finally {
+    await disposeFixtureVault(vault);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// BLUE-WEBUI-SHELL-8: shell HTML contains <section id="tab-search"> + search hint
+// ---------------------------------------------------------------------------
+
+test('BLUE-WEBUI-SHELL-8: shell HTML contains tab-search section + Option C UX narrative hint', async () => {
+  const vault = await cloneSmallVault();
+  try {
+    const html = await withoutQmd(() => buildShellHtml(vault, { mode: 'snapshot' }));
+    assert.ok(html.includes('id="tab-search"'),
+      'shell HTML must contain <section id="tab-search">');
+    // Option C narrative must appear in either the template hint or the rendered IIFE strings
+    assert.ok(html.includes('Tier 1') && html.includes('Tier 2'),
+      'shell HTML must embed Option C Tier 1 / Tier 2 narrative');
+    assert.ok(html.includes('kioku_search'),
+      'shell HTML must reference the kioku_search MCP tool for Tier 2 deep-dive');
+  } finally {
+    await disposeFixtureVault(vault);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// BLUE-WEBUI-SHELL-9: search_index JSON island parses; results have no body/abs_path
+// ---------------------------------------------------------------------------
+
+test('BLUE-WEBUI-SHELL-9: search_index JSON island parse + results strip body/abs_path', async () => {
+  const vault = await cloneSmallVault();
+  try {
+    const html = await withoutQmd(() => buildShellHtml(vault, { mode: 'snapshot' }));
+    const m = html.match(/<script id="kioku-shell-data" type="application\/json">([\s\S]*?)<\/script>/);
+    assert.ok(m, 'kioku-shell-data <script> block must exist');
+    const parsed = JSON.parse(m[1]);
+    assert.ok(parsed.search_index, 'parsed shell data must contain search_index');
+    assert.ok(Array.isArray(parsed.search_index.queries));
+    for (const q of parsed.search_index.queries) {
+      for (const r of (q.results || [])) {
+        assert.ok(!('body' in r),
+          `search result for query "${q.query}" must not contain body`);
+        assert.ok(!('abs_path' in r),
+          `search result for query "${q.query}" must not contain abs_path`);
+        assert.equal(typeof r.title, 'string');
+        assert.equal(typeof r.rel, 'string');
+        assert.equal(typeof r.snippet, 'string');
+      }
+    }
+  } finally {
+    await disposeFixtureVault(vault);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// BLUE-WEBUI-SHELL-10: shell HTML self-contained — no fetch / XHR / sendBeacon
+// ---------------------------------------------------------------------------
+
+test('BLUE-WEBUI-SHELL-10: shell HTML self-contained (no fetch / XHR / sendBeacon / EventSource)', async () => {
+  const vault = await cloneSmallVault();
+  try {
+    const html = await withoutQmd(() => buildShellHtml(vault, { mode: 'snapshot' }));
+    const fetchHits = (html.match(/\bfetch\s*\(/g) || []).length;
+    const xhrHits = (html.match(/\bXMLHttpRequest\b/g) || []).length;
+    const beaconHits = (html.match(/\bsendBeacon\b/g) || []).length;
+    const sseHits = (html.match(/\bEventSource\b/g) || []).length;
+    const wsHits = (html.match(/\bWebSocket\b/g) || []).length;
+    const swHits = (html.match(/navigator\.serviceWorker/g) || []).length;
+    assert.equal(fetchHits, 0, 'snapshot mode shell HTML must not contain fetch() calls');
+    assert.equal(xhrHits, 0, 'snapshot mode shell HTML must not contain XMLHttpRequest');
+    assert.equal(beaconHits, 0, 'snapshot mode shell HTML must not contain sendBeacon');
+    assert.equal(sseHits, 0, 'snapshot mode shell HTML must not contain EventSource');
+    assert.equal(wsHits, 0, 'snapshot mode shell HTML must not contain WebSocket');
+    assert.equal(swHits, 0, 'snapshot mode shell HTML must not contain navigator.serviceWorker');
+  } finally {
+    await disposeFixtureVault(vault);
+  }
+});

--- a/tests/xss-search-result-escape.test.mjs
+++ b/tests/xss-search-result-escape.test.mjs
@@ -1,0 +1,107 @@
+// xss-search-result-escape.test.mjs — Sprint 4 Phase 2 PR B2
+//
+// Verifies that an adversarial query string (from wikilink discovery)
+// containing </script> / <img onerror> payloads is properly escaped in
+// the shell HTML JSON island, so the JS parser cannot be broken out of.
+//
+// F-numbers: per-file scope, F1..F3.
+
+import { test, describe, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { buildShellHtml } from '../mcp/lib/web-ui-shell.mjs';
+import { withoutQmd } from './fixtures/test-helpers.mjs';
+
+// withoutQmd は fixtures/test-helpers.mjs から import (LEARN#8b N=3 shared extract、
+// PR B2 sibling: qmd-search-index.test.mjs / web-ui-shell.test.mjs).
+// 仕組み: PATH を /usr/bin:/bin:/usr/sbin:/sbin に縮めて qmd を隠し、handleSearch を
+// in-process Node fallback walker 経路に固定。git は system path に残るので
+// buildVisualizerData 中の getFileHistory は通常通り動く。
+
+let workspace;
+let vault;
+
+before(async () => {
+  workspace = await mkdtemp(join(tmpdir(), 'kioku-xss-search-'));
+  vault = join(workspace, 'vault');
+  await mkdir(join(vault, 'wiki', 'meta'), { recursive: true });
+  // CLAUDE.md `.claude/rules/code-style.md` LEARN#13: only build U+2028 via
+  // String.fromCharCode in source — never write it as a regex literal.
+  const U2028 = String.fromCharCode(0x2028);
+  // index.md wikilinks → discoverQueries source 2 (weight 2). We push adversarial
+  // wikilink names so they become queries in the precomputed index.
+  // - [[</script>…]] proves the </script> close-tag escape.
+  // - [[……]]   proves the U+2028 escape inside the JSON island.
+  await writeFile(
+    join(vault, 'wiki', 'index.md'),
+    [
+      '# Index',
+      '',
+      '- [[</script><img src=x onerror=alert(1)>]]',
+      '- [[normal-page]]',
+      `- [[line${U2028}sep${U2028}payload]]`,
+      '',
+    ].join('\n'),
+  );
+  // Empty dashboard.base so buildShellData proceeds without errors. The
+  // default base_source path is wiki/meta/dashboard.base.
+  await writeFile(
+    join(vault, 'wiki', 'meta', 'dashboard.base'),
+    [
+      'name: empty',
+      'views: []',
+      '',
+    ].join('\n'),
+  );
+  // Empty log.md so source 1 produces nothing — only the adversarial wikilinks matter.
+  await writeFile(join(vault, 'wiki', 'log.md'), '# log\n');
+});
+
+after(() => rm(workspace, { recursive: true, force: true }));
+
+describe('xss-search-result-escape', () => {
+  test('F1 (BLUE-XSS-SEARCH-1): adversarial </script> in query is JSON-escaped inside the JSON island', async () => {
+    const html = await withoutQmd(() => buildShellHtml(vault, { mode: 'snapshot' }));
+    const m = html.match(/<script id="kioku-shell-data" type="application\/json">([\s\S]*?)<\/script>/);
+    assert.ok(m, 'JSON island block must exist');
+    const dataBlob = m[1];
+    // The JSON blob must NOT contain a raw </script> (otherwise the closing tag breaks out).
+    assert.ok(!/<\/script>/i.test(dataBlob),
+      'JSON island must not contain raw </script>');
+    // The escape sequence </script> must be present (safeJsonForScript path).
+    assert.ok(dataBlob.includes('\\u003c/script>'),
+      'JSON island must encode </script> as \\u003c/script>');
+  });
+
+  test('F2 (BLUE-XSS-SEARCH-2): adversarial payload does not appear as live HTML', async () => {
+    const html = await withoutQmd(() => buildShellHtml(vault, { mode: 'snapshot' }));
+    // Split HTML around the JSON island; the payload may appear ONLY inside the JSON island.
+    const islandMatch = html.match(/<script id="kioku-shell-data" type="application\/json">([\s\S]*?)<\/script>/);
+    assert.ok(islandMatch, 'JSON island block must exist');
+    const islandStart = html.indexOf(islandMatch[0]);
+    const islandEnd = islandStart + islandMatch[0].length;
+    const outsideIsland = html.slice(0, islandStart) + html.slice(islandEnd);
+    // Payload chars OUTSIDE the JSON island must not appear (live HTML tag escape).
+    assert.ok(!outsideIsland.includes('<img src=x onerror=alert(1)>'),
+      'raw adversarial <img> tag must not appear outside JSON island');
+    // Sanity: the payload IS encoded inside the JSON island (escaped form).
+    // Note: JSON only escapes a small set of control chars; < > are preserved as-is in JSON strings.
+    // The XSS-safe contract is that the JSON island block is treated as data, not HTML.
+  });
+
+  test('F3 (BLUE-XSS-SEARCH-3): U+2028 in payload is escaped to \\u2028 (safeJsonForScript)', async () => {
+    const html = await withoutQmd(() => buildShellHtml(vault, { mode: 'snapshot' }));
+    const m = html.match(/<script id="kioku-shell-data" type="application\/json">([\s\S]*?)<\/script>/);
+    assert.ok(m);
+    const dataBlob = m[1];
+    // Raw U+2028 must NOT appear in the JSON island (ECMAScript parser-illegal in inline JS).
+    const U2028 = String.fromCharCode(0x2028);
+    assert.ok(!dataBlob.includes(U2028),
+      'raw U+2028 must not appear in JSON island');
+    assert.ok(dataBlob.includes('\\u2028'),
+      'U+2028 must be escaped to \\u2028 by safeJsonForScript');
+  });
+});


### PR DESCRIPTION
## Summary

KIOKU **v0.9.0** release sync from parent (`megaphone-kurata/claude-tools` main `7292a23`).

**Sprint 3** (Visualizer β) + **Sprint 4 Phase 1-4** (Search + Mobile + Sync polish) 全 phase 完走、Path C+β progress **70% → 100%** 達成 = Sprint 4 全 cycle 完走。

## What changed in v0.9.0

**4 pillar narrative** = "Hardened LLM Wiki for Professionals + **Claude-augmented Search** + **Mobile responsive** + **Sync polished**":

### Sprint 3 (Visualizer β)
- Phase 1-4 全 4 cycle 完走 (graph node + edge + relation extraction + URL fragment 連動)
- `kioku_generate_viz mode=viz` で graph HTML 生成

### Sprint 4 Phase 1 (data + shell + dispatch)
- `qmd-search-index.mjs` snapshot precompute (vault offline filter 対応)
- `web-ui-shell.mjs` shell HTML 生成 (Search tab + dispatch routing)
- `kioku_generate_viz mode=shell` 追加

### Sprint 4 Phase 2 (Search)
- `kioku_search` intent param + discoverQueries 3→7 source 拡張
- shell Search tab UI + Tier 1 (offline filter) → Tier 2 (Claude で深掘り検索 deep-link)
- Visualizer β URL fragment `#q=...` → graph node highlight 連動

### Sprint 4 Phase 3 (Mobile responsive)
- shell + viz responsive CSS + hamburger menu + tap target 44pt+
- Tier 2 Mobile deep-link (`claude://` URI scheme + 1.5s timeout + claude.ai web fallback)
- iOS auto-zoom 防止 16px + virtual keyboard scroll 対応
- Mobile simplified view (renderMobileFallback) + 300KB performance budget guard

### Sprint 4 Phase 4 (Sync polish)
- `sync-vault.mjs` Git push retry queue + `classifyGitError` + `maskCredentials`
- `doctor.sh` sync state diagnostic (`check_sync_state`) + test infrastructure

## Coverage

- **Tests**: 全 suite pass (Phase 4 累計新規 44 件 BLUE-* test)
- **Security**: secret masking + classifyGitError + maskCredentials (Phase 4 Sync polish)
- **XSS**: search result escape test (Phase 2 Search)
- **CSP**: navigate-to policy for Tier 2 deep-link (Phase 3 Mobile)
- **Performance**: 300KB Mobile budget guard (Phase 3 Mobile)

## sync source

parent main commit `7292a23` (Sprint 3 PR #131 + Sprint 4 PR #135-#160 全 land 反映済)

## Next steps after merge

- kioku 側 10 言語 README + Changelog PR (`update-readme-v0.9.0`、別 PR、LEARN#11 critical)
- post-release-sync.sh execute (parent app/ sync)
- GitHub Release tag v0.9.0
- マーケ article publish (Zenn + dev.to + X)
- post-release dogfood Checkpoint 1