### PR TITLE
KIOKU v0.10.0 release (Sprint 5 + 5.5 = auto-ingest reliability + discoverQueries 自動学習)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "KIOKU: Hardened LLM Wiki for Claude Code / Claude Desktop by megaphone-tokyo",
-    "version": "0.9.0"
+    "version": "0.10.0"
   },
   "plugins": [
     {
@@ -17,7 +17,7 @@
         "ref": "main"
       },
       "description": "Hardened LLM Wiki for Claude Code + Claude Desktop. Automatic conversation → Obsidian Vault knowledge base. Hot cache + PostCompact hook + secret masking + Git sync.",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "author": {
         "name": "megaphone-tokyo",
         "url": "https://github.com/megaphone-tokyo"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kioku",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "KIOKU — Hardened LLM Wiki for Claude Code + Claude Desktop. Automatic conversation capture to Obsidian Vault, Karpathy LLM Wiki pattern, hot cache + PostCompact hook, secret masking, cross-machine Git sync. Research/legal/enterprise-grade memory for Claude.",
   "author": {
     "name": "megaphone-tokyo",

--- a/hooks/auto-ingest-retry.mjs
+++ b/hooks/auto-ingest-retry.mjs
@@ -1,0 +1,489 @@
+#!/usr/bin/env node
+// hooks/auto-ingest-retry.mjs — Auto-ingest pipeline retry queue (Sprint 5 PR A5).
+//
+// Mirrors hooks/sync-vault.mjs (Sprint 4 Phase 4 PR A4) but adapted for the
+// auto-ingest pipeline. Where sync-vault.mjs tracks a single push failure
+// (atomic batch op), auto-ingest fails per-raw-source so the queue holds an
+// array of entries keyed by `rawSource`.
+//
+// Failure points wired by scripts/auto-ingest.sh:
+//   - extract pre-step (PDF / EPUB / DOCX / URL): per-source failures
+//   - claude -p invocation: a single batch failure recorded against
+//     `<llm-batch>` placeholder (LLM operates on all unprocessed sources)
+//
+// Queue lifecycle:
+//   - First failure for a rawSource     → entry added with retryCount=0
+//   - Subsequent failures for same key  → retryCount incremented
+//   - retryCount >= MAX_RETRY_COUNT (3) → entry promoted to manual review queue
+//   - Successful processing             → entry removed from retry queue
+//
+// Files in $OBSIDIAN_VAULT:
+//   - .kioku-auto-ingest-retry.json          retry queue (subject to retry)
+//   - .kioku-auto-ingest-manual-review.json  exhausted entries (human action)
+//
+// Security contract (mirrors sync-vault.mjs):
+//   - Every stderr string passes through maskText() (scripts/lib/masking.mjs
+//     SSOT) before being persisted to disk or printed to user.
+//   - Never reads process.env.* token literals; only error type + masked
+//     message + raw-source path are persisted.
+//   - Atomic writes (tmp file + rename) so a partial JSON cannot be observed
+//     by a concurrent reader (doctor.sh, next cron tick).
+//   - Reads tolerate malformed JSON (treat queue as absent).
+
+import { existsSync } from 'node:fs';
+import {
+  mkdtemp,
+  readFile,
+  rename,
+  rm,
+  unlink,
+  writeFile,
+} from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { maskText } from '../scripts/lib/masking.mjs';
+
+// -----------------------------------------------------------------------------
+// Constants
+// -----------------------------------------------------------------------------
+
+const RETRY_QUEUE_FILENAME = '.kioku-auto-ingest-retry.json';
+const MANUAL_REVIEW_FILENAME = '.kioku-auto-ingest-manual-review.json';
+const MAX_STDERR_EXCERPT = 512;
+const MAX_RETRY_COUNT = 3;
+const SCHEMA_VERSION = 1;
+
+// -----------------------------------------------------------------------------
+// Pure helpers (exported for unit tests)
+// -----------------------------------------------------------------------------
+
+/**
+ * Classify an auto-ingest stderr into one of five bucket strings. Order is
+ * conservative: only stderr patterns confidently mapping to a single bucket.
+ */
+export function classifyAutoIngestError(stderr) {
+  if (typeof stderr !== 'string' || stderr.length === 0) return 'unknown';
+  if (
+    /sha256.*mismatch/i.test(stderr) ||
+    /sidecar.*drift/i.test(stderr) ||
+    /source_sha256.*differ/i.test(stderr)
+  ) {
+    return 'sha256_drift';
+  }
+  if (
+    /extract-(pdf|epub|docx|url|html)\.(sh|mjs).*(failed|exit\s+1|rc=[1-9])/i.test(stderr) ||
+    /poppler.*missing/i.test(stderr) ||
+    /yauzl.*invalid/i.test(stderr) ||
+    /mammoth.*failed/i.test(stderr) ||
+    /readability.*null/i.test(stderr)
+  ) {
+    return 'extract_failed';
+  }
+  if (
+    /\bclaude\b.*(timeout|timed out)/i.test(stderr) ||
+    /anthropic.*error/i.test(stderr) ||
+    /\bllm\b.*(failed|error)/i.test(stderr) ||
+    /max-turns.*reached/i.test(stderr) ||
+    /\bcontext.*(too\s+long|exceeded)/i.test(stderr) ||
+    /rate.?limit/i.test(stderr) ||
+    /api[_\-]?error/i.test(stderr)
+  ) {
+    return 'llm_failed';
+  }
+  if (
+    /\bENOENT\b/.test(stderr) ||
+    /\bEACCES\b/.test(stderr) ||
+    /\bENOSPC\b/.test(stderr) ||
+    /\bEEXIST\b/.test(stderr) ||
+    /\bEISDIR\b/.test(stderr) ||
+    /no\s+such\s+file\s+or\s+directory/i.test(stderr) ||
+    /permission\s+denied/i.test(stderr) ||
+    /no\s+space\s+left\s+on\s+device/i.test(stderr)
+  ) {
+    return 'fs_error';
+  }
+  return 'unknown';
+}
+
+/**
+ * Mask credential-like substrings before they leak into the retry queue file
+ * or user-visible stderr. Thin wrapper over maskText so call sites read
+ * intentionally ("we are masking for credential safety").
+ */
+export function maskCredentials(text) {
+  if (typeof text !== 'string') return '';
+  return maskText(text);
+}
+
+/**
+ * Compute the retry queue path for a given vault.
+ */
+export function retryQueuePathFor(vaultPath) {
+  return join(vaultPath, RETRY_QUEUE_FILENAME);
+}
+
+/**
+ * Compute the manual review queue path for a given vault.
+ */
+export function manualReviewQueuePathFor(vaultPath) {
+  return join(vaultPath, MANUAL_REVIEW_FILENAME);
+}
+
+/**
+ * Atomically write a queue file. Writes to a tmp file in the parent directory
+ * of the target, then renames into place — rename is atomic on the same
+ * filesystem so concurrent readers never observe partial JSON.
+ */
+export async function writeQueueFile(queuePath, queue) {
+  const parent = dirname(queuePath);
+  const tmpDir = await mkdtemp(join(parent, '.kioku-auto-ingest-tmp-'));
+  const tmpFile = join(tmpDir, 'queue.json');
+  try {
+    await writeFile(tmpFile, JSON.stringify(queue, null, 2) + '\n', 'utf8');
+    await rename(tmpFile, queuePath);
+  } finally {
+    try {
+      await unlink(tmpFile);
+    } catch {
+      /* expected when rename succeeded */
+    }
+    try {
+      await rm(tmpDir, { recursive: true, force: true });
+    } catch {
+      /* tolerate */
+    }
+  }
+}
+
+/**
+ * Read and parse a queue file. Returns null if the file is missing or
+ * malformed (defensive: a corrupt queue must not block the pipeline).
+ * Always returns the canonical shape `{ version, entries: [...] }` when valid;
+ * legacy single-entry shape is migrated transparently.
+ */
+export async function readQueueFile(queuePath) {
+  if (!existsSync(queuePath)) return null;
+  try {
+    const raw = await readFile(queuePath, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') return null;
+    if (Array.isArray(parsed.entries)) {
+      return {
+        version: Number.isFinite(parsed.version) ? parsed.version : SCHEMA_VERSION,
+        entries: parsed.entries,
+      };
+    }
+    return { version: SCHEMA_VERSION, entries: [] };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Remove a queue file. Idempotent — missing file is not an error.
+ */
+export async function clearQueueFile(queuePath) {
+  try {
+    await unlink(queuePath);
+  } catch (e) {
+    if (e && e.code === 'ENOENT') return;
+    /* best-effort; queue is auxiliary state */
+  }
+}
+
+/**
+ * Read the retry queue. Convenience over readQueueFile that always returns the
+ * canonical empty-queue shape when nothing is present (callers prefer
+ * `.entries.length === 0` over null-checks for the common path).
+ */
+export async function readAutoIngestRetryQueue(vaultPath) {
+  const queue = await readQueueFile(retryQueuePathFor(vaultPath));
+  return queue || { version: SCHEMA_VERSION, entries: [] };
+}
+
+/**
+ * Read the manual review queue. Same canonical-empty contract as the retry
+ * queue read.
+ */
+export async function readManualReviewQueue(vaultPath) {
+  const queue = await readQueueFile(manualReviewQueuePathFor(vaultPath));
+  return queue || { version: SCHEMA_VERSION, entries: [] };
+}
+
+/**
+ * Write the retry queue. If `entries` is empty, the queue file is removed
+ * (no point keeping an empty queue around for doctor.sh to misreport).
+ */
+export async function writeAutoIngestRetryQueue(vaultPath, queue) {
+  const queuePath = retryQueuePathFor(vaultPath);
+  if (!queue || !Array.isArray(queue.entries) || queue.entries.length === 0) {
+    await clearQueueFile(queuePath);
+    return;
+  }
+  await writeQueueFile(queuePath, {
+    version: SCHEMA_VERSION,
+    entries: queue.entries,
+  });
+}
+
+/**
+ * Append an entry to the manual review queue. Existing review queue is loaded,
+ * the entry is appended (or replaces an existing entry with the same
+ * rawSource), and the queue is written back atomically.
+ */
+export async function writeManualReviewQueue(vaultPath, queue) {
+  const queuePath = manualReviewQueuePathFor(vaultPath);
+  if (!queue || !Array.isArray(queue.entries) || queue.entries.length === 0) {
+    await clearQueueFile(queuePath);
+    return;
+  }
+  await writeQueueFile(queuePath, {
+    version: SCHEMA_VERSION,
+    entries: queue.entries,
+  });
+}
+
+/**
+ * Build a queue entry for a single failure. Centralizes the masking +
+ * truncation contract so callers cannot forget to mask. `previous` lets
+ * callers preserve `firstAttempt` and increment `retryCount` when updating an
+ * existing entry.
+ */
+export function buildAutoIngestRetryEntry({ rawSource, errorType, stderr, previous, now }) {
+  const clock = typeof now === 'function' ? now : () => new Date().toISOString();
+  const ts = clock();
+  const message = maskCredentials(stderr || '').slice(0, MAX_STDERR_EXCERPT);
+  if (previous && typeof previous === 'object') {
+    return {
+      rawSource,
+      errorType,
+      message,
+      firstAttempt: previous.firstAttempt || ts,
+      lastAttempt: ts,
+      retryCount: Number.isFinite(previous.retryCount) ? previous.retryCount + 1 : 1,
+    };
+  }
+  return {
+    rawSource,
+    errorType,
+    message,
+    firstAttempt: ts,
+    lastAttempt: ts,
+    retryCount: 0,
+  };
+}
+
+/**
+ * Add or update an entry in the retry queue. If the same rawSource already
+ * has an entry, build the next entry with `previous` (preserves
+ * firstAttempt + increments retryCount). Returns the updated queue (does not
+ * write — caller writes after deciding promote-to-manual-review).
+ */
+export function upsertEntry(queue, { rawSource, errorType, stderr, now }) {
+  const entries = Array.isArray(queue && queue.entries) ? [...queue.entries] : [];
+  const idx = entries.findIndex((e) => e && e.rawSource === rawSource);
+  const previous = idx >= 0 ? entries[idx] : null;
+  const next = buildAutoIngestRetryEntry({ rawSource, errorType, stderr, previous, now });
+  if (idx >= 0) {
+    entries[idx] = next;
+  } else {
+    entries.push(next);
+  }
+  return { version: SCHEMA_VERSION, entries };
+}
+
+/**
+ * Remove an entry by rawSource. Returns the updated queue. Missing entry is
+ * a no-op (returns queue unchanged).
+ */
+export function removeEntry(queue, rawSource) {
+  const entries = Array.isArray(queue && queue.entries) ? queue.entries : [];
+  const next = entries.filter((e) => !e || e.rawSource !== rawSource);
+  return { version: SCHEMA_VERSION, entries: next };
+}
+
+/**
+ * Split the retry queue into `keep` (entries still under threshold) and
+ * `promote` (entries that have hit MAX_RETRY_COUNT and should be moved to
+ * the manual review queue). Threshold comparison is `>=` so that the third
+ * retry failure (retryCount=3) triggers promotion.
+ */
+export function partitionForPromotion(queue, threshold = MAX_RETRY_COUNT) {
+  const entries = Array.isArray(queue && queue.entries) ? queue.entries : [];
+  const keep = [];
+  const promote = [];
+  for (const e of entries) {
+    if (!e) continue;
+    if (Number.isFinite(e.retryCount) && e.retryCount >= threshold) {
+      promote.push(e);
+    } else {
+      keep.push(e);
+    }
+  }
+  return {
+    keep: { version: SCHEMA_VERSION, entries: keep },
+    promote,
+  };
+}
+
+/**
+ * Merge new manual review entries into the existing manual review queue,
+ * keyed by rawSource (last-write-wins on duplicate keys). Used after
+ * partitionForPromotion to persist the promoted entries.
+ */
+export function mergeManualReview(existing, addEntries) {
+  const baseEntries = Array.isArray(existing && existing.entries) ? existing.entries : [];
+  const map = new Map();
+  for (const e of baseEntries) {
+    if (e && typeof e.rawSource === 'string') map.set(e.rawSource, e);
+  }
+  for (const e of addEntries || []) {
+    if (e && typeof e.rawSource === 'string') map.set(e.rawSource, e);
+  }
+  return { version: SCHEMA_VERSION, entries: Array.from(map.values()) };
+}
+
+// -----------------------------------------------------------------------------
+// High-level orchestration (used by CLI + auto-ingest.sh)
+// -----------------------------------------------------------------------------
+
+/**
+ * Record a failure for a rawSource. Loads the retry queue, upserts the entry,
+ * promotes any entries that hit the retry threshold to the manual review
+ * queue, and persists both. Returns a summary describing the result.
+ */
+export async function recordFailure({
+  vaultPath,
+  rawSource,
+  errorType,
+  stderr,
+  now,
+}) {
+  const retryQueue = await readAutoIngestRetryQueue(vaultPath);
+  const upserted = upsertEntry(retryQueue, { rawSource, errorType, stderr, now });
+  const { keep, promote } = partitionForPromotion(upserted);
+  if (promote.length > 0) {
+    const existingManual = await readManualReviewQueue(vaultPath);
+    const mergedManual = mergeManualReview(existingManual, promote);
+    await writeManualReviewQueue(vaultPath, mergedManual);
+  }
+  await writeAutoIngestRetryQueue(vaultPath, keep);
+  const recorded = upserted.entries.find((e) => e.rawSource === rawSource);
+  return {
+    status: promote.some((p) => p.rawSource === rawSource) ? 'promoted' : 'queued',
+    errorType,
+    retryCount: recorded ? recorded.retryCount : 0,
+    promotedCount: promote.length,
+  };
+}
+
+/**
+ * Record a success for a rawSource. If the rawSource was previously in the
+ * retry queue, remove it. Manual review queue is left untouched (a manual
+ * review entry implies a human needs to inspect; cron should not silently
+ * clear it on next-tick success).
+ */
+export async function recordSuccess({ vaultPath, rawSource }) {
+  const retryQueue = await readAutoIngestRetryQueue(vaultPath);
+  const before = retryQueue.entries.length;
+  const next = removeEntry(retryQueue, rawSource);
+  await writeAutoIngestRetryQueue(vaultPath, next);
+  return { status: before === next.entries.length ? 'noop' : 'cleared' };
+}
+
+// -----------------------------------------------------------------------------
+// CLI entry (LEARN#14 isEntry pattern — never fires during test import)
+// -----------------------------------------------------------------------------
+
+function isEntry() {
+  return Boolean(
+    process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href
+  );
+}
+
+async function readStdin() {
+  return new Promise((resolve) => {
+    let data = '';
+    if (process.stdin.isTTY) {
+      resolve('');
+      return;
+    }
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (chunk) => {
+      data += chunk;
+      if (data.length > 64 * 1024) {
+        // Defensive cap: refuse to buffer arbitrarily large stderr from a
+        // misbehaving extract script. Anything beyond 64KB is truncated.
+        data = data.slice(0, 64 * 1024);
+      }
+    });
+    process.stdin.on('end', () => resolve(data));
+    process.stdin.on('error', () => resolve(data));
+  });
+}
+
+async function main() {
+  const mode = process.argv[2];
+  const vaultPath = process.env.OBSIDIAN_VAULT;
+  if (!vaultPath) {
+    process.stderr.write('auto-ingest-retry: OBSIDIAN_VAULT not set\n');
+    process.exit(0);
+  }
+  if (!existsSync(vaultPath)) {
+    process.stderr.write(`auto-ingest-retry: OBSIDIAN_VAULT not found: ${vaultPath}\n`);
+    process.exit(0);
+  }
+  try {
+    if (mode === '--enqueue') {
+      const rawSource = process.argv[3];
+      const errorTypeArg = process.argv[4];
+      if (!rawSource) {
+        process.stderr.write('auto-ingest-retry: --enqueue requires <rawSource>\n');
+        process.exit(0);
+      }
+      const stderrText = await readStdin();
+      const errorType =
+        errorTypeArg && errorTypeArg !== 'auto'
+          ? errorTypeArg
+          : classifyAutoIngestError(stderrText);
+      const result = await recordFailure({
+        vaultPath,
+        rawSource,
+        errorType,
+        stderr: stderrText,
+      });
+      process.stdout.write(JSON.stringify(result) + '\n');
+    } else if (mode === '--remove') {
+      const rawSource = process.argv[3];
+      if (!rawSource) {
+        process.stderr.write('auto-ingest-retry: --remove requires <rawSource>\n');
+        process.exit(0);
+      }
+      const result = await recordSuccess({ vaultPath, rawSource });
+      process.stdout.write(JSON.stringify(result) + '\n');
+    } else if (mode === '--read') {
+      const retry = await readAutoIngestRetryQueue(vaultPath);
+      const manual = await readManualReviewQueue(vaultPath);
+      process.stdout.write(
+        JSON.stringify({ retry, manualReview: manual }, null, 2) + '\n'
+      );
+    } else {
+      process.stderr.write(
+        'auto-ingest-retry: unknown mode (use --enqueue|--remove|--read)\n'
+      );
+    }
+  } catch (e) {
+    try {
+      process.stderr.write(
+        `auto-ingest-retry: unexpected error (${maskCredentials(String((e && e.message) || e))})\n`
+      );
+    } catch {
+      /* suppress secondary failures */
+    }
+  }
+}
+
+if (isEntry()) {
+  main();
+}

--- a/mcp/lib/discoverqueries-learning.mjs
+++ b/mcp/lib/discoverqueries-learning.mjs
@@ -1,0 +1,458 @@
+// discoverqueries-learning.mjs — Sprint 5.5 PR A55: discoverQueries 8th source helper.
+//
+// Plan: tools/claude-brain/plan/claude/26051509_v0-10-sprint5-5-discoverqueries-learning-plan.md
+// Handoff: tools/claude-brain/handoff/26051504_v0-10-sprint5-5-discoverqueries-learning-delegation.md
+//
+// Responsibility:
+//   - Scan ${vault}/session-logs/*.md (top MAX_SCAN_FILES by mtime desc) and
+//     extract user-typed query signals (tag refs / wikilinks / ATX h1-h3
+//     headings) for use as Source 8 in qmd-search-index.mjs discoverQueries
+//     (weight 2.8, highest among all 8 sources).
+//   - Persist a usage log (`.kioku-discoverqueries-usage.json`) of accumulated
+//     query → count entries with FIFO rotation at 64KB cap.
+//
+// Privacy contract (3 axis):
+//   1. masking SSOT: applyMasks() from ./masking.mjs sanitizes credentials
+//      AFTER pre-strip steps so any literal that survived stripping is redacted.
+//   2. opt-out: ${vault}/.kioku-discoverqueries-opt-out file existence →
+//      scanSessionLogs returns empty Map; appendToUsageLog is a no-op (zero
+//      dynamic learning footprint on disk).
+//   3. 64KB FIFO rotate: usage log JSON ≤ 64KB; oldest entries (by lastSeen
+//      ASC) dropped one at a time until under cap.
+//
+// Local PII layer (scope-local, not in masking SSOT):
+//   - Email pattern → <email>
+//   - Japanese mobile phone (070/080/090, 4-4 digit pattern) → <phone>
+//
+// Atomic write contract (mirrors hooks/auto-ingest-retry.mjs writeQueueFile):
+//   - mkdtemp + writeFile + rename so concurrent readers never observe partial JSON.
+//   - Defensive read returns canonical empty `{ version, entries: [] }` on
+//     missing / malformed JSON (mirrors readAutoIngestRetryQueue).
+//
+// Path C+β boundary: no eval / new Function / fetch family / setTimeout with
+// string arg. Only node:fs/promises + node:path + masking SSOT.
+//
+// Library-only (no CLI entry / no isEntry block) — called from
+// qmd-search-index.mjs discoverQueries Source 8.
+
+import { existsSync } from 'node:fs';
+import {
+  mkdtemp,
+  readdir,
+  readFile,
+  rename,
+  rm,
+  stat,
+  unlink,
+  writeFile,
+} from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+
+import { applyMasks } from './masking.mjs';
+
+// -----------------------------------------------------------------------------
+// Public constants (privacy contract knobs + schema)
+// -----------------------------------------------------------------------------
+
+export const USAGE_LOG_FILENAME = '.kioku-discoverqueries-usage.json';
+export const USAGE_LOG_MAX_BYTES = 64 * 1024; // 64KB capacity bound
+export const OPT_OUT_FILENAME = '.kioku-discoverqueries-opt-out';
+export const SCHEMA_VERSION = 1;
+
+// -----------------------------------------------------------------------------
+// Internal constants (mirrors qmd-search-index.mjs budgets)
+// -----------------------------------------------------------------------------
+
+// session-logs/ scan cap: recency-biased, mirrors MAX_SCAN_FILES = 30 in
+// qmd-search-index.mjs (Source 3 / wiki dir scan).
+const MAX_SCAN_FILES = 30;
+
+// Per-file byte budget: large session-logs (long Claude turns) capped at 256KB
+// head-only read to bound CPU/memory.
+const MAX_SESSION_LOG_BYTES_PER_FILE = 256 * 1024;
+
+// Heading length filter (mirrors qmd-search-index.mjs Source 3).
+const MIN_HEADING_LEN = 2;
+const MAX_HEADING_LEN = 80;
+
+// -----------------------------------------------------------------------------
+// Regex (ASCII only — LEARN#13 invisible unicode prohibition satisfied)
+//
+// TAG_RE / WIKILINK_RE / HEADING_RE MUST mirror qmd-search-index.mjs so the
+// Source 8 query keys align with Source 1-7 keys (Map dedupe works correctly).
+// -----------------------------------------------------------------------------
+
+const TAG_RE = /(?:^|[^\w])#([a-z][a-z0-9-]{1,30})/gi;
+const WIKILINK_RE = /\[\[([^\]|]+?)(?:\|[^\]]+)?\]\]/g;
+const HEADING_RE = /^#{1,3}\s+(.+?)\s*$/gm;
+
+// Frontmatter: opening `---\n` ... closing `\n---\n` at file head only.
+// Trailing `\n?` accommodates files where frontmatter is the only content.
+const FRONTMATTER_RE = /^---\n[\s\S]*?\n---\n?/;
+
+// Fenced code block: both ``` ... ``` and ~~~ ... ~~~ styles.
+// Non-greedy so consecutive blocks are stripped independently. Each fence's
+// opener (with optional language tag) and closer are captured by the pattern.
+const FENCED_CODE_RE = /(?:^|\n)(```|~~~)[^\n]*\n[\s\S]*?\n\1[ \t]*(?=\n|$)/g;
+
+// Obsidian callout block: contiguous run of lines starting with `>` (with
+// optional leading whitespace). Strips both `> [!type]` Obsidian callouts and
+// plain `>` blockquotes (typically copied terminal output / tool stdout that
+// should not feed query signals).
+const CALLOUT_BLOCK_RE = /(?:^|\n)((?:[ \t]*>[^\n]*\n?)+)/g;
+
+// Local PII regex.
+//
+// Email: simplified ASCII-only RFC-5322 friendly. Avoids catastrophic regex
+// backtracking by being non-recursive.
+const EMAIL_RE = /[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}/g;
+
+// Japanese mobile phone: leading 070 / 080 / 090, then 4 digits, then 4 digits,
+// with optional hyphens between groups. `\b` boundaries reduce false positives.
+const JP_PHONE_RE = /\b0[789]0-?\d{4}-?\d{4}\b/g;
+
+// -----------------------------------------------------------------------------
+// Pre-strip helpers (exposed for unit tests via __test__)
+// -----------------------------------------------------------------------------
+
+/**
+ * Strip the leading YAML frontmatter block (between the first `---\n` and the
+ * matching `\n---\n`). Content after the frontmatter is returned verbatim.
+ * If no frontmatter is detected, input is returned unchanged.
+ */
+function stripFrontmatter(text) {
+  if (typeof text !== 'string') return '';
+  return text.replace(FRONTMATTER_RE, '');
+}
+
+/**
+ * Strip fenced code blocks (``` ... ``` and ~~~ ... ~~~). Fences and their body
+ * content are both removed. Inline code (`` `x` ``) is NOT stripped — inline
+ * tokens can legitimately be tag refs or wikilinks worth indexing.
+ */
+function stripCodeBlocks(text) {
+  if (typeof text !== 'string') return '';
+  return text.replace(FENCED_CODE_RE, '\n');
+}
+
+/**
+ * Strip Obsidian callout blocks AND plain blockquotes (any contiguous run of
+ * `> ...` lines). Both `> [!type]` Obsidian-style callouts and standalone `>`
+ * quotes are removed — the latter typically contain copied terminal stdout
+ * that should not feed query signals.
+ */
+function stripCalloutBlocks(text) {
+  if (typeof text !== 'string') return '';
+  return text.replace(CALLOUT_BLOCK_RE, '\n');
+}
+
+/**
+ * Apply local PII redaction (email + Japanese mobile phone) AFTER masking SSOT.
+ * Matches are replaced with `<email>` / `<phone>` placeholders so downstream
+ * query extraction cannot derive PII strings as query keys.
+ */
+function sanitizePII(text) {
+  if (typeof text !== 'string') return '';
+  return text.replace(EMAIL_RE, '<email>').replace(JP_PHONE_RE, '<phone>');
+}
+
+/**
+ * Extract query signals from sanitized content. Returns Map<string, number>
+ * keyed by lowercased query candidate with occurrence count as value.
+ *
+ * Signals:
+ *   - Tag refs:     #word-with-hyphen (TAG_RE)
+ *   - Wikilinks:    [[name]] / [[name|alias]] (WIKILINK_RE)
+ *   - ATX headings: # / ## / ### (HEADING_RE), length-filtered 2..80
+ *
+ * All keys lowercased + length-filtered to mirror qmd-search-index.mjs
+ * Source 1-7 contract.
+ */
+function extractQuerySignals(content) {
+  const out = new Map();
+  if (typeof content !== 'string' || content.length === 0) return out;
+
+  let m;
+  TAG_RE.lastIndex = 0;
+  while ((m = TAG_RE.exec(content)) !== null) {
+    const tag = m[1].toLowerCase();
+    if (tag.length < MIN_HEADING_LEN || tag.length > MAX_HEADING_LEN) continue;
+    out.set(tag, (out.get(tag) ?? 0) + 1);
+  }
+
+  WIKILINK_RE.lastIndex = 0;
+  while ((m = WIKILINK_RE.exec(content)) !== null) {
+    const name = m[1].trim().toLowerCase();
+    // Intentional hardening (stricter than qmd-search-index.mjs Source 2,
+    // which accepts any non-empty wikilink): session-logs are user-generated
+    // and noisier than wiki/index.md, and Source 8 carries the highest weight
+    // (2.8). Applying the same 2..80 length filter as headings suppresses
+    // 1-char / >80-char wikilink noise from being amplified into TopN.
+    if (!name || name.length < MIN_HEADING_LEN || name.length > MAX_HEADING_LEN) continue;
+    out.set(name, (out.get(name) ?? 0) + 1);
+  }
+
+  HEADING_RE.lastIndex = 0;
+  while ((m = HEADING_RE.exec(content)) !== null) {
+    const heading = m[1].trim().toLowerCase();
+    if (heading.length < MIN_HEADING_LEN || heading.length > MAX_HEADING_LEN) continue;
+    out.set(heading, (out.get(heading) ?? 0) + 1);
+  }
+
+  return out;
+}
+
+// -----------------------------------------------------------------------------
+// Public API
+// -----------------------------------------------------------------------------
+
+/**
+ * Compute the usage log path for a given vault.
+ */
+export function usageLogPathFor(vault) {
+  return join(vault, USAGE_LOG_FILENAME);
+}
+
+/**
+ * Compute the opt-out marker path for a given vault.
+ */
+export function optOutPathFor(vault) {
+  return join(vault, OPT_OUT_FILENAME);
+}
+
+/**
+ * True iff `${vault}/.kioku-discoverqueries-opt-out` exists. This is the
+ * privacy hard gate — when true, `scanSessionLogs` returns an empty Map and
+ * `appendToUsageLog` is a no-op (no file is created or modified).
+ *
+ * @param {string} vault
+ * @returns {Promise<boolean>}
+ */
+export async function isOptedOut(vault) {
+  if (typeof vault !== 'string' || vault.length === 0) return false;
+  return existsSync(optOutPathFor(vault));
+}
+
+/**
+ * Scan `${vault}/session-logs/*.md` (top MAX_SCAN_FILES by mtime descending),
+ * apply pre-strip + masking + PII sanitize, then extract query signals.
+ * Returns Map<string, number> of query → aggregate count across scanned files.
+ *
+ * Privacy contract:
+ *   1. opt-out hard gate (early return empty Map)
+ *   2. pre-strip: frontmatter → code blocks → callout blocks
+ *   3. applyMasks (credential SSOT redaction)
+ *   4. sanitizePII (email / 日本式 phone)
+ *
+ * Graceful skip cases (return empty Map, no throw):
+ *   - opted out
+ *   - session-logs/ does not exist or is unreadable
+ *
+ * @param {string} vault
+ * @param {object} [options] - reserved for future scan options (currently ignored); scan is always pure/read-only
+ * @returns {Promise<Map<string, number>>}
+ */
+export async function scanSessionLogs(vault, options = {}) {
+  void options; // reserved
+  const out = new Map();
+  if (typeof vault !== 'string' || vault.length === 0) return out;
+  if (await isOptedOut(vault)) return out;
+
+  const sessionLogsDir = join(vault, 'session-logs');
+  let dirents;
+  try {
+    dirents = await readdir(sessionLogsDir, { withFileTypes: true });
+  } catch {
+    return out; // session-logs/ absent or unreadable — graceful skip
+  }
+
+  // Collect (path, mtimeMs) for .md entries so we can sort by recency (newest first).
+  const candidates = [];
+  for (const dirent of dirents) {
+    if (!dirent.isFile() || !dirent.name.endsWith('.md')) continue;
+    const full = join(sessionLogsDir, dirent.name);
+    try {
+      const s = await stat(full);
+      candidates.push({ path: full, mtimeMs: s.mtimeMs || 0 });
+    } catch {
+      // file disappeared between readdir + stat — skip
+    }
+  }
+  candidates.sort((a, b) => b.mtimeMs - a.mtimeMs);
+  const selected = candidates.slice(0, MAX_SCAN_FILES);
+
+  for (const c of selected) {
+    let raw;
+    try {
+      raw = await readFile(c.path, 'utf8');
+    } catch {
+      continue; // tolerate per-file read failures
+    }
+    if (typeof raw !== 'string' || raw.length === 0) continue;
+    // Head-only read for DoS surface bound on pathological huge files.
+    if (raw.length > MAX_SESSION_LOG_BYTES_PER_FILE) {
+      raw = raw.slice(0, MAX_SESSION_LOG_BYTES_PER_FILE);
+    }
+    // Pre-strip → mask → PII sanitize → extract.
+    const stripped = stripCalloutBlocks(stripCodeBlocks(stripFrontmatter(raw)));
+    const masked = applyMasks(stripped);
+    const sanitized = sanitizePII(masked);
+    const signals = extractQuerySignals(sanitized);
+    for (const [k, v] of signals.entries()) {
+      out.set(k, (out.get(k) ?? 0) + v);
+    }
+  }
+
+  return out;
+}
+
+/**
+ * Read the usage log. Returns canonical empty shape on missing / malformed JSON
+ * (defensive: a corrupt log must not block precompute). Mirrors the contract
+ * of `readAutoIngestRetryQueue` in hooks/auto-ingest-retry.mjs.
+ *
+ * Entry shape: `{ query: string, count: number, firstSeen: ISO, lastSeen: ISO }`
+ *
+ * @param {string} vault
+ * @returns {Promise<{ version: number, entries: Array<{query: string, count: number, firstSeen: string, lastSeen: string}> }>}
+ */
+export async function readUsageLog(vault) {
+  const empty = { version: SCHEMA_VERSION, entries: [] };
+  if (typeof vault !== 'string' || vault.length === 0) return empty;
+  const filePath = usageLogPathFor(vault);
+  if (!existsSync(filePath)) return empty;
+  try {
+    const raw = await readFile(filePath, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') return empty;
+    if (!Array.isArray(parsed.entries)) return empty;
+    return {
+      version: Number.isFinite(parsed.version) ? parsed.version : SCHEMA_VERSION,
+      entries: parsed.entries.filter(
+        (e) =>
+          e &&
+          typeof e === 'object' &&
+          typeof e.query === 'string' &&
+          Number.isFinite(e.count)
+      ),
+    };
+  } catch {
+    return empty;
+  }
+}
+
+/**
+ * Append incoming queries (Map<string, number>) to the usage log. Existing
+ * entries have their `count` incremented and `lastSeen` updated; new entries
+ * are created with `firstSeen = lastSeen = now`. The serialized result is
+ * checked against USAGE_LOG_MAX_BYTES; oldest entries (by `lastSeen` ASC) are
+ * dropped one at a time until under cap. Written atomically (mkdtemp + rename)
+ * so concurrent readers never observe partial JSON.
+ *
+ * Opt-out: if `.kioku-discoverqueries-opt-out` exists, this is a no-op (the
+ * usage log file is neither created nor modified).
+ *
+ * @param {string} vault
+ * @param {Map<string, number>} queries
+ * @returns {Promise<void>}
+ */
+export async function appendToUsageLog(vault, queries) {
+  if (typeof vault !== 'string' || vault.length === 0) return;
+  if (!queries || typeof queries.entries !== 'function') return;
+  if (await isOptedOut(vault)) return;
+
+  // Empty input → nothing to write.
+  let hasInput = false;
+  for (const _ of queries.entries()) {
+    void _;
+    hasInput = true;
+    break;
+  }
+  if (!hasInput) return;
+
+  const filePath = usageLogPathFor(vault);
+  const existing = await readUsageLog(vault);
+
+  // Index existing entries by query for O(1) merge.
+  const idx = new Map();
+  for (const e of existing.entries) {
+    if (e && typeof e.query === 'string') {
+      idx.set(e.query, {
+        query: e.query,
+        count: Number.isFinite(e.count) ? e.count : 0,
+        firstSeen: typeof e.firstSeen === 'string' ? e.firstSeen : '',
+        lastSeen: typeof e.lastSeen === 'string' ? e.lastSeen : '',
+      });
+    }
+  }
+
+  const now = new Date().toISOString();
+  for (const [query, inc] of queries.entries()) {
+    if (typeof query !== 'string' || query.length === 0) continue;
+    if (!Number.isFinite(inc) || inc <= 0) continue;
+    const prev = idx.get(query);
+    if (prev) {
+      prev.count = (Number.isFinite(prev.count) ? prev.count : 0) + inc;
+      prev.lastSeen = now;
+      if (!prev.firstSeen) prev.firstSeen = now;
+    } else {
+      idx.set(query, { query, count: inc, firstSeen: now, lastSeen: now });
+    }
+  }
+
+  // FIFO rotation: drop oldest entry (smallest lastSeen) one at a time until
+  // serialized payload fits the 64KB budget. Sort by lastSeen ASC ONCE up
+  // front — shift() preserves the sorted order so re-sorting inside the loop
+  // is unnecessary (avoids O(n² log n)).
+  let entries = Array.from(idx.values());
+  entries.sort((a, b) => {
+    const al = typeof a.lastSeen === 'string' ? a.lastSeen : '';
+    const bl = typeof b.lastSeen === 'string' ? b.lastSeen : '';
+    return al < bl ? -1 : al > bl ? 1 : 0;
+  });
+  let payload = JSON.stringify({ version: SCHEMA_VERSION, entries }, null, 2) + '\n';
+  while (Buffer.byteLength(payload, 'utf8') > USAGE_LOG_MAX_BYTES && entries.length > 0) {
+    entries.shift();
+    payload = JSON.stringify({ version: SCHEMA_VERSION, entries }, null, 2) + '\n';
+  }
+
+  // Atomic write: tmp file in parent dir + rename. Mirrors writeQueueFile
+  // contract in hooks/auto-ingest-retry.mjs.
+  const parent = dirname(filePath);
+  const tmpDir = await mkdtemp(join(parent, '.kioku-dq-usage-tmp-'));
+  const tmpFile = join(tmpDir, 'usage.json');
+  try {
+    await writeFile(tmpFile, payload, 'utf8');
+    await rename(tmpFile, filePath);
+  } finally {
+    try {
+      await unlink(tmpFile);
+    } catch {
+      /* expected when rename succeeded */
+    }
+    try {
+      await rm(tmpDir, { recursive: true, force: true });
+    } catch {
+      /* tolerate */
+    }
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Internal helpers exposed for unit tests only.
+// Production callers must use the named exports above.
+// -----------------------------------------------------------------------------
+
+export const __test__ = Object.freeze({
+  stripFrontmatter,
+  stripCodeBlocks,
+  stripCalloutBlocks,
+  sanitizePII,
+  extractQuerySignals,
+  MAX_SCAN_FILES,
+  TAG_RE,
+  WIKILINK_RE,
+  HEADING_RE,
+  EMAIL_RE,
+  JP_PHONE_RE,
+});

--- a/mcp/lib/qmd-search-index.mjs
+++ b/mcp/lib/qmd-search-index.mjs
@@ -23,6 +23,7 @@ import { readFile, readdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { handleSearch } from '../tools/search.mjs';
 import { getFileHistory, isGitRepo } from './git-history.mjs';
+import { scanSessionLogs } from './discoverqueries-learning.mjs';
 
 export const SEARCH_INDEX_SCHEMA_VERSION = 1;
 
@@ -113,6 +114,10 @@ export async function buildSearchIndex(vault, options = {}) {
  *      (hot context = 直近 priority、user 関心と整合度高)
  *   7. wiki/*.md broadly-referenced (>=2 files) — bonus 1.2 * (file_count - 1)
  *      (broadly referenced concept; source 3 と独立に bonus、double-count 回避は per-file Set で記録)
+ *   8. session-logs/ user utilization scan (Sprint 5.5 PR A55) — weight 2.8
+ *      (highest single-source weight: dynamic learning from actual user activity.
+ *      Privacy contract: masking SSOT + opt-out file + 64KB usage log rotate.
+ *      See mcp/lib/discoverqueries-learning.mjs for details.)
  *
  * Dedupe / score: Map で同 query 加算、最後に weight 降順 sort + limit clamp。
  *
@@ -217,6 +222,20 @@ async function discoverQueries(vault, limit) {
       const bonus = 1.2 * (fileSet.size - 1);
       counts.set(heading, (counts.get(heading) ?? 0) + bonus);
     }
+  }
+
+  // Source 8 (NEW, Sprint 5.5 PR A55): user utilization log scan (weight 2.8).
+  // session-logs/ scan with masking SSOT for credential safety + opt-out file
+  // for user control + 64KB FIFO rotation for bounded persistence.
+  // graceful skip on any failure: opt-out / session-logs absent / scan error
+  // all yield an empty Map, preserving build precompute robustness.
+  try {
+    const usageMap = await scanSessionLogs(vault);
+    for (const [query, count] of usageMap.entries()) {
+      counts.set(query, (counts.get(query) ?? 0) + 2.8 * count);
+    }
+  } catch {
+    // best-effort: dynamic learning failure must not abort discoverQueries
   }
 
   // sort by weighted score desc, take top N, dedupe (Map keys already unique)

--- a/mcp/manifest.json
+++ b/mcp/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "kioku-wiki",
   "display_name": "KIOKU Wiki",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Read, search, and write your KIOKU Obsidian Wiki from Claude Desktop or Claude Code.",
   "long_description": "KIOKU is a personal knowledge base ('second brain') built on top of an Obsidian Vault. This MCP server exposes eleven tools (kioku_search, kioku_read, kioku_list, kioku_write_note, kioku_write_wiki, kioku_delete, kioku_ingest_pdf, kioku_ingest_url, kioku_ingest_document, kioku_generate_viz, kioku_health) so that Claude Desktop and Claude Code can browse and update the Wiki without leaving the chat. All operations are local stdio — nothing leaves your machine. See https://github.com/megaphone-tokyo/kioku for the full project.",
   "author": {

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kioku-mcp",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "private": true,
   "type": "module",
   "description": "KIOKU local MCP server (Wiki read/list/search/write_note/write_wiki/delete) for Claude Desktop and Claude Code.",

--- a/scripts/auto-ingest.sh
+++ b/scripts/auto-ingest.sh
@@ -34,6 +34,49 @@ elapsed_seconds() {
 }
 
 # -----------------------------------------------------------------------------
+# Auto-ingest retry queue (Sprint 5 PR A5)
+# -----------------------------------------------------------------------------
+# extract pre-step (PDF / EPUB / DOCX / URL) と LLM 呼び出し (claude -p) の失敗を
+# Vault 内 JSON に記録し、3 回 retry 後に manual review queue へ promote する。
+# Implementation: hooks/auto-ingest-retry.mjs (Node ESM、scripts/lib/masking.mjs SSOT 経由 credential 自動マスク)
+#
+# Bash 側は rc/stderr を helper に渡すだけで、queue I/O / 分類 / promotion logic は
+# 全て Node 側。 cron 環境で node 不在の場合は record_* は silent no-op、auto-ingest 本体
+# の動作には影響しない (resilience-first)。
+AUTO_INGEST_RETRY_HELPER="$(dirname "$0")/../hooks/auto-ingest-retry.mjs"
+
+# 失敗を記録 (extract または LLM)。$3 が指定されていればそのファイルから stderr を読む、
+# 無ければ空 stdin で起動 (errorType を caller が決め打ちするケース)。
+record_auto_ingest_failure() {
+  local raw_source="$1"
+  local error_type="$2"
+  local stderr_log="${3:-}"
+  if [[ ! -f "${AUTO_INGEST_RETRY_HELPER}" ]] || ! command -v node >/dev/null 2>&1; then
+    return 0
+  fi
+  if [[ -n "${stderr_log}" ]] && [[ -f "${stderr_log}" ]]; then
+    OBSIDIAN_VAULT="${OBSIDIAN_VAULT}" \
+      node "${AUTO_INGEST_RETRY_HELPER}" --enqueue "${raw_source}" "${error_type}" \
+      < "${stderr_log}" >/dev/null 2>&1 || true
+  else
+    OBSIDIAN_VAULT="${OBSIDIAN_VAULT}" \
+      node "${AUTO_INGEST_RETRY_HELPER}" --enqueue "${raw_source}" "${error_type}" \
+      </dev/null >/dev/null 2>&1 || true
+  fi
+}
+
+# 成功を記録 (rawSource を retry queue から削除、manual review queue は触らない)。
+record_auto_ingest_success() {
+  local raw_source="$1"
+  if [[ ! -f "${AUTO_INGEST_RETRY_HELPER}" ]] || ! command -v node >/dev/null 2>&1; then
+    return 0
+  fi
+  OBSIDIAN_VAULT="${OBSIDIAN_VAULT}" \
+    node "${AUTO_INGEST_RETRY_HELPER}" --remove "${raw_source}" \
+    </dev/null >/dev/null 2>&1 || true
+}
+
+# -----------------------------------------------------------------------------
 # Raw MD sha256 計算 helper (v0.6 Phase C-3)
 # -----------------------------------------------------------------------------
 # raw-sources/<subdir>/<name>.md (fetched/ 以外、ユーザー直接配置) の source_sha256 を
@@ -244,18 +287,24 @@ if [[ -d "${RAW_SOURCES_DIR}" ]] \
       subdir_prefix="root"
     fi
 
+    pdf_stderr_log=$(mktemp)
     set +e
-    bash "${EXTRACT_PDF_SCRIPT}" "${pdf}" "${CACHE_DIR}" "${subdir_prefix}"
+    bash "${EXTRACT_PDF_SCRIPT}" "${pdf}" "${CACHE_DIR}" "${subdir_prefix}" 2>"${pdf_stderr_log}"
     rc=$?
+    cat "${pdf_stderr_log}" >&2
     set -e
     case "${rc}" in
-      0) ;;
+      0) record_auto_ingest_success "${pdf}" ;;
       2) echo "${LOG_PREFIX} [info] skipped PDF (encrypted/invalid): ${pdf}" >&2 ;;
       3) echo "${LOG_PREFIX} [info] skipped PDF (empty text / scanned): ${pdf}" >&2 ;;
       4) echo "${LOG_PREFIX} [info] skipped PDF (exceeds hard page limit): ${pdf}" >&2 ;;
       5) echo "${LOG_PREFIX} [warn] PDF outside raw-sources/: ${pdf}" >&2 ;;
-      *) echo "${LOG_PREFIX} [warn] extract-pdf.sh failed (rc=${rc}): ${pdf}" >&2 ;;
+      *)
+        echo "${LOG_PREFIX} [warn] extract-pdf.sh failed (rc=${rc}): ${pdf}" >&2
+        record_auto_ingest_failure "${pdf}" "extract_failed" "${pdf_stderr_log}"
+        ;;
     esac
+    rm -f "${pdf_stderr_log}"
   done < <(find "${RAW_SOURCES_DIR}" -type f -name "*.pdf" 2>/dev/null)
 elif [[ -d "${RAW_SOURCES_DIR}" ]] && find "${RAW_SOURCES_DIR}" -type f -name "*.pdf" 2>/dev/null | grep -q .; then
   echo "${LOG_PREFIX} [warn] PDF(s) present in raw-sources/ but poppler (pdfinfo/pdftotext) or extract-pdf.sh is unavailable. Install poppler to enable PDF ingestion." >&2
@@ -292,23 +341,29 @@ if [[ -d "${RAW_SOURCES_DIR}" ]] && [[ -f "${EXTRACT_EPUB_SCRIPT}" ]]; then
     # OBSIDIAN_VAULT と KIOKU_DOC_MAX_* を呼出側が明示注入 (child-env allowlist 不変)。
     # KIOKU_DOC_MAX_* を allowlist に追加すると prompt injection 経由で size cap を巨大化
     # される攻撃余地ができる (meeting 26042202 合意)。
+    epub_stderr_log=$(mktemp)
     set +e
     OBSIDIAN_VAULT="${OBSIDIAN_VAULT}" \
     KIOKU_DOC_MAX_EXTRACT_BYTES="${KIOKU_DOC_MAX_EXTRACT_BYTES:-209715200}" \
     KIOKU_DOC_MAX_ENTRIES="${KIOKU_DOC_MAX_ENTRIES:-5000}" \
     KIOKU_DOC_MAX_ENTRY_BYTES="${KIOKU_DOC_MAX_ENTRY_BYTES:-52428800}" \
     KIOKU_DOC_MAX_INPUT_BYTES="${KIOKU_DOC_MAX_INPUT_BYTES:-104857600}" \
-      node "${EXTRACT_EPUB_SCRIPT}" "${epub}" "${RAW_SOURCES_DIR}" "${subdir_prefix}"
+      node "${EXTRACT_EPUB_SCRIPT}" "${epub}" "${RAW_SOURCES_DIR}" "${subdir_prefix}" 2>"${epub_stderr_log}"
     rc=$?
+    cat "${epub_stderr_log}" >&2
     set -e
     case "${rc}" in
-      0) ;;
+      0) record_auto_ingest_success "${epub}" ;;
       2) echo "${LOG_PREFIX} [info] skipped EPUB (invalid): ${epub}" >&2 ;;
       3) echo "${LOG_PREFIX} [info] skipped EPUB (empty spine): ${epub}" >&2 ;;
       4) echo "${LOG_PREFIX} [info] skipped EPUB (exceeds max input size): ${epub}" >&2 ;;
       5) echo "${LOG_PREFIX} [warn] EPUB outside raw-sources/: ${epub}" >&2 ;;
-      *) echo "${LOG_PREFIX} [warn] extract-epub.mjs failed (rc=${rc}): ${epub}" >&2 ;;
+      *)
+        echo "${LOG_PREFIX} [warn] extract-epub.mjs failed (rc=${rc}): ${epub}" >&2
+        record_auto_ingest_failure "${epub}" "extract_failed" "${epub_stderr_log}"
+        ;;
     esac
+    rm -f "${epub_stderr_log}"
   done < <(find "${RAW_SOURCES_DIR}" -type f -name "*.epub" 2>/dev/null)
 fi
 
@@ -343,23 +398,29 @@ if [[ -d "${RAW_SOURCES_DIR}" ]] && [[ -f "${EXTRACT_DOCX_SCRIPT}" ]]; then
     # OBSIDIAN_VAULT と KIOKU_DOC_MAX_* を呼出側が明示注入 (child-env allowlist 不変)。
     # KIOKU_DOC_MAX_* を allowlist に追加すると prompt injection 経由で size cap を巨大化
     # される攻撃余地ができる (meeting 26042202 合意、EPUB と同方針)。
+    docx_stderr_log=$(mktemp)
     set +e
     OBSIDIAN_VAULT="${OBSIDIAN_VAULT}" \
     KIOKU_DOC_MAX_EXTRACT_BYTES="${KIOKU_DOC_MAX_EXTRACT_BYTES:-209715200}" \
     KIOKU_DOC_MAX_ENTRIES="${KIOKU_DOC_MAX_ENTRIES:-5000}" \
     KIOKU_DOC_MAX_ENTRY_BYTES="${KIOKU_DOC_MAX_ENTRY_BYTES:-52428800}" \
     KIOKU_DOC_MAX_INPUT_BYTES="${KIOKU_DOC_MAX_INPUT_BYTES:-104857600}" \
-      node "${EXTRACT_DOCX_SCRIPT}" "${docx}" "${RAW_SOURCES_DIR}" "${subdir_prefix}"
+      node "${EXTRACT_DOCX_SCRIPT}" "${docx}" "${RAW_SOURCES_DIR}" "${subdir_prefix}" 2>"${docx_stderr_log}"
     rc=$?
+    cat "${docx_stderr_log}" >&2
     set -e
     case "${rc}" in
-      0) ;;
+      0) record_auto_ingest_success "${docx}" ;;
       2) echo "${LOG_PREFIX} [info] skipped DOCX (invalid): ${docx}" >&2 ;;
       3) echo "${LOG_PREFIX} [info] skipped DOCX (empty content): ${docx}" >&2 ;;
       4) echo "${LOG_PREFIX} [info] skipped DOCX (exceeds max input size): ${docx}" >&2 ;;
       5) echo "${LOG_PREFIX} [warn] DOCX outside raw-sources/: ${docx}" >&2 ;;
-      *) echo "${LOG_PREFIX} [warn] extract-docx.mjs failed (rc=${rc}): ${docx}" >&2 ;;
+      *)
+        echo "${LOG_PREFIX} [warn] extract-docx.mjs failed (rc=${rc}): ${docx}" >&2
+        record_auto_ingest_failure "${docx}" "extract_failed" "${docx_stderr_log}"
+        ;;
     esac
+    rm -f "${docx_stderr_log}"
   done < <(find "${RAW_SOURCES_DIR}" -type f -name "*.docx" 2>/dev/null)
 fi
 
@@ -395,16 +456,22 @@ if [[ -d "${RAW_SOURCES_DIR}" ]] && [[ -f "${EXTRACT_URL_SCRIPT}" ]]; then
 
     url_subdir="$(basename "$(dirname "${urls_file}")")"
 
+    url_stderr_log=$(mktemp)
     set +e
     bash "${EXTRACT_URL_SCRIPT}" \
       --urls-file "${urls_file}" \
       --vault "${OBSIDIAN_VAULT}" \
-      --subdir "${url_subdir}"
+      --subdir "${url_subdir}" 2>"${url_stderr_log}"
     rc=$?
+    cat "${url_stderr_log}" >&2
     set -e
     if [[ "${rc}" -ne 0 ]]; then
       echo "${LOG_PREFIX} [warn] extract-url.sh for ${urls_file} exited ${rc}" >&2
+      record_auto_ingest_failure "${urls_file}" "extract_failed" "${url_stderr_log}"
+    else
+      record_auto_ingest_success "${urls_file}"
     fi
+    rm -f "${url_stderr_log}"
   done < <(find "${RAW_SOURCES_DIR}" -type f -name "urls.txt" 2>/dev/null)
 fi
 
@@ -673,7 +740,30 @@ run_ingest() {
     --max-turns 60
 }
 
-run_ingest
+# Sprint 5 PR A5: LLM 呼び出しの失敗を retry queue に記録する。
+# `<llm-batch>` placeholder を rawSource に使う (LLM は全 unprocessed sources を
+# 1 回で処理するため per-source 粒度は持たない。3 連敗で manual review queue 行き)。
+#
+# trap chain: claude -p は 25 分動く可能性があるため、SIGTERM / SIGKILL で kill
+# された場合に tmp file を /tmp に残さないよう、acquire_lock の EXIT trap を
+# release_lock + LLM_STDERR_LOG cleanup の合成 handler に上書きする (bash trap は
+# per-signal で 1 handler、複数 cleanup は `;` 区切りで chain)。
+LLM_STDERR_LOG=$(mktemp)
+trap 'release_lock; rm -f "${LLM_STDERR_LOG:-}"' EXIT
+
+set +e
+run_ingest 2>"${LLM_STDERR_LOG}"
+LLM_RC=$?
+cat "${LLM_STDERR_LOG}" >&2 || true
+set -e
+
+if [[ "${LLM_RC}" -ne 0 ]]; then
+  echo "${LOG_PREFIX} [warn] claude -p failed (rc=${LLM_RC})" >&2
+  record_auto_ingest_failure "<llm-batch>" "llm_failed" "${LLM_STDERR_LOG}"
+else
+  record_auto_ingest_success "<llm-batch>"
+fi
+rm -f "${LLM_STDERR_LOG}" || true
 
 # -----------------------------------------------------------------------------
 # Ingest 結果を commit & push

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -598,6 +598,221 @@ check_sync_state() {
 }
 
 # -----------------------------------------------------------------------------
+# Section: Auto-ingest state (Sprint 5 PR B5)
+#
+# Sprint 5 PR A5 で導入した auto-ingest retry queue + manual review queue を
+# read-only で集約表示する。doctor.sh はユーザーが「最後に Wiki が更新されたのは
+# いつか」「extract / LLM 失敗で retry を待っている file はあるか」「人手 review
+# が必要な entry はあるか」を一目で把握できるようにする。
+#
+# 集約する 3 axis:
+# - auto-ingest-last  : raw-sources/ 配下 .processed marker の最新 mtime
+#                       (extract-pdf.sh / extract-epub.mjs / extract-docx.mjs
+#                       が成功時に touch する規約 — 現状未定義の場合は
+#                       wiki/summaries/ の最新 mtime で fallback)
+# - auto-ingest-retry : .kioku-auto-ingest-retry.json の entries 件数 + 最新 errorType
+# - auto-ingest-manual: .kioku-auto-ingest-manual-review.json の entries 件数
+#
+# Vault が存在しない / OBSIDIAN_VAULT 未設定の場合は本 section を丸ごと skip
+# (existing env-vault check が既に状態を伝えている)。
+# -----------------------------------------------------------------------------
+check_auto_ingest_state() {
+  if [[ -z "${OBSIDIAN_VAULT:-}" ]] || [[ ! -d "${OBSIDIAN_VAULT}" ]]; then
+    return 0
+  fi
+
+  # axis 1: last successful auto-ingest 時刻
+  # raw-sources/ 配下 .processed marker (extract-* 成功時に touch、現状は
+  # extract scripts 側 PR で導入予定) → 無ければ wiki/summaries/ 最新 mtime fallback
+  local last_marker_epoch=""
+  if [[ -d "${OBSIDIAN_VAULT}/raw-sources" ]]; then
+    last_marker_epoch="$(find "${OBSIDIAN_VAULT}/raw-sources" -name ".processed" -type f \
+      -exec stat -f '%m' {} + 2>/dev/null | sort -rn | head -1 || true)"
+  fi
+  if [[ -z "${last_marker_epoch}" ]] && [[ -d "${OBSIDIAN_VAULT}/wiki/summaries" ]]; then
+    last_marker_epoch="$(find "${OBSIDIAN_VAULT}/wiki/summaries" -type f -name "*.md" \
+      -exec stat -f '%m' {} + 2>/dev/null | sort -rn | head -1 || true)"
+  fi
+  if [[ -n "${last_marker_epoch}" ]]; then
+    local last_iso
+    last_iso="$(date -r "${last_marker_epoch}" -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \
+      || date -u -d "@${last_marker_epoch}" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \
+      || echo "${last_marker_epoch}")"
+    add_check "auto-ingest-last" "ok" \
+      "Last auto-ingest activity: ${last_iso}"
+  else
+    # Both raw-sources/ markers and wiki/summaries/ are empty.
+    # Treat as fresh-install state: silent (matches the auto-ingest-manual
+    # convention of "absent = healthy default"). doctor.sh's existing
+    # "no message = nothing to flag" convention preserves the EXIT-CODE-1 (all
+    # ok) test expectation when wiki/summaries/ is empty.
+    :
+  fi
+
+  # axis 2: pending retry queue
+  local retry_queue="${OBSIDIAN_VAULT}/.kioku-auto-ingest-retry.json"
+  if [[ ! -f "${retry_queue}" ]]; then
+    add_check "auto-ingest-retry" "ok" \
+      "No pending auto-ingest retry"
+  elif [[ "${HAS_JQ}" -eq 1 ]]; then
+    local entries_count last_error_type
+    entries_count="$(jq -r '.entries | length' "${retry_queue}" 2>/dev/null || echo "?")"
+    last_error_type="$(jq -r '.entries[-1].errorType // "unknown"' "${retry_queue}" 2>/dev/null || echo "unknown")"
+    if [[ "${entries_count}" == "0" ]]; then
+      add_check "auto-ingest-retry" "ok" \
+        "No pending auto-ingest retry (queue file present but empty)"
+    else
+      add_check "auto-ingest-retry" "warn" \
+        "Pending auto-ingest retry queue: ${entries_count} entries (latest error: ${last_error_type})" \
+        "Next cron tick will retry. Inspect: cat \"\${OBSIDIAN_VAULT}/.kioku-auto-ingest-retry.json\""
+    fi
+  else
+    # jq 不在 fallback: file 存在 + 行数で entries を粗く count
+    local rough_count
+    rough_count="$(grep -c '"errorType"' "${retry_queue}" 2>/dev/null | tr -d ' ' || echo "?")"
+    add_check "auto-ingest-retry" "warn" \
+      "Pending auto-ingest retry queue (~${rough_count} entries, install jq for detail)" \
+      "brew install jq  # or: apt-get install jq"
+  fi
+
+  # axis 3: manual review queue (3 連敗 → human review 待ち)
+  local manual_review="${OBSIDIAN_VAULT}/.kioku-auto-ingest-manual-review.json"
+  if [[ ! -f "${manual_review}" ]]; then
+    # absent = 健全 (entry 0 は default state)、ok 行は出さず silent
+    :
+  elif [[ "${HAS_JQ}" -eq 1 ]]; then
+    local manual_count
+    manual_count="$(jq -r '.entries | length' "${manual_review}" 2>/dev/null || echo "?")"
+    if [[ "${manual_count}" == "0" ]]; then
+      :
+    else
+      add_check "auto-ingest-manual" "fail" \
+        "Manual review queue: ${manual_count} entries (3 retry failed, human action required)" \
+        "Inspect: cat \"\${OBSIDIAN_VAULT}/.kioku-auto-ingest-manual-review.json\""
+    fi
+  else
+    local manual_rough
+    manual_rough="$(grep -c '"rawSource"' "${manual_review}" 2>/dev/null | tr -d ' ' || echo "?")"
+    add_check "auto-ingest-manual" "fail" \
+      "Manual review queue: ~${manual_rough} entries (3 retry failed, human action required, install jq for detail)" \
+      "brew install jq"
+  fi
+}
+
+# -----------------------------------------------------------------------------
+# Section: DiscoverQueries state (Sprint 5.5 PR B55)
+#
+# Sprint 5.5 PR A55 で導入した discoverQueries 8th source (session-logs/ scan
+# dynamic learning) は、`.kioku-discoverqueries-usage.json` usage log に
+# query → count を蓄積し、`.kioku-discoverqueries-opt-out` file でユーザーが
+# 無効化できる。doctor.sh はユーザーが「dynamic learning は動いているか」
+# 「opt-out 済か」「usage log は 64KB rotation 間際か」を一目で把握できる
+# read-only diagnostic を提供する。
+#
+# 集約する 3 axis:
+# - discoverqueries-optout : .kioku-discoverqueries-opt-out 存在 → warn
+#                            (dynamic learning disabled、static 7 source のみ)。
+#                            不在なら silent (= dynamic learning 有効が default)
+# - discoverqueries-usage  : .kioku-discoverqueries-usage.json の entries 件数 +
+#                            最終更新時刻 (= entries[].lastSeen の最大値。
+#                            top-level lastUpdated key は production schema に
+#                            無く、jq fallback `max(.entries[].lastSeen)` で
+#                            算出)。不在 / empty は silent (fresh state)、
+#                            entries>=1 は ok。jq 不在は grep ベース概数 fallback
+# - discoverqueries-size   : usage log file size。64KB (USAGE_LOG_MAX_BYTES)
+#                            未満は silent、超過は warn (FIFO rotation 動作示唆)。
+#                            `wc -c` で OS 非依存 (BSD/GNU stat -f / -c 回避)
+#
+# opt-out enabled 時は usage / size axis を skip (dynamic learning disabled で
+# usage log は無いか stale、noise 回避 — check_auto_ingest_state の
+# "absent = silent" convention に倣う)。
+#
+# Vault が存在しない / OBSIDIAN_VAULT 未設定の場合は本 section を丸ごと skip
+# (existing env-vault check が既に状態を伝えている)。
+#
+# DQ_USAGE_LOG_MAX_BYTES は mcp/lib/discoverqueries-learning.mjs の同名 export
+# USAGE_LOG_MAX_BYTES (64 * 1024) と pin。drift すれば DQ-3 test が検出する。
+# -----------------------------------------------------------------------------
+DQ_USAGE_LOG_MAX_BYTES=$((64 * 1024))
+
+check_discoverqueries_state() {
+  if [[ -z "${OBSIDIAN_VAULT:-}" ]] || [[ ! -d "${OBSIDIAN_VAULT}" ]]; then
+    return 0
+  fi
+
+  local optout_file="${OBSIDIAN_VAULT}/.kioku-discoverqueries-opt-out"
+  local usage_log="${OBSIDIAN_VAULT}/.kioku-discoverqueries-usage.json"
+
+  # axis 1: opt-out marker. Present → dynamic learning disabled (warn). When
+  # opted out the usage / size axes are skipped (the log is absent or stale —
+  # surfacing it would be misleading noise).
+  if [[ -f "${optout_file}" ]]; then
+    add_check "discoverqueries-optout" "warn" \
+      "DiscoverQueries dynamic learning: opt-out enabled (static 7 source only)" \
+      "Remove \"\${OBSIDIAN_VAULT}/.kioku-discoverqueries-opt-out\" to re-enable session-log learning"
+    return 0
+  fi
+
+  # axis 2: usage log entries count + last-update timestamp. The production
+  # appendToUsageLog writes no top-level `lastUpdated` key — only per-entry
+  # `lastSeen` — so the jq expression falls back to max(.entries[].lastSeen).
+  if [[ ! -f "${usage_log}" ]]; then
+    # absent = fresh state (no session-log learning has happened yet). Silent,
+    # matching the auto-ingest-manual "absent = healthy default" convention so
+    # the all-ok EXIT-CODE-1 expectation is preserved.
+    :
+  elif [[ "${HAS_JQ}" -eq 1 ]]; then
+    local entries_count last_updated
+    entries_count="$(jq -r '.entries | length' "${usage_log}" 2>/dev/null || echo "?")"
+    last_updated="$(jq -r '.lastUpdated // (.entries | map(.lastSeen) | max) // ""' "${usage_log}" 2>/dev/null || echo "")"
+    if [[ "${entries_count}" == "0" || "${entries_count}" == "?" ]]; then
+      # empty / unreadable usage log → treat as fresh state, stay silent.
+      :
+    else
+      local detail="usage log present, ${entries_count} queries learned"
+      if [[ -n "${last_updated}" ]]; then
+        detail="${detail}, last updated ${last_updated}"
+      fi
+      add_check "discoverqueries-usage" "ok" \
+        "DiscoverQueries dynamic learning: active (${detail})"
+    fi
+  else
+    # jq 不在 fallback: count usage-log entries roughly by "query" occurrences.
+    # `grep -c` prints 0 yet exits 1 on no-match; under `set -o pipefail` that
+    # exit 1 propagates across the pipe and would trip `|| echo "?"`, yielding a
+    # corrupt 2-line "0\n?" capture that matches neither "0" nor "?" and falls
+    # through to a bogus active line on an empty log. Capture pipefail-safe:
+    # tolerate grep's non-zero exit, then strip whitespace/newlines separately.
+    local rough_count
+    rough_count="$(grep -c '"query"' "${usage_log}" 2>/dev/null || true)"
+    rough_count="$(printf '%s' "${rough_count}" | tr -d ' \n')"
+    [[ -z "${rough_count}" ]] && rough_count="?"
+    if [[ "${rough_count}" == "0" || "${rough_count}" == "?" ]]; then
+      :
+    else
+      add_check "discoverqueries-usage" "ok" \
+        "DiscoverQueries dynamic learning: active (usage log present, ~${rough_count} queries learned, install jq for detail)"
+    fi
+  fi
+
+  # axis 3: usage log size vs the 64KB privacy / FIFO-rotation cap. Uses
+  # `wc -c` (OS-neutral) instead of stat -f / -c (BSD vs GNU divergence).
+  if [[ -f "${usage_log}" ]]; then
+    local log_bytes
+    log_bytes="$(wc -c < "${usage_log}" 2>/dev/null | tr -d ' ' || echo "0")"
+    if [[ ! "${log_bytes}" =~ ^[0-9]+$ ]]; then
+      log_bytes=0
+    fi
+    if [[ "${log_bytes}" -gt "${DQ_USAGE_LOG_MAX_BYTES}" ]]; then
+      local log_kb=$((log_bytes / 1024))
+      add_check "discoverqueries-size" "warn" \
+        "DiscoverQueries usage log near capacity: ${log_kb}KB (>64KB cap, FIFO rotation active — oldest queries are being dropped)" \
+        "Expected behavior (64KB bound); no action needed unless query recall degrades"
+    fi
+  fi
+}
+
+# -----------------------------------------------------------------------------
 # Section: Dependencies
 # -----------------------------------------------------------------------------
 check_dependencies() {
@@ -771,6 +986,8 @@ check_mcp_configs
 check_metadata_parity
 check_dependencies
 check_sync_state
+check_auto_ingest_state
+check_discoverqueries_state
 detect_install_mode
 
 if [[ "${JSON_MODE}" -eq 1 ]]; then

--- a/tests/auto-ingest-diagnostic.test.sh
+++ b/tests/auto-ingest-diagnostic.test.sh
@@ -1,0 +1,290 @@
+#!/usr/bin/env bash
+#
+# auto-ingest-diagnostic.test.sh — Sprint 5 PR B5 (BLUE-DOCTOR-AI-1..5)
+#
+# Target: scripts/doctor.sh check_auto_ingest_state + tests/fixtures/test-helpers.mjs
+#         mockAutoIngestFailure / readAutoIngestRetryQueue (LEARN#8b N=3 mandatory extract)
+#
+# Test prefixes (per-file scope F1..F5、LEARN#8a):
+#   BLUE-DOCTOR-AI-1   healthy state (no retry queue) → "auto-ingest-retry: ok"
+#   BLUE-DOCTOR-AI-2   pending retry queue (1 extract_failed entry) → "auto-ingest-retry: warn" with errorType
+#   BLUE-DOCTOR-AI-3   manual review queue (3 連敗 promoted entry) → "auto-ingest-manual: fail"
+#   BLUE-DOCTOR-AI-4   mockAutoIngestFailure helper produces functional stub script
+#   BLUE-DOCTOR-AI-5   readAutoIngestRetryQueue / readAutoIngestManualReviewQueue helper round-trip
+#
+# 実行: bash tools/claude-brain/tests/auto-ingest-diagnostic.test.sh
+#
+# 設計方針:
+#   - mock 環境は doctor.sh がチェックする他 axis (env / runtime / hook / mcp /
+#     metadata / sync) を最低限 OK 状態にした temp HOME / temp Vault で固める
+#   - JSON mode (--json) を主軸にし、auto-ingest-* check id の level を jq で assert
+#   - LEARN#8b N=3 extract した helper (mockAutoIngestFailure /
+#     readAutoIngestRetryQueue) を import & 実 functional verify
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+DOCTOR="${REPO_ROOT}/tools/claude-brain/scripts/doctor.sh"
+RETRY_HELPER="${REPO_ROOT}/tools/claude-brain/hooks/auto-ingest-retry.mjs"
+TEST_HELPERS="${REPO_ROOT}/tools/claude-brain/tests/fixtures/test-helpers.mjs"
+
+if [[ ! -f "${DOCTOR}" ]]; then
+  echo "FATAL: doctor.sh not found at ${DOCTOR}" >&2
+  exit 1
+fi
+if [[ ! -f "${RETRY_HELPER}" ]]; then
+  echo "FATAL: auto-ingest-retry.mjs not found at ${RETRY_HELPER}" >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "skip: jq not installed (auto-ingest-diagnostic tests use --json mode)"
+  exit 0
+fi
+if ! command -v node >/dev/null 2>&1; then
+  echo "skip: node not installed (auto-ingest-retry helper requires Node 18+)"
+  exit 0
+fi
+
+TMPROOT="$(mktemp -d)"
+trap 'rm -rf "${TMPROOT}"' EXIT
+
+PASS=0
+FAIL=0
+
+pass() {
+  PASS=$((PASS + 1))
+  echo "  ok  $1"
+}
+
+fail() {
+  FAIL=$((FAIL + 1))
+  echo "  NG  $1" >&2
+}
+
+assert_eq() {
+  if [[ "$1" == "$2" ]]; then
+    pass "$3"
+  else
+    fail "$3 (expected=$1, actual=$2)"
+  fi
+}
+
+assert_contains() {
+  if printf '%s' "$1" | grep -q -F -- "$2"; then
+    pass "$3"
+  else
+    fail "$3 (substring not found: $2)"
+  fi
+}
+
+# -----------------------------------------------------------------------------
+# Common: minimum-viable Vault setup
+# -----------------------------------------------------------------------------
+make_vault() {
+  local name="$1"
+  local vault="${TMPROOT}/${name}"
+  mkdir -p "${vault}/session-logs" "${vault}/wiki/summaries" \
+           "${vault}/raw-sources/articles" "${vault}/templates"
+  : > "${vault}/CLAUDE.md"
+  cat > "${vault}/.gitignore" <<'EOF'
+session-logs/
+.cache/
+.obsidian/
+.DS_Store
+EOF
+  echo "${vault}"
+}
+
+# Pre-populate a wiki/summaries entry so check_auto_ingest_state's "last marker"
+# axis returns ok (rather than "warn: no activity yet").
+seed_summary() {
+  local vault="$1"
+  local name="${2:-foo}"
+  cat > "${vault}/wiki/summaries/${name}.md" <<'EOF'
+---
+type: summary
+source_sha256: "0000000000000000000000000000000000000000000000000000000000000000"
+---
+
+stub summary
+EOF
+}
+
+# Run doctor.sh in JSON mode with minimal env. Returns the JSON to stdout,
+# never reads real ~/.claude / ~/.codex / ~/.gemini / real OBSIDIAN_VAULT.
+run_doctor_json() {
+  local vault="$1"
+  local fake_home="${TMPROOT}/fake-home-$$"
+  mkdir -p "${fake_home}"
+  env -i \
+    HOME="${fake_home}" \
+    PATH="/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin" \
+    OBSIDIAN_VAULT="${vault}" \
+    bash "${DOCTOR}" --json 2>/dev/null || true
+}
+
+# -----------------------------------------------------------------------------
+# BLUE-DOCTOR-AI-1: healthy state (no retry queue) → "auto-ingest-retry: ok"
+# -----------------------------------------------------------------------------
+echo "BLUE-DOCTOR-AI-1: no retry queue file → auto-ingest-retry ok"
+VAULT_AI1="$(make_vault vault-ai1)"
+seed_summary "${VAULT_AI1}" "ai1"
+
+json_ai1="$(run_doctor_json "${VAULT_AI1}")"
+retry_level_ai1="$(echo "${json_ai1}" | jq -r '.checks[] | select(.id=="auto-ingest-retry") | .level' 2>/dev/null || echo "")"
+retry_msg_ai1="$(echo "${json_ai1}" | jq -r '.checks[] | select(.id=="auto-ingest-retry") | .message' 2>/dev/null || echo "")"
+last_level_ai1="$(echo "${json_ai1}" | jq -r '.checks[] | select(.id=="auto-ingest-last") | .level' 2>/dev/null || echo "")"
+
+assert_eq "ok" "${retry_level_ai1}" "AI-1 auto-ingest-retry level = ok"
+assert_contains "${retry_msg_ai1}" "No pending auto-ingest retry" "AI-1 retry message = healthy"
+assert_eq "ok" "${last_level_ai1}" "AI-1 auto-ingest-last level = ok (wiki/summaries seeded)"
+
+# manual review section should NOT appear (silent when absent / empty)
+manual_count_ai1="$(echo "${json_ai1}" | jq '[.checks[] | select(.id=="auto-ingest-manual")] | length' 2>/dev/null || echo "?")"
+assert_eq "0" "${manual_count_ai1}" "AI-1 auto-ingest-manual not surfaced in healthy state"
+
+# -----------------------------------------------------------------------------
+# BLUE-DOCTOR-AI-2: pending retry queue → "auto-ingest-retry: warn" with errorType
+# -----------------------------------------------------------------------------
+echo "BLUE-DOCTOR-AI-2: pending retry queue (1 entry) → auto-ingest-retry warn"
+VAULT_AI2="$(make_vault vault-ai2)"
+seed_summary "${VAULT_AI2}" "ai2"
+
+# Use the production helper to create a retry queue entry (round-trip verify)
+echo "extract-pdf.sh: failed (rc=99) — diagnostic test mock" \
+  | OBSIDIAN_VAULT="${VAULT_AI2}" \
+    node "${RETRY_HELPER}" --enqueue "raw-sources/articles/pending.pdf" "extract_failed" >/dev/null
+
+json_ai2="$(run_doctor_json "${VAULT_AI2}")"
+retry_level_ai2="$(echo "${json_ai2}" | jq -r '.checks[] | select(.id=="auto-ingest-retry") | .level')"
+retry_msg_ai2="$(echo "${json_ai2}" | jq -r '.checks[] | select(.id=="auto-ingest-retry") | .message')"
+
+assert_eq "warn" "${retry_level_ai2}" "AI-2 auto-ingest-retry level = warn"
+assert_contains "${retry_msg_ai2}" "1 entries" "AI-2 message includes entry count"
+assert_contains "${retry_msg_ai2}" "extract_failed" "AI-2 message includes errorType"
+
+# manual review still absent
+manual_count_ai2="$(echo "${json_ai2}" | jq '[.checks[] | select(.id=="auto-ingest-manual")] | length')"
+assert_eq "0" "${manual_count_ai2}" "AI-2 auto-ingest-manual still absent (only retry queue populated)"
+
+# -----------------------------------------------------------------------------
+# BLUE-DOCTOR-AI-3: manual review queue (3 連敗 promoted) → "auto-ingest-manual: fail"
+# -----------------------------------------------------------------------------
+echo "BLUE-DOCTOR-AI-3: manual review queue populated → auto-ingest-manual fail"
+VAULT_AI3="$(make_vault vault-ai3)"
+seed_summary "${VAULT_AI3}" "ai3"
+
+# 4 consecutive failures for the same rawSource → promotes on 4th
+for tick in 1 2 3 4; do
+  echo "extract-pdf.sh: failed (rc=99) — tick ${tick}" \
+    | OBSIDIAN_VAULT="${VAULT_AI3}" \
+      node "${RETRY_HELPER}" --enqueue "raw-sources/articles/persistent.pdf" "extract_failed" >/dev/null
+done
+
+# Verify the promotion happened (precondition for AI-3 assertion)
+manual_pre_ai3="$(jq -r '.entries | length' "${VAULT_AI3}/.kioku-auto-ingest-manual-review.json" 2>/dev/null || echo "?")"
+assert_eq "1" "${manual_pre_ai3}" "AI-3 precondition: 1 entry in manual review after 4 failures"
+
+json_ai3="$(run_doctor_json "${VAULT_AI3}")"
+manual_level_ai3="$(echo "${json_ai3}" | jq -r '.checks[] | select(.id=="auto-ingest-manual") | .level')"
+manual_msg_ai3="$(echo "${json_ai3}" | jq -r '.checks[] | select(.id=="auto-ingest-manual") | .message')"
+
+assert_eq "fail" "${manual_level_ai3}" "AI-3 auto-ingest-manual level = fail"
+assert_contains "${manual_msg_ai3}" "1 entries" "AI-3 manual message includes entry count"
+assert_contains "${manual_msg_ai3}" "human action required" "AI-3 message indicates human review needed"
+
+# Retry queue should be empty (entry was promoted, file removed)
+retry_level_ai3="$(echo "${json_ai3}" | jq -r '.checks[] | select(.id=="auto-ingest-retry") | .level')"
+assert_eq "ok" "${retry_level_ai3}" "AI-3 auto-ingest-retry level = ok (entry promoted to manual review)"
+
+# -----------------------------------------------------------------------------
+# BLUE-DOCTOR-AI-4: mockAutoIngestFailure helper produces functional stub
+# -----------------------------------------------------------------------------
+echo "BLUE-DOCTOR-AI-4: mockAutoIngestFailure helper functional verify"
+helper_check_ai4="$(node --input-type=module -e "
+import { mockAutoIngestFailure } from '${TEST_HELPERS}';
+const { path, restore } = await mockAutoIngestFailure('llm_failed');
+import('node:child_process').then(({ spawnSync }) => {
+  const r = spawnSync('bash', [path]);
+  console.log(JSON.stringify({
+    rc: r.status,
+    stderr_includes_test_mock: (r.stderr.toString() || '').includes('test mock'),
+    stderr_includes_classify_keyword: (r.stderr.toString() || '').includes('claude'),
+  }));
+  return restore();
+}).catch(e => { console.error(e); process.exit(1); });
+" 2>&1)"
+
+assert_contains "${helper_check_ai4}" '"rc":99' "AI-4 stub exits rc=99 (default unknown failure)"
+assert_contains "${helper_check_ai4}" '"stderr_includes_test_mock":true' "AI-4 stub stderr contains 'test mock'"
+assert_contains "${helper_check_ai4}" '"stderr_includes_classify_keyword":true' "AI-4 llm_failed stub stderr contains 'claude' (classifyAutoIngestError trigger word)"
+
+# Verify each errorType produces a distinct, classifyAutoIngestError-matching stderr
+for et in extract_failed llm_failed fs_error sha256_drift unknown; do
+  helper_match="$(node --input-type=module -e "
+import { mockAutoIngestFailure } from '${TEST_HELPERS}';
+import { classifyAutoIngestError } from '${RETRY_HELPER}';
+const { path, restore } = await mockAutoIngestFailure('${et}');
+import('node:child_process').then(({ spawnSync }) => {
+  const r = spawnSync('bash', [path]);
+  console.log(classifyAutoIngestError(r.stderr.toString()));
+  return restore();
+});
+" 2>&1)"
+  assert_eq "${et}" "${helper_match}" "AI-4 ${et} stub stderr round-trips through classifyAutoIngestError"
+done
+
+# -----------------------------------------------------------------------------
+# BLUE-DOCTOR-AI-5: readAutoIngestRetryQueue + readAutoIngestManualReviewQueue helper round-trip
+# -----------------------------------------------------------------------------
+echo "BLUE-DOCTOR-AI-5: readAutoIngest{Retry,ManualReview}Queue helper round-trip"
+VAULT_AI5="$(make_vault vault-ai5)"
+
+# missing file → null
+read_check_ai5_null="$(node --input-type=module -e "
+import { readAutoIngestRetryQueue, readAutoIngestManualReviewQueue } from '${TEST_HELPERS}';
+const r = await readAutoIngestRetryQueue('${VAULT_AI5}');
+const m = await readAutoIngestManualReviewQueue('${VAULT_AI5}');
+console.log(JSON.stringify({ retry: r, manual: m }));
+" 2>&1)"
+assert_contains "${read_check_ai5_null}" '"retry":null' "AI-5 readAutoIngestRetryQueue returns null for missing file"
+assert_contains "${read_check_ai5_null}" '"manual":null' "AI-5 readAutoIngestManualReviewQueue returns null for missing file"
+
+# populate retry queue → helper sees 1 entry
+echo "extract failed mock" \
+  | OBSIDIAN_VAULT="${VAULT_AI5}" \
+    node "${RETRY_HELPER}" --enqueue "raw-sources/foo.pdf" "extract_failed" >/dev/null
+
+read_check_ai5_present="$(node --input-type=module -e "
+import { readAutoIngestRetryQueue } from '${TEST_HELPERS}';
+const r = await readAutoIngestRetryQueue('${VAULT_AI5}');
+console.log(JSON.stringify({
+  count: r.entries.length,
+  rawSource: r.entries[0].rawSource,
+  errorType: r.entries[0].errorType,
+}));
+" 2>&1)"
+assert_contains "${read_check_ai5_present}" '"count":1' "AI-5 helper sees 1 entry post-enqueue"
+assert_contains "${read_check_ai5_present}" "raw-sources/foo.pdf" "AI-5 helper preserves rawSource"
+assert_contains "${read_check_ai5_present}" '"errorType":"extract_failed"' "AI-5 helper preserves errorType"
+
+# malformed JSON tolerated → null
+echo "{ broken json" > "${VAULT_AI5}/.kioku-auto-ingest-retry.json"
+read_check_ai5_malformed="$(node --input-type=module -e "
+import { readAutoIngestRetryQueue } from '${TEST_HELPERS}';
+const r = await readAutoIngestRetryQueue('${VAULT_AI5}');
+console.log(JSON.stringify({ result: r }));
+" 2>&1)"
+assert_contains "${read_check_ai5_malformed}" '"result":null' "AI-5 helper returns null for malformed JSON"
+
+# -----------------------------------------------------------------------------
+# Summary
+# -----------------------------------------------------------------------------
+echo ""
+echo "summary: ${PASS} pass, ${FAIL} fail"
+if [[ "${FAIL}" -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/tests/auto-ingest-retry.test.mjs
+++ b/tests/auto-ingest-retry.test.mjs
@@ -1,0 +1,659 @@
+// tests/auto-ingest-retry.test.mjs — Sprint 5 PR A5 (BLUE-AUTO-INGEST-A5-1..5)
+//
+// Target: hooks/auto-ingest-retry.mjs
+//
+// Test prefixes:
+//   - BLUE-AUTO-INGEST-A5-1   classifyAutoIngestError buckets
+//                             (extract / llm / fs / sha256 / unknown)
+//   - BLUE-AUTO-INGEST-A5-2   maskCredentials scrubs ghp_*, github_pat_*,
+//                             Bearer, embedded URL credentials, sk-ant-*
+//   - BLUE-AUTO-INGEST-A5-3   queue I/O round-trip (per-source entries) +
+//                             atomic write + malformed-tolerant read
+//   - BLUE-AUTO-INGEST-A5-4   3-strike promotion to manual review queue +
+//                             firstAttempt preserved across retries
+//   - BLUE-AUTO-INGEST-A5-5   recordFailure / recordSuccess end-to-end +
+//                             credential masking persisted to queue file
+//
+// Mirrors tests/sync-retry.test.mjs structure (Sprint 4 Phase 4 PR A4).
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  buildAutoIngestRetryEntry,
+  classifyAutoIngestError,
+  clearQueueFile,
+  manualReviewQueuePathFor,
+  maskCredentials,
+  mergeManualReview,
+  partitionForPromotion,
+  readAutoIngestRetryQueue,
+  readManualReviewQueue,
+  recordFailure,
+  recordSuccess,
+  removeEntry,
+  retryQueuePathFor,
+  upsertEntry,
+  writeAutoIngestRetryQueue,
+  writeManualReviewQueue,
+} from '../hooks/auto-ingest-retry.mjs';
+
+// -----------------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------------
+
+async function makeVault() {
+  return mkdtemp(join(tmpdir(), 'kioku-auto-ingest-vault-'));
+}
+
+// -----------------------------------------------------------------------------
+// BLUE-AUTO-INGEST-A5-1: classifyAutoIngestError buckets
+// -----------------------------------------------------------------------------
+
+describe('BLUE-AUTO-INGEST-A5-1 classifyAutoIngestError', () => {
+  test('extract_failed: extract-pdf.sh exit 1', () => {
+    assert.equal(
+      classifyAutoIngestError('extract-pdf.sh: failed (rc=1)\n'),
+      'extract_failed'
+    );
+  });
+
+  test('extract_failed: extract-epub.mjs failure', () => {
+    assert.equal(
+      classifyAutoIngestError('node extract-epub.mjs: exit 1\n'),
+      'extract_failed'
+    );
+  });
+
+  test('extract_failed: yauzl invalid container', () => {
+    assert.equal(
+      classifyAutoIngestError('yauzl: invalid central directory record\n'),
+      'extract_failed'
+    );
+  });
+
+  test('llm_failed: claude timeout', () => {
+    assert.equal(
+      classifyAutoIngestError('claude -p timed out after 600s\n'),
+      'llm_failed'
+    );
+  });
+
+  test('llm_failed: max-turns reached', () => {
+    assert.equal(
+      classifyAutoIngestError('claude: max-turns reached\n'),
+      'llm_failed'
+    );
+  });
+
+  test('llm_failed: anthropic error', () => {
+    assert.equal(
+      classifyAutoIngestError('anthropic.error: 529 Overloaded\n'),
+      'llm_failed'
+    );
+  });
+
+  test('llm_failed: rate limit', () => {
+    assert.equal(
+      classifyAutoIngestError('429 rate-limit reached\n'),
+      'llm_failed'
+    );
+  });
+
+  test('fs_error: ENOENT', () => {
+    assert.equal(
+      classifyAutoIngestError('Error: ENOENT: no such file or directory, open ...\n'),
+      'fs_error'
+    );
+  });
+
+  test('fs_error: EACCES', () => {
+    assert.equal(
+      classifyAutoIngestError('EACCES: permission denied, open ...\n'),
+      'fs_error'
+    );
+  });
+
+  test('fs_error: ENOSPC', () => {
+    assert.equal(
+      classifyAutoIngestError('ENOSPC: no space left on device\n'),
+      'fs_error'
+    );
+  });
+
+  test('sha256_drift: mismatch detected', () => {
+    assert.equal(
+      classifyAutoIngestError('source_sha256 mismatch detected for chunk\n'),
+      'sha256_drift'
+    );
+  });
+
+  test('sha256_drift: sidecar drift', () => {
+    assert.equal(
+      classifyAutoIngestError('sidecar drift between raw MD and summary\n'),
+      'sha256_drift'
+    );
+  });
+
+  test('unknown: empty + unrecognized', () => {
+    assert.equal(classifyAutoIngestError(''), 'unknown');
+    assert.equal(classifyAutoIngestError(null), 'unknown');
+    assert.equal(classifyAutoIngestError('something weird happened'), 'unknown');
+  });
+});
+
+// -----------------------------------------------------------------------------
+// BLUE-AUTO-INGEST-A5-2: maskCredentials (delegates to maskText SSOT)
+// -----------------------------------------------------------------------------
+
+describe('BLUE-AUTO-INGEST-A5-2 maskCredentials', () => {
+  test('masks ghp_ classic token', () => {
+    const input = 'extract-pdf.sh failed: https://ghp_ABCDEFGHIJ1234567890abcdefg@github.com/org/repo.git';
+    const masked = maskCredentials(input);
+    assert.equal(masked.includes('ghp_ABCDEFGHIJ1234567890'), false);
+    assert.equal(masked.includes('ghp_***'), true);
+  });
+
+  test('masks github_pat_ fine-grained token', () => {
+    const input = 'remote: github_pat_11ABCDEFG0abcdefghijklmnopqrstuvwxyz fail';
+    const masked = maskCredentials(input);
+    assert.equal(/github_pat_11ABCDEFG0abcdefghijklm/.test(masked), false);
+    assert.equal(masked.includes('github_pat_***'), true);
+  });
+
+  test('masks sk-ant Anthropic token', () => {
+    const input = 'anthropic.error: invalid token sk-ant-abcdefghij1234567890ABC';
+    const masked = maskCredentials(input);
+    assert.equal(masked.includes('sk-ant-abcdefghij1234567890'), false);
+    assert.equal(masked.includes('sk-ant-***'), true);
+  });
+
+  test('masks Bearer header', () => {
+    const input = 'Authorization: Bearer abc.DEF.GHIjklmnop123';
+    const masked = maskCredentials(input);
+    assert.equal(masked.includes('abc.DEF.GHIjklmnop123'), false);
+    assert.equal(masked.includes('Bearer ***'), true);
+  });
+
+  test('masks embedded URL credentials', () => {
+    const input = 'fatal: https://user:s3cret@github.com/repo.git';
+    const masked = maskCredentials(input);
+    assert.equal(masked.includes('user:s3cret'), false);
+    assert.equal(masked.includes('://***:***@'), true);
+  });
+
+  test('non-string input returns empty string', () => {
+    assert.equal(maskCredentials(null), '');
+    assert.equal(maskCredentials(undefined), '');
+    assert.equal(maskCredentials(42), '');
+  });
+
+  test('plain text passes through', () => {
+    const input = 'extract-pdf.sh: failed';
+    assert.equal(maskCredentials(input), input);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// BLUE-AUTO-INGEST-A5-3: queue I/O round-trip + per-source array shape
+// -----------------------------------------------------------------------------
+
+describe('BLUE-AUTO-INGEST-A5-3 queue I/O', () => {
+  test('write then read returns the same entries', async () => {
+    const vault = await makeVault();
+    try {
+      const queue = {
+        version: 1,
+        entries: [
+          buildAutoIngestRetryEntry({
+            rawSource: 'raw-sources/articles/a.pdf',
+            errorType: 'extract_failed',
+            stderr: 'extract-pdf.sh: rc=1',
+            now: () => '2026-05-17T10:00:00.000Z',
+          }),
+          buildAutoIngestRetryEntry({
+            rawSource: 'raw-sources/books/b.epub',
+            errorType: 'extract_failed',
+            stderr: 'yauzl: invalid',
+            now: () => '2026-05-17T10:01:00.000Z',
+          }),
+        ],
+      };
+      await writeAutoIngestRetryQueue(vault, queue);
+      assert.equal(existsSync(retryQueuePathFor(vault)), true);
+      const round = await readAutoIngestRetryQueue(vault);
+      assert.equal(round.entries.length, 2);
+      assert.equal(round.entries[0].rawSource, 'raw-sources/articles/a.pdf');
+      assert.equal(round.entries[0].retryCount, 0);
+      assert.equal(round.entries[1].rawSource, 'raw-sources/books/b.epub');
+    } finally {
+      await rm(vault, { recursive: true, force: true });
+    }
+  });
+
+  test('subsequent buildAutoIngestRetryEntry preserves firstAttempt + increments retryCount', () => {
+    const previous = buildAutoIngestRetryEntry({
+      rawSource: 'raw-sources/foo.pdf',
+      errorType: 'extract_failed',
+      stderr: 'first',
+      now: () => '2026-05-17T10:00:00.000Z',
+    });
+    const next = buildAutoIngestRetryEntry({
+      rawSource: 'raw-sources/foo.pdf',
+      errorType: 'extract_failed',
+      stderr: 'second',
+      previous,
+      now: () => '2026-05-17T11:00:00.000Z',
+    });
+    assert.equal(next.firstAttempt, '2026-05-17T10:00:00.000Z');
+    assert.equal(next.lastAttempt, '2026-05-17T11:00:00.000Z');
+    assert.equal(next.retryCount, 1);
+  });
+
+  test('upsertEntry replaces existing entry for same rawSource (not appended)', () => {
+    const initial = upsertEntry(
+      { entries: [] },
+      {
+        rawSource: 'raw-sources/foo.pdf',
+        errorType: 'extract_failed',
+        stderr: 'first',
+        now: () => '2026-05-17T10:00:00.000Z',
+      }
+    );
+    assert.equal(initial.entries.length, 1);
+    const updated = upsertEntry(initial, {
+      rawSource: 'raw-sources/foo.pdf',
+      errorType: 'extract_failed',
+      stderr: 'second',
+      now: () => '2026-05-17T11:00:00.000Z',
+    });
+    assert.equal(updated.entries.length, 1, 'no duplicate entries for same rawSource');
+    assert.equal(updated.entries[0].retryCount, 1);
+    assert.equal(updated.entries[0].firstAttempt, '2026-05-17T10:00:00.000Z');
+  });
+
+  test('upsertEntry appends entries with different rawSource', () => {
+    const queue = upsertEntry(
+      upsertEntry(
+        { entries: [] },
+        { rawSource: 'a.pdf', errorType: 'extract_failed', stderr: '' }
+      ),
+      { rawSource: 'b.pdf', errorType: 'llm_failed', stderr: '' }
+    );
+    assert.equal(queue.entries.length, 2);
+    const sources = queue.entries.map((e) => e.rawSource).sort();
+    assert.deepEqual(sources, ['a.pdf', 'b.pdf']);
+  });
+
+  test('removeEntry strips matching rawSource (no-op when absent)', () => {
+    const initial = upsertEntry(
+      { entries: [] },
+      { rawSource: 'a.pdf', errorType: 'extract_failed', stderr: '' }
+    );
+    const after = removeEntry(initial, 'a.pdf');
+    assert.equal(after.entries.length, 0);
+    const noop = removeEntry(initial, 'nonexistent.pdf');
+    assert.equal(noop.entries.length, 1);
+  });
+
+  test('readAutoIngestRetryQueue tolerates malformed JSON', async () => {
+    const vault = await makeVault();
+    try {
+      await writeFile(retryQueuePathFor(vault), '{ not valid json', 'utf8');
+      const round = await readAutoIngestRetryQueue(vault);
+      assert.deepEqual(round, { version: 1, entries: [] });
+    } finally {
+      await rm(vault, { recursive: true, force: true });
+    }
+  });
+
+  test('readAutoIngestRetryQueue returns empty queue for missing file', async () => {
+    const vault = await makeVault();
+    try {
+      const round = await readAutoIngestRetryQueue(vault);
+      assert.deepEqual(round, { version: 1, entries: [] });
+    } finally {
+      await rm(vault, { recursive: true, force: true });
+    }
+  });
+
+  test('writeAutoIngestRetryQueue removes file when entries empty', async () => {
+    const vault = await makeVault();
+    try {
+      await writeAutoIngestRetryQueue(vault, {
+        entries: [
+          buildAutoIngestRetryEntry({
+            rawSource: 'a.pdf',
+            errorType: 'extract_failed',
+            stderr: 'x',
+            now: () => '2026-05-17T10:00:00.000Z',
+          }),
+        ],
+      });
+      assert.equal(existsSync(retryQueuePathFor(vault)), true);
+      await writeAutoIngestRetryQueue(vault, { entries: [] });
+      assert.equal(existsSync(retryQueuePathFor(vault)), false, 'empty queue removes file');
+    } finally {
+      await rm(vault, { recursive: true, force: true });
+    }
+  });
+
+  test('clearQueueFile is idempotent', async () => {
+    const vault = await makeVault();
+    try {
+      const path = retryQueuePathFor(vault);
+      await clearQueueFile(path); // missing file: no throw
+      await writeAutoIngestRetryQueue(vault, {
+        entries: [
+          buildAutoIngestRetryEntry({
+            rawSource: 'a.pdf',
+            errorType: 'extract_failed',
+            stderr: '',
+            now: () => '2026-05-17T10:00:00.000Z',
+          }),
+        ],
+      });
+      assert.equal(existsSync(path), true);
+      await clearQueueFile(path);
+      assert.equal(existsSync(path), false);
+      await clearQueueFile(path); // second time: still no throw
+    } finally {
+      await rm(vault, { recursive: true, force: true });
+    }
+  });
+});
+
+// -----------------------------------------------------------------------------
+// BLUE-AUTO-INGEST-A5-4: 3-strike promotion to manual review queue
+// -----------------------------------------------------------------------------
+
+describe('BLUE-AUTO-INGEST-A5-4 manual review promotion', () => {
+  test('partitionForPromotion holds entries below threshold', () => {
+    const queue = {
+      entries: [
+        { rawSource: 'a.pdf', errorType: 'extract_failed', retryCount: 0 },
+        { rawSource: 'b.pdf', errorType: 'extract_failed', retryCount: 1 },
+        { rawSource: 'c.pdf', errorType: 'extract_failed', retryCount: 2 },
+      ],
+    };
+    const { keep, promote } = partitionForPromotion(queue);
+    assert.equal(keep.entries.length, 3);
+    assert.equal(promote.length, 0);
+  });
+
+  test('partitionForPromotion promotes retryCount >= threshold', () => {
+    const queue = {
+      entries: [
+        { rawSource: 'a.pdf', errorType: 'extract_failed', retryCount: 2 },
+        { rawSource: 'b.pdf', errorType: 'llm_failed', retryCount: 3 },
+        { rawSource: 'c.pdf', errorType: 'fs_error', retryCount: 5 },
+      ],
+    };
+    const { keep, promote } = partitionForPromotion(queue);
+    assert.equal(keep.entries.length, 1);
+    assert.equal(keep.entries[0].rawSource, 'a.pdf');
+    assert.equal(promote.length, 2);
+    assert.deepEqual(
+      promote.map((e) => e.rawSource).sort(),
+      ['b.pdf', 'c.pdf']
+    );
+  });
+
+  test('mergeManualReview last-write-wins on duplicate rawSource', () => {
+    const existing = {
+      entries: [{ rawSource: 'a.pdf', errorType: 'extract_failed', retryCount: 3 }],
+    };
+    const adds = [
+      { rawSource: 'a.pdf', errorType: 'llm_failed', retryCount: 5 },
+      { rawSource: 'b.pdf', errorType: 'fs_error', retryCount: 3 },
+    ];
+    const merged = mergeManualReview(existing, adds);
+    assert.equal(merged.entries.length, 2);
+    const a = merged.entries.find((e) => e.rawSource === 'a.pdf');
+    assert.equal(a.errorType, 'llm_failed', 'last-write-wins');
+    assert.equal(a.retryCount, 5);
+  });
+
+  test('end-to-end: 4 failures for same rawSource → moved to manual review on 4th', async () => {
+    const vault = await makeVault();
+    try {
+      const rawSource = 'raw-sources/articles/foo.pdf';
+
+      // Failure 1: retryCount=0, in retry queue
+      let result = await recordFailure({
+        vaultPath: vault,
+        rawSource,
+        errorType: 'extract_failed',
+        stderr: 'extract-pdf.sh: rc=1',
+        now: () => '2026-05-17T10:00:00.000Z',
+      });
+      assert.equal(result.status, 'queued');
+      assert.equal(result.retryCount, 0);
+      let retry = await readAutoIngestRetryQueue(vault);
+      assert.equal(retry.entries.length, 1);
+      let manual = await readManualReviewQueue(vault);
+      assert.equal(manual.entries.length, 0);
+
+      // Failure 2: retryCount=1
+      result = await recordFailure({
+        vaultPath: vault,
+        rawSource,
+        errorType: 'extract_failed',
+        stderr: 'extract-pdf.sh: rc=1',
+        now: () => '2026-05-17T11:00:00.000Z',
+      });
+      assert.equal(result.status, 'queued');
+      assert.equal(result.retryCount, 1);
+
+      // Failure 3: retryCount=2
+      result = await recordFailure({
+        vaultPath: vault,
+        rawSource,
+        errorType: 'extract_failed',
+        stderr: 'extract-pdf.sh: rc=1',
+        now: () => '2026-05-17T12:00:00.000Z',
+      });
+      assert.equal(result.status, 'queued');
+      assert.equal(result.retryCount, 2);
+      retry = await readAutoIngestRetryQueue(vault);
+      assert.equal(retry.entries.length, 1, 'still in retry queue at retryCount=2');
+
+      // Failure 4: retryCount would become 3 → promote to manual review
+      result = await recordFailure({
+        vaultPath: vault,
+        rawSource,
+        errorType: 'extract_failed',
+        stderr: 'extract-pdf.sh: rc=1',
+        now: () => '2026-05-17T13:00:00.000Z',
+      });
+      assert.equal(result.status, 'promoted');
+      assert.equal(result.retryCount, 3);
+      assert.equal(result.promotedCount, 1);
+
+      retry = await readAutoIngestRetryQueue(vault);
+      assert.equal(retry.entries.length, 0, 'retry queue cleared after promotion');
+      manual = await readManualReviewQueue(vault);
+      assert.equal(manual.entries.length, 1, 'manual review queue contains promoted entry');
+      assert.equal(manual.entries[0].rawSource, rawSource);
+      assert.equal(manual.entries[0].retryCount, 3);
+      assert.equal(manual.entries[0].firstAttempt, '2026-05-17T10:00:00.000Z');
+      assert.equal(manual.entries[0].lastAttempt, '2026-05-17T13:00:00.000Z');
+    } finally {
+      await rm(vault, { recursive: true, force: true });
+    }
+  });
+
+  test('different rawSources tracked independently', async () => {
+    const vault = await makeVault();
+    try {
+      await recordFailure({
+        vaultPath: vault,
+        rawSource: 'a.pdf',
+        errorType: 'extract_failed',
+        stderr: '',
+        now: () => '2026-05-17T10:00:00.000Z',
+      });
+      await recordFailure({
+        vaultPath: vault,
+        rawSource: 'b.pdf',
+        errorType: 'llm_failed',
+        stderr: '',
+        now: () => '2026-05-17T10:01:00.000Z',
+      });
+      const queue = await readAutoIngestRetryQueue(vault);
+      assert.equal(queue.entries.length, 2);
+      const sources = queue.entries.map((e) => e.rawSource).sort();
+      assert.deepEqual(sources, ['a.pdf', 'b.pdf']);
+    } finally {
+      await rm(vault, { recursive: true, force: true });
+    }
+  });
+});
+
+// -----------------------------------------------------------------------------
+// BLUE-AUTO-INGEST-A5-5: recordFailure / recordSuccess + masking persistence
+// -----------------------------------------------------------------------------
+
+describe('BLUE-AUTO-INGEST-A5-5 recordFailure / recordSuccess', () => {
+  test('recordSuccess removes entry from retry queue', async () => {
+    const vault = await makeVault();
+    try {
+      await recordFailure({
+        vaultPath: vault,
+        rawSource: 'a.pdf',
+        errorType: 'extract_failed',
+        stderr: 'rc=1',
+        now: () => '2026-05-17T10:00:00.000Z',
+      });
+      assert.equal(existsSync(retryQueuePathFor(vault)), true);
+      const result = await recordSuccess({ vaultPath: vault, rawSource: 'a.pdf' });
+      assert.equal(result.status, 'cleared');
+      assert.equal(existsSync(retryQueuePathFor(vault)), false, 'queue file removed when last entry cleared');
+    } finally {
+      await rm(vault, { recursive: true, force: true });
+    }
+  });
+
+  test('recordSuccess on absent rawSource is no-op', async () => {
+    const vault = await makeVault();
+    try {
+      const result = await recordSuccess({ vaultPath: vault, rawSource: 'never-failed.pdf' });
+      assert.equal(result.status, 'noop');
+    } finally {
+      await rm(vault, { recursive: true, force: true });
+    }
+  });
+
+  test('recordSuccess preserves manual review queue (does not auto-clear human-pending entries)', async () => {
+    const vault = await makeVault();
+    try {
+      // Force promotion to manual review by 4 failures
+      const rawSource = 'raw-sources/articles/foo.pdf';
+      for (let i = 0; i < 4; i += 1) {
+        await recordFailure({
+          vaultPath: vault,
+          rawSource,
+          errorType: 'extract_failed',
+          stderr: 'rc=1',
+          now: () => `2026-05-17T1${i}:00:00.000Z`,
+        });
+      }
+      const manualBefore = await readManualReviewQueue(vault);
+      assert.equal(manualBefore.entries.length, 1);
+
+      // recordSuccess should remove from retry queue (already absent) but
+      // leave manual review intact for human inspection
+      await recordSuccess({ vaultPath: vault, rawSource });
+      const manualAfter = await readManualReviewQueue(vault);
+      assert.equal(manualAfter.entries.length, 1, 'manual review queue retained after success');
+    } finally {
+      await rm(vault, { recursive: true, force: true });
+    }
+  });
+
+  test('serialized retry queue file never includes raw token literal', async () => {
+    const vault = await makeVault();
+    try {
+      await recordFailure({
+        vaultPath: vault,
+        rawSource: 'raw-sources/articles/foo.pdf',
+        errorType: 'extract_failed',
+        stderr: 'fatal: https://ghp_VeryRealLookingToken1234567890abcdef@github.com fail',
+        now: () => '2026-05-17T10:00:00.000Z',
+      });
+      const raw = await readFile(retryQueuePathFor(vault), 'utf8');
+      assert.equal(
+        raw.includes('ghp_VeryRealLookingToken1234567890'),
+        false,
+        'token literal must never appear in serialized queue file'
+      );
+      assert.equal(raw.includes('ghp_***'), true, 'masked replacement present');
+    } finally {
+      await rm(vault, { recursive: true, force: true });
+    }
+  });
+
+  test('serialized retry queue file masks Bearer token', async () => {
+    const vault = await makeVault();
+    try {
+      await recordFailure({
+        vaultPath: vault,
+        rawSource: 'raw-sources/articles/bar.pdf',
+        errorType: 'llm_failed',
+        stderr: 'anthropic 401: Authorization: Bearer abc.DEF.GHIjkl987654321',
+        now: () => '2026-05-17T10:00:00.000Z',
+      });
+      const raw = await readFile(retryQueuePathFor(vault), 'utf8');
+      assert.equal(raw.includes('abc.DEF.GHIjkl987654321'), false);
+      assert.equal(raw.includes('Bearer ***'), true);
+    } finally {
+      await rm(vault, { recursive: true, force: true });
+    }
+  });
+
+  test('manual review queue file also has credentials masked', async () => {
+    const vault = await makeVault();
+    try {
+      const rawSource = 'raw-sources/articles/foo.pdf';
+      // 4 failures to force promotion
+      for (let i = 0; i < 4; i += 1) {
+        await recordFailure({
+          vaultPath: vault,
+          rawSource,
+          errorType: 'extract_failed',
+          stderr: `rc=1 https://ghp_LeakedTokenAttempt${i}1234567890abcdef@github.com fail`,
+          now: () => `2026-05-17T1${i}:00:00.000Z`,
+        });
+      }
+      const manualPath = manualReviewQueuePathFor(vault);
+      assert.equal(existsSync(manualPath), true);
+      const raw = await readFile(manualPath, 'utf8');
+      assert.equal(/ghp_LeakedTokenAttempt\d/.test(raw), false);
+      assert.equal(raw.includes('ghp_***'), true);
+    } finally {
+      await rm(vault, { recursive: true, force: true });
+    }
+  });
+
+  test('recordFailure truncates very long stderr to MAX_STDERR_EXCERPT (512)', async () => {
+    const vault = await makeVault();
+    try {
+      const longStderr = 'a'.repeat(2000);
+      await recordFailure({
+        vaultPath: vault,
+        rawSource: 'a.pdf',
+        errorType: 'extract_failed',
+        stderr: longStderr,
+        now: () => '2026-05-17T10:00:00.000Z',
+      });
+      const queue = await readAutoIngestRetryQueue(vault);
+      assert.equal(queue.entries[0].message.length, 512);
+    } finally {
+      await rm(vault, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/auto-ingest-retry.test.sh
+++ b/tests/auto-ingest-retry.test.sh
@@ -1,0 +1,344 @@
+#!/usr/bin/env bash
+#
+# auto-ingest-retry.test.sh — Sprint 5 PR A5 bash integration smoke test
+#
+# Verifies that scripts/auto-ingest.sh wires hooks/auto-ingest-retry.mjs at
+# the extract / LLM failure paths. Per-file F-number scope (F1..F5):
+#
+#   F1  PDF extract rc=99 (unknown failure)  → retry queue has 1 entry
+#   F2  PDF extract rc=2  (skip = encrypted) → retry queue NOT created
+#   F3  claude -p exit 1 (LLM failure)       → retry queue has <llm-batch> entry
+#   F4  4 PDF failures for same source       → moved to manual review queue
+#   F5  stderr contains ghp_* token literal  → queue file masks as ghp_***
+#
+# 実行: bash tools/claude-brain/tests/auto-ingest-retry.test.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+AUTO_INGEST="${REPO_ROOT}/tools/claude-brain/scripts/auto-ingest.sh"
+RETRY_HELPER="${REPO_ROOT}/tools/claude-brain/hooks/auto-ingest-retry.mjs"
+
+if [[ ! -x "$(command -v node 2>/dev/null)" ]]; then
+  echo "skip: node not installed (auto-ingest-retry helper requires Node 18+)"
+  exit 0
+fi
+
+TMPROOT="$(mktemp -d)"
+trap 'rm -rf "${TMPROOT}"' EXIT
+
+PASS=0
+FAIL=0
+
+pass() {
+  PASS=$((PASS + 1))
+  echo "  ok  $1"
+}
+
+fail() {
+  FAIL=$((FAIL + 1))
+  echo "  NG  $1" >&2
+}
+
+assert_eq() {
+  if [[ "$1" == "$2" ]]; then
+    pass "$3"
+  else
+    fail "$3 (expected=$1, actual=$2)"
+  fi
+}
+
+assert_file_exists() {
+  if [[ -f "$1" ]]; then
+    pass "$2"
+  else
+    fail "$2 (file missing: $1)"
+  fi
+}
+
+assert_file_absent() {
+  if [[ ! -f "$1" ]]; then
+    pass "$2"
+  else
+    fail "$2 (file unexpectedly present: $1)"
+  fi
+}
+
+assert_contains() {
+  if printf '%s' "$1" | grep -q -F -- "$2"; then
+    pass "$3"
+  else
+    fail "$3 (substring not found: $2)"
+  fi
+}
+
+assert_not_contains() {
+  if printf '%s' "$1" | grep -q -F -- "$2"; then
+    fail "$3 (substring unexpectedly present: $2)"
+  else
+    pass "$3"
+  fi
+}
+
+# -----------------------------------------------------------------------------
+# Common stubs (claude success, pdfinfo, pdftotext — needed for PDF pre-step gate)
+# -----------------------------------------------------------------------------
+STUB_DIR="${TMPROOT}/stub-bin"
+mkdir -p "${STUB_DIR}"
+
+cat > "${STUB_DIR}/claude" <<'STUB'
+#!/usr/bin/env bash
+echo "stub-claude ok" >&2
+exit 0
+STUB
+chmod +x "${STUB_DIR}/claude"
+
+cat > "${STUB_DIR}/pdfinfo" <<'STUB'
+#!/usr/bin/env bash
+echo "Pages: 1"
+exit 0
+STUB
+chmod +x "${STUB_DIR}/pdfinfo"
+
+cat > "${STUB_DIR}/pdftotext" <<'STUB'
+#!/usr/bin/env bash
+echo "stub pdftotext text"
+exit 0
+STUB
+chmod +x "${STUB_DIR}/pdftotext"
+
+# -----------------------------------------------------------------------------
+# Vault helper
+# -----------------------------------------------------------------------------
+make_vault() {
+  local name="$1"
+  local vault="${TMPROOT}/${name}"
+  mkdir -p "${vault}/session-logs" "${vault}/wiki" "${vault}/raw-sources/articles" "${vault}/templates" "${vault}/wiki/summaries"
+  : > "${vault}/CLAUDE.md"
+  echo "${vault}"
+}
+
+# -----------------------------------------------------------------------------
+# F1: PDF extract rc=99 (unknown failure) → retry queue has 1 entry
+# -----------------------------------------------------------------------------
+echo "test F1: PDF extract failure (rc=99) -> retry queue created"
+VAULT_F1="$(make_vault vault-f1)"
+echo "fake pdf body" > "${VAULT_F1}/raw-sources/articles/foo.pdf"
+
+# Stub extract-pdf.sh that always exits 99 (unknown failure)
+EXTRACT_STUB_F1="${TMPROOT}/extract-pdf-fail-f1.sh"
+cat > "${EXTRACT_STUB_F1}" <<'STUB'
+#!/usr/bin/env bash
+echo "stub-extract-pdf: simulated failure" >&2
+exit 99
+STUB
+chmod +x "${EXTRACT_STUB_F1}"
+
+set +e
+out_f1="$(
+  PATH="${STUB_DIR}:${PATH}" \
+  OBSIDIAN_VAULT="${VAULT_F1}" \
+  KIOKU_EXTRACT_PDF_SCRIPT="${EXTRACT_STUB_F1}" \
+  KIOKU_ALLOW_EXTRACT_PDF_OVERRIDE=1 \
+  KIOKU_DRY_RUN=1 \
+  bash "${AUTO_INGEST}" 2>&1
+)"
+rc_f1=$?
+set -e
+assert_eq "0" "${rc_f1}" "F1 auto-ingest exit code 0"
+assert_contains "${out_f1}" "extract-pdf.sh failed (rc=99)" "F1 warn message present"
+assert_file_exists "${VAULT_F1}/.kioku-auto-ingest-retry.json" "F1 retry queue file created"
+
+# Verify entry shape (use node -e for JSON parsing — avoids jq dependency)
+queue_check_f1=$(node -e "
+const data = require('${VAULT_F1}/.kioku-auto-ingest-retry.json');
+console.log(JSON.stringify({
+  count: data.entries.length,
+  rawSource: data.entries[0]?.rawSource,
+  errorType: data.entries[0]?.errorType,
+  retryCount: data.entries[0]?.retryCount,
+}));
+")
+assert_contains "${queue_check_f1}" '"count":1' "F1 entry count = 1"
+assert_contains "${queue_check_f1}" '"errorType":"extract_failed"' "F1 errorType = extract_failed"
+assert_contains "${queue_check_f1}" '"retryCount":0' "F1 retryCount = 0 (first failure)"
+assert_contains "${queue_check_f1}" "foo.pdf" "F1 rawSource includes foo.pdf"
+
+# -----------------------------------------------------------------------------
+# F2: PDF extract rc=2 (skip = encrypted) → retry queue NOT created
+# -----------------------------------------------------------------------------
+echo "test F2: PDF extract rc=2 (info skip) -> retry queue NOT created"
+VAULT_F2="$(make_vault vault-f2)"
+echo "fake pdf body" > "${VAULT_F2}/raw-sources/articles/encrypted.pdf"
+
+EXTRACT_STUB_F2="${TMPROOT}/extract-pdf-skip-f2.sh"
+cat > "${EXTRACT_STUB_F2}" <<'STUB'
+#!/usr/bin/env bash
+echo "stub-extract-pdf: encrypted (info skip)" >&2
+exit 2
+STUB
+chmod +x "${EXTRACT_STUB_F2}"
+
+set +e
+out_f2="$(
+  PATH="${STUB_DIR}:${PATH}" \
+  OBSIDIAN_VAULT="${VAULT_F2}" \
+  KIOKU_EXTRACT_PDF_SCRIPT="${EXTRACT_STUB_F2}" \
+  KIOKU_ALLOW_EXTRACT_PDF_OVERRIDE=1 \
+  KIOKU_DRY_RUN=1 \
+  bash "${AUTO_INGEST}" 2>&1
+)"
+rc_f2=$?
+set -e
+assert_eq "0" "${rc_f2}" "F2 auto-ingest exit code 0"
+assert_contains "${out_f2}" "skipped PDF (encrypted/invalid)" "F2 info skip message present"
+assert_file_absent "${VAULT_F2}/.kioku-auto-ingest-retry.json" "F2 retry queue NOT created for info-skip rc=2"
+
+# -----------------------------------------------------------------------------
+# F3: claude -p exit 1 (LLM failure) → <llm-batch> entry in retry queue
+#
+# auto-ingest.sh は実行時に export PATH="${HOME}/.local/share/mise/shims:...:/opt/homebrew/bin:..."
+# で多くの dir を prepend するため、単純に STUB_DIR を PATH 先頭に置いても real claude が
+# /opt/homebrew/bin 等に存在すると shadow される。fake HOME の mise shims に stub claude を
+# 配置することで、auto-ingest.sh 自身の export PATH chain で stub が最優先になる。
+# -----------------------------------------------------------------------------
+echo "test F3: LLM failure (claude exit 1) -> <llm-batch> entry in retry queue"
+VAULT_F3="$(make_vault vault-f3)"
+cat > "${VAULT_F3}/session-logs/20260517-100000-test-llm-fail.md" <<'EOF'
+---
+type: session-log
+session_id: test-llm-fail
+ingested: false
+---
+
+body
+EOF
+
+FAKE_HOME_F3="${TMPROOT}/fake-home-f3"
+FAKE_MISE_F3="${FAKE_HOME_F3}/.local/share/mise/shims"
+mkdir -p "${FAKE_MISE_F3}"
+cat > "${FAKE_MISE_F3}/claude" <<'STUB'
+#!/usr/bin/env bash
+echo "stub-claude: anthropic.error: 529 Overloaded" >&2
+exit 1
+STUB
+chmod +x "${FAKE_MISE_F3}/claude"
+
+# node は real 実装が必要 (helper を spawn する) ため /usr/bin etc. を残す。
+set +e
+out_f3="$(
+  HOME="${FAKE_HOME_F3}" \
+  PATH="${PATH}" \
+  OBSIDIAN_VAULT="${VAULT_F3}" \
+  bash "${AUTO_INGEST}" 2>&1
+)"
+rc_f3=$?
+set -e
+assert_eq "0" "${rc_f3}" "F3 auto-ingest exit code 0 (no longer fatal on LLM failure)"
+assert_contains "${out_f3}" "claude -p failed (rc=1)" "F3 LLM failure warn present"
+assert_file_exists "${VAULT_F3}/.kioku-auto-ingest-retry.json" "F3 retry queue file created"
+
+queue_check_f3=$(node -e "
+const data = require('${VAULT_F3}/.kioku-auto-ingest-retry.json');
+console.log(JSON.stringify({
+  count: data.entries.length,
+  rawSource: data.entries[0]?.rawSource,
+  errorType: data.entries[0]?.errorType,
+}));
+")
+assert_contains "${queue_check_f3}" '"count":1' "F3 entry count = 1"
+assert_contains "${queue_check_f3}" '"errorType":"llm_failed"' "F3 errorType = llm_failed (auto-classified from anthropic.error)"
+assert_contains "${queue_check_f3}" "<llm-batch>" "F3 rawSource = <llm-batch> placeholder"
+
+# -----------------------------------------------------------------------------
+# F4: 4 PDF failures for same source → moved to manual review queue
+# -----------------------------------------------------------------------------
+echo "test F4: 4 consecutive PDF failures -> entry moved to manual review queue"
+VAULT_F4="$(make_vault vault-f4)"
+echo "fake pdf body" > "${VAULT_F4}/raw-sources/articles/persistent-fail.pdf"
+
+EXTRACT_STUB_F4="${TMPROOT}/extract-pdf-fail-f4.sh"
+cat > "${EXTRACT_STUB_F4}" <<'STUB'
+#!/usr/bin/env bash
+echo "stub-extract-pdf: persistent failure" >&2
+exit 99
+STUB
+chmod +x "${EXTRACT_STUB_F4}"
+
+# Run auto-ingest 4 times in a row, simulating 4 cron ticks
+for tick in 1 2 3 4; do
+  set +e
+  PATH="${STUB_DIR}:${PATH}" \
+    OBSIDIAN_VAULT="${VAULT_F4}" \
+    KIOKU_EXTRACT_PDF_SCRIPT="${EXTRACT_STUB_F4}" \
+    KIOKU_ALLOW_EXTRACT_PDF_OVERRIDE=1 \
+    KIOKU_DRY_RUN=1 \
+    bash "${AUTO_INGEST}" >/dev/null 2>&1
+  set -e
+done
+
+assert_file_exists "${VAULT_F4}/.kioku-auto-ingest-manual-review.json" "F4 manual review queue created after 4 ticks"
+
+manual_check_f4=$(node -e "
+const data = require('${VAULT_F4}/.kioku-auto-ingest-manual-review.json');
+console.log(JSON.stringify({
+  count: data.entries.length,
+  retryCount: data.entries[0]?.retryCount,
+  rawSource: data.entries[0]?.rawSource,
+}));
+")
+assert_contains "${manual_check_f4}" '"count":1' "F4 manual review has 1 entry"
+assert_contains "${manual_check_f4}" '"retryCount":3' "F4 retryCount = 3 at promotion"
+assert_contains "${manual_check_f4}" "persistent-fail.pdf" "F4 rawSource preserved"
+
+# Retry queue should NOT contain this rawSource any more (could be empty file = removed)
+if [[ -f "${VAULT_F4}/.kioku-auto-ingest-retry.json" ]]; then
+  retry_check_f4=$(node -e "
+const data = require('${VAULT_F4}/.kioku-auto-ingest-retry.json');
+const persistent = data.entries.filter(e => e.rawSource && e.rawSource.includes('persistent-fail.pdf'));
+console.log(persistent.length);
+")
+  assert_eq "0" "${retry_check_f4}" "F4 retry queue no longer holds promoted entry"
+else
+  pass "F4 retry queue no longer holds promoted entry"
+fi
+
+# -----------------------------------------------------------------------------
+# F5: stderr contains ghp_* token literal → queue file masks as ghp_***
+# -----------------------------------------------------------------------------
+echo "test F5: credential masking applied to retry queue file"
+VAULT_F5="$(make_vault vault-f5)"
+echo "fake pdf body" > "${VAULT_F5}/raw-sources/articles/leaky.pdf"
+
+EXTRACT_STUB_F5="${TMPROOT}/extract-pdf-leak-f5.sh"
+cat > "${EXTRACT_STUB_F5}" <<'STUB'
+#!/usr/bin/env bash
+echo "fatal: https://ghp_LeakedSecretToken1234567890abcdefg@github.com/repo failed" >&2
+exit 99
+STUB
+chmod +x "${EXTRACT_STUB_F5}"
+
+set +e
+PATH="${STUB_DIR}:${PATH}" \
+  OBSIDIAN_VAULT="${VAULT_F5}" \
+  KIOKU_EXTRACT_PDF_SCRIPT="${EXTRACT_STUB_F5}" \
+  KIOKU_ALLOW_EXTRACT_PDF_OVERRIDE=1 \
+  KIOKU_DRY_RUN=1 \
+  bash "${AUTO_INGEST}" >/dev/null 2>&1
+set -e
+
+assert_file_exists "${VAULT_F5}/.kioku-auto-ingest-retry.json" "F5 retry queue file created"
+queue_raw_f5="$(cat "${VAULT_F5}/.kioku-auto-ingest-retry.json")"
+assert_not_contains "${queue_raw_f5}" "ghp_LeakedSecretToken1234567890" "F5 token literal NOT in queue file"
+assert_contains "${queue_raw_f5}" "ghp_***" "F5 masked replacement present in queue file"
+
+# -----------------------------------------------------------------------------
+# Summary
+# -----------------------------------------------------------------------------
+echo ""
+echo "summary: ${PASS} pass, ${FAIL} fail"
+if [[ "${FAIL}" -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/tests/discoverqueries-diagnostic.test.sh
+++ b/tests/discoverqueries-diagnostic.test.sh
@@ -1,0 +1,351 @@
+#!/usr/bin/env bash
+#
+# discoverqueries-diagnostic.test.sh — Sprint 5.5 PR B55 (BLUE-DOCTOR-DQ-1..3)
+#
+# Target: scripts/doctor.sh check_discoverqueries_state +
+#         tests/fixtures/test-helpers.mjs mockSessionLogScan / readUsageLog
+#         (LEARN#8b N=4 reinforcement)
+#
+# Test prefixes (per-file scope F1..F3、LEARN#8a — NEW file = DQ-1 から):
+#   BLUE-DOCTOR-DQ-1   usage log present (entries>=1) → "discoverqueries-usage: ok" + queries count surface
+#   BLUE-DOCTOR-DQ-1b  jq-absent + usage log present but entries EMPTY → silent
+#                      (regression guard for the pipefail/`grep -c` 取りこぼし:
+#                       `grep -c` prints 0 + exits 1 under pipefail → `|| echo "?"`
+#                       fired → rough_count="0\n?" → bogus active line. v0.10 hotfix.)
+#   BLUE-DOCTOR-DQ-2   opt-out file present → "discoverqueries-optout: warn" + usage/size axis skip (silent)
+#   BLUE-DOCTOR-DQ-3   usage log >64KB → "discoverqueries-size: warn" (FIFO rotation 示唆)
+#
+# 実行: bash tools/claude-brain/tests/discoverqueries-diagnostic.test.sh
+#
+# 設計方針:
+#   - mock 環境は doctor.sh がチェックする他 axis (env / runtime / hook / mcp /
+#     metadata / sync / auto-ingest) を最低限 OK 状態にした temp HOME / temp Vault で固める
+#   - JSON mode (--json) を主軸にし、discoverqueries-* check id の level を jq で assert
+#   - jq 不在環境では grep-fallback path を別途 verify (text mode)
+#   - 実 HOME / 実 Vault / 実 ~/.claude / ~/.codex / ~/.gemini に絶対 touch しない
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+DOCTOR="${REPO_ROOT}/tools/claude-brain/scripts/doctor.sh"
+DQ_LIB="${REPO_ROOT}/tools/claude-brain/mcp/lib/discoverqueries-learning.mjs"
+TEST_HELPERS="${REPO_ROOT}/tools/claude-brain/tests/fixtures/test-helpers.mjs"
+
+if [[ ! -f "${DOCTOR}" ]]; then
+  echo "FATAL: doctor.sh not found at ${DOCTOR}" >&2
+  exit 1
+fi
+if [[ ! -f "${DQ_LIB}" ]]; then
+  echo "FATAL: discoverqueries-learning.mjs not found at ${DQ_LIB}" >&2
+  exit 1
+fi
+if ! command -v node >/dev/null 2>&1; then
+  echo "skip: node not installed (discoverqueries-learning helper requires Node 18+)"
+  exit 0
+fi
+
+HAS_JQ=0
+if command -v jq >/dev/null 2>&1; then
+  HAS_JQ=1
+fi
+
+TMPROOT="$(mktemp -d)"
+trap 'rm -rf "${TMPROOT}"' EXIT
+
+PASS=0
+FAIL=0
+
+pass() {
+  PASS=$((PASS + 1))
+  echo "  ok  $1"
+}
+
+fail() {
+  FAIL=$((FAIL + 1))
+  echo "  NG  $1" >&2
+}
+
+assert_eq() {
+  if [[ "$1" == "$2" ]]; then
+    pass "$3"
+  else
+    fail "$3 (expected=$1, actual=$2)"
+  fi
+}
+
+assert_contains() {
+  if printf '%s' "$1" | grep -q -F -- "$2"; then
+    pass "$3"
+  else
+    fail "$3 (substring not found: $2)"
+  fi
+}
+
+# -----------------------------------------------------------------------------
+# Common: minimum-viable Vault setup
+# -----------------------------------------------------------------------------
+make_vault() {
+  local name="$1"
+  local vault="${TMPROOT}/${name}"
+  mkdir -p "${vault}/session-logs" "${vault}/wiki/summaries" \
+           "${vault}/raw-sources/articles" "${vault}/templates"
+  : > "${vault}/CLAUDE.md"
+  cat > "${vault}/.gitignore" <<'EOF'
+session-logs/
+.cache/
+.obsidian/
+.DS_Store
+EOF
+  echo "${vault}"
+}
+
+# Pre-populate a wiki/summaries entry so check_auto_ingest_state's "last marker"
+# axis returns ok (keeps other-axis noise out of the assertions).
+seed_summary() {
+  local vault="$1"
+  local name="${2:-foo}"
+  cat > "${vault}/wiki/summaries/${name}.md" <<'EOF'
+---
+type: summary
+---
+
+stub summary
+EOF
+}
+
+# Run doctor.sh in JSON mode with minimal env. Never reads real
+# ~/.claude / ~/.codex / ~/.gemini / real OBSIDIAN_VAULT.
+run_doctor_json() {
+  local vault="$1"
+  local fake_home="${TMPROOT}/fake-home-$$"
+  mkdir -p "${fake_home}"
+  env -i \
+    HOME="${fake_home}" \
+    PATH="/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin" \
+    OBSIDIAN_VAULT="${vault}" \
+    bash "${DOCTOR}" --json 2>/dev/null || true
+}
+
+# Run doctor.sh in text mode (used for jq-fallback path verification).
+run_doctor_text() {
+  local vault="$1"
+  local fake_home="${TMPROOT}/fake-home-text-$$"
+  mkdir -p "${fake_home}"
+  env -i \
+    HOME="${fake_home}" \
+    PATH="/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin" \
+    OBSIDIAN_VAULT="${vault}" \
+    bash "${DOCTOR}" 2>/dev/null || true
+}
+
+# Run doctor.sh with jq deterministically ABSENT (forces the grep-based
+# fallback branch regardless of whether jq is installed on the test host).
+# A stub PATH dir is populated with symlinks to the core binaries doctor.sh
+# needs (bash/grep/wc/tr/printf/sed/awk/env/cat/mkdir/...) but *no jq*, so
+# `command -v jq` fails inside doctor.sh and HAS_JQ stays 0.
+run_doctor_text_nojq() {
+  local vault="$1"
+  local fake_home="${TMPROOT}/fake-home-nojq-$$"
+  local stub_bin="${TMPROOT}/stub-bin-nojq-$$"
+  mkdir -p "${fake_home}" "${stub_bin}"
+  local tool src
+  for tool in bash sh grep wc tr printf sed awk env cat mkdir rm ls dirname \
+              basename date node git cut head tail sort uniq find stat \
+              command test true false; do
+    src="$(PATH="/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin" command -v "${tool}" 2>/dev/null || true)"
+    if [[ -n "${src}" && ! -e "${stub_bin}/${tool}" ]]; then
+      ln -s "${src}" "${stub_bin}/${tool}" 2>/dev/null || true
+    fi
+  done
+  env -i \
+    HOME="${fake_home}" \
+    PATH="${stub_bin}" \
+    OBSIDIAN_VAULT="${vault}" \
+    bash "${DOCTOR}" 2>/dev/null || true
+}
+
+# -----------------------------------------------------------------------------
+# BLUE-DOCTOR-DQ-1: usage log present (entries>=1) → discoverqueries-usage ok
+# -----------------------------------------------------------------------------
+echo "BLUE-DOCTOR-DQ-1: usage log present → discoverqueries-usage ok"
+VAULT_DQ1="$(make_vault vault-dq1)"
+seed_summary "${VAULT_DQ1}" "dq1"
+
+# Use mockSessionLogScan + production scanSessionLogs/appendToUsageLog to
+# create a real usage log (round-trip verify the privacy-safe pipeline).
+node --input-type=module -e "
+import { mockSessionLogScan } from '${TEST_HELPERS}';
+import { scanSessionLogs, appendToUsageLog } from '${DQ_LIB}';
+await mockSessionLogScan('${VAULT_DQ1}', 'doctor-diag-query', 3);
+const usage = await scanSessionLogs('${VAULT_DQ1}');
+await appendToUsageLog('${VAULT_DQ1}', usage);
+" >/dev/null 2>&1
+
+# Precondition: usage log file exists with >=1 entry. (mockSessionLogScan
+# writes a `## User (HH:MM:SS)` heading + N `#query` tag refs, so the scan
+# yields >=2 distinct query signals — assert ">=1" robustly, not an exact N.)
+usage_entries_dq1="$(node --input-type=module -e "
+import { readUsageLog } from '${TEST_HELPERS}';
+const u = await readUsageLog('${VAULT_DQ1}');
+const n = u === null ? 0 : (u.entries || []).length;
+console.log(n >= 1 ? 'HAS_ENTRIES' : 'EMPTY');
+" 2>&1)"
+assert_contains "${usage_entries_dq1}" "HAS_ENTRIES" "DQ-1 precondition: usage log has >=1 entry (helper readUsageLog round-trip)"
+
+if [[ "${HAS_JQ}" -eq 1 ]]; then
+  json_dq1="$(run_doctor_json "${VAULT_DQ1}")"
+  usage_level_dq1="$(echo "${json_dq1}" | jq -r '.checks[] | select(.id=="discoverqueries-usage") | .level' 2>/dev/null || echo "")"
+  usage_msg_dq1="$(echo "${json_dq1}" | jq -r '.checks[] | select(.id=="discoverqueries-usage") | .message' 2>/dev/null || echo "")"
+  optout_count_dq1="$(echo "${json_dq1}" | jq '[.checks[] | select(.id=="discoverqueries-optout")] | length' 2>/dev/null || echo "?")"
+
+  assert_eq "ok" "${usage_level_dq1}" "DQ-1 discoverqueries-usage level = ok"
+  assert_contains "${usage_msg_dq1}" "queries learned" "DQ-1 usage message surfaces learned query count"
+  assert_eq "0" "${optout_count_dq1}" "DQ-1 discoverqueries-optout not surfaced (opt-out absent = silent)"
+else
+  text_dq1="$(run_doctor_text "${VAULT_DQ1}")"
+  assert_contains "${text_dq1}" "DiscoverQueries dynamic learning: active" "DQ-1 (jq-fallback) usage active line in text mode"
+fi
+
+# -----------------------------------------------------------------------------
+# BLUE-DOCTOR-DQ-1b: jq-absent + usage log present but entries EMPTY → silent
+#
+# Regression guard for the pipefail / `grep -c` 取りこぼし bug. With an empty
+# `entries: []` usage log and jq absent, the old fallback
+#   rough_count="$(grep -c '"query"' "$f" | tr -d ' ' || echo "?")"
+# would: grep prints "0" but exits 1 → `set -o pipefail` propagates the
+# failure → `|| echo "?"` runs → rough_count becomes the 2-line string
+# "0\n?", which equals neither "0" nor "?" → falls into the else branch and
+# emits a bogus `DiscoverQueries dynamic learning: active (...~0\n? queries
+# learned...)` line on what is actually a fresh/empty log. The fix captures
+# pipefail-safe (grep `|| true`, strip whitespace+newlines separately,
+# empty → "?"). Expected post-fix: discoverqueries-usage stays SILENT (entry
+# count 0 = healthy fresh-state default) and the corrupt count never appears.
+# -----------------------------------------------------------------------------
+echo "BLUE-DOCTOR-DQ-1b: jq-absent + usage log present but entries empty → silent (pipefail regression guard)"
+VAULT_DQ1B="$(make_vault vault-dq1b)"
+seed_summary "${VAULT_DQ1B}" "dq1b"
+
+# Usage log present on disk but with zero entries (the production
+# canonical-empty shape). No opt-out marker → axis-2 fallback path is reached.
+cat > "${VAULT_DQ1B}/.kioku-discoverqueries-usage.json" <<'EOF'
+{ "version": 1, "entries": [] }
+EOF
+
+text_dq1b="$(run_doctor_text_nojq "${VAULT_DQ1B}")"
+
+# 1. The corrupt 2-line "0\n?" count must NEVER surface.
+if printf '%s' "${text_dq1b}" | grep -q -F -- '~0'; then
+  fail "DQ-1b corrupt count leaked: '~0' appears in output (pipefail bug regressed)"
+else
+  pass "DQ-1b no corrupt '~0' count in output"
+fi
+if printf '%s' "${text_dq1b}" | grep -q -F -- '~?'; then
+  fail "DQ-1b corrupt count leaked: '~?' appears in output (pipefail bug regressed)"
+else
+  pass "DQ-1b no corrupt '~?' count in output"
+fi
+
+# 2. Empty log = fresh state → discoverqueries-usage must stay SILENT
+#    (no active line at all). Asserting the active phrase is absent covers
+#    both "silent" (correct) and rejects the bogus active emission.
+if printf '%s' "${text_dq1b}" | grep -q -F -- 'DiscoverQueries dynamic learning: active'; then
+  fail "DQ-1b empty usage log wrongly emitted an 'active' line (should be silent on entries:[] )"
+else
+  pass "DQ-1b empty usage log → discoverqueries-usage silent (no bogus active line)"
+fi
+
+# 3. Sanity: this path really exercised the jq-absent fallback (the run must
+#    not have crashed — doctor still produced its summary banner).
+if printf '%s' "${text_dq1b}" | grep -q -E 'doctor|check|KIOKU|Environment|Runtime'; then
+  pass "DQ-1b doctor.sh ran to completion under jq-absent stub PATH"
+else
+  fail "DQ-1b doctor.sh produced no recognizable output under jq-absent stub PATH"
+fi
+
+# -----------------------------------------------------------------------------
+# BLUE-DOCTOR-DQ-2: opt-out file present → discoverqueries-optout warn + skip
+# -----------------------------------------------------------------------------
+echo "BLUE-DOCTOR-DQ-2: opt-out file present → discoverqueries-optout warn, usage/size skipped"
+VAULT_DQ2="$(make_vault vault-dq2)"
+seed_summary "${VAULT_DQ2}" "dq2"
+
+# opt-out marker present. A stale usage log is also written to prove that the
+# usage / size axis is skipped (silent) when opt-out is active.
+: > "${VAULT_DQ2}/.kioku-discoverqueries-opt-out"
+cat > "${VAULT_DQ2}/.kioku-discoverqueries-usage.json" <<'EOF'
+{ "version": 1, "entries": [ { "query": "stale", "count": 1, "firstSeen": "2026-05-15T00:00:00.000Z", "lastSeen": "2026-05-15T00:00:00.000Z" } ] }
+EOF
+
+if [[ "${HAS_JQ}" -eq 1 ]]; then
+  json_dq2="$(run_doctor_json "${VAULT_DQ2}")"
+  optout_level_dq2="$(echo "${json_dq2}" | jq -r '.checks[] | select(.id=="discoverqueries-optout") | .level' 2>/dev/null || echo "")"
+  optout_msg_dq2="$(echo "${json_dq2}" | jq -r '.checks[] | select(.id=="discoverqueries-optout") | .message' 2>/dev/null || echo "")"
+  usage_count_dq2="$(echo "${json_dq2}" | jq '[.checks[] | select(.id=="discoverqueries-usage")] | length' 2>/dev/null || echo "?")"
+  size_count_dq2="$(echo "${json_dq2}" | jq '[.checks[] | select(.id=="discoverqueries-size")] | length' 2>/dev/null || echo "?")"
+
+  assert_eq "warn" "${optout_level_dq2}" "DQ-2 discoverqueries-optout level = warn"
+  assert_contains "${optout_msg_dq2}" "opt-out" "DQ-2 optout message mentions opt-out"
+  assert_eq "0" "${usage_count_dq2}" "DQ-2 discoverqueries-usage skipped (opt-out active)"
+  assert_eq "0" "${size_count_dq2}" "DQ-2 discoverqueries-size skipped (opt-out active)"
+else
+  text_dq2="$(run_doctor_text "${VAULT_DQ2}")"
+  assert_contains "${text_dq2}" "opt-out enabled" "DQ-2 (jq-fallback) opt-out warn line in text mode"
+fi
+
+# -----------------------------------------------------------------------------
+# BLUE-DOCTOR-DQ-3: usage log >64KB → discoverqueries-size warn
+# -----------------------------------------------------------------------------
+echo "BLUE-DOCTOR-DQ-3: usage log >64KB → discoverqueries-size warn (FIFO rotation 示唆)"
+VAULT_DQ3="$(make_vault vault-dq3)"
+seed_summary "${VAULT_DQ3}" "dq3"
+
+# Hand-craft a usage log JSON whose serialized size exceeds 64KB. doctor.sh
+# size axis uses `wc -c` (OS-neutral, no BSD/GNU stat divergence). We DO NOT
+# go through appendToUsageLog here (it rotates at 64KB by contract); we want a
+# >64KB file on disk so the size axis warn fires deterministically.
+node --input-type=module -e "
+import { writeFile } from 'node:fs/promises';
+const entries = [];
+for (let i = 0; i < 1200; i += 1) {
+  entries.push({
+    query: 'padding-query-' + i + '-' + 'x'.repeat(40),
+    count: i + 1,
+    firstSeen: '2026-05-15T00:00:00.000Z',
+    lastSeen: '2026-05-15T00:00:0' + (i % 10) + '.000Z',
+  });
+}
+const payload = JSON.stringify({ version: 1, entries }, null, 2) + '\n';
+await writeFile('${VAULT_DQ3}/.kioku-discoverqueries-usage.json', payload, 'utf8');
+" >/dev/null 2>&1
+
+bytes_dq3="$(wc -c < "${VAULT_DQ3}/.kioku-discoverqueries-usage.json" | tr -d ' ')"
+if [[ "${bytes_dq3}" -le 65536 ]]; then
+  fail "DQ-3 precondition: usage log must exceed 64KB (got ${bytes_dq3} bytes)"
+else
+  pass "DQ-3 precondition: usage log exceeds 64KB (${bytes_dq3} bytes)"
+fi
+
+if [[ "${HAS_JQ}" -eq 1 ]]; then
+  json_dq3="$(run_doctor_json "${VAULT_DQ3}")"
+  size_level_dq3="$(echo "${json_dq3}" | jq -r '.checks[] | select(.id=="discoverqueries-size") | .level' 2>/dev/null || echo "")"
+  size_msg_dq3="$(echo "${json_dq3}" | jq -r '.checks[] | select(.id=="discoverqueries-size") | .message' 2>/dev/null || echo "")"
+  usage_level_dq3="$(echo "${json_dq3}" | jq -r '.checks[] | select(.id=="discoverqueries-usage") | .level' 2>/dev/null || echo "")"
+
+  assert_eq "warn" "${size_level_dq3}" "DQ-3 discoverqueries-size level = warn"
+  assert_contains "${size_msg_dq3}" "64KB" "DQ-3 size message references the 64KB cap"
+  assert_eq "ok" "${usage_level_dq3}" "DQ-3 discoverqueries-usage still ok (entries present, opt-out absent)"
+else
+  text_dq3="$(run_doctor_text "${VAULT_DQ3}")"
+  assert_contains "${text_dq3}" "near capacity" "DQ-3 (jq-fallback) size warn line in text mode"
+fi
+
+# -----------------------------------------------------------------------------
+# Summary
+# -----------------------------------------------------------------------------
+echo ""
+echo "summary: ${PASS} pass, ${FAIL} fail"
+if [[ "${FAIL}" -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/tests/discoverqueries-learning.test.mjs
+++ b/tests/discoverqueries-learning.test.mjs
@@ -1,0 +1,467 @@
+// discoverqueries-learning.test.mjs — Sprint 5.5 PR A55 (axis B, N=32).
+//
+// Plan: tools/claude-brain/plan/claude/26051509_v0-10-sprint5-5-discoverqueries-learning-plan.md §「PR A55」
+//
+// F-number scope: per-file (NEW file = BLUE-DQ-LEARN-A55-1..5).
+//
+// Test 観点:
+//   - BLUE-DQ-LEARN-A55-1: scanSessionLogs gracefully returns empty Map when
+//                          session-logs/ is absent (no throw)
+//   - BLUE-DQ-LEARN-A55-2: scanSessionLogs extracts #tag / [[wikilink]] /
+//                          ATX heading from session-log markdown into Map
+//   - BLUE-DQ-LEARN-A55-3: appendToUsageLog persists entries and FIFO-rotates
+//                          when the serialized payload exceeds 64KB
+//   - BLUE-DQ-LEARN-A55-4: discoverQueries 8th source integrates — session-log
+//                          query weight (2.8) combines with static-source weight
+//                          and influences TopN sort
+//   - BLUE-DQ-LEARN-A55-5: regression guard — static 7 source behavior is
+//                          unchanged when session-logs/ is absent (additive only)
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync } from 'node:fs';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const LEARNING_LIB = join(__dirname, '..', 'mcp', 'lib', 'discoverqueries-learning.mjs');
+const QMD_INDEX_LIB = join(__dirname, '..', 'mcp', 'lib', 'qmd-search-index.mjs');
+
+const {
+  USAGE_LOG_FILENAME,
+  USAGE_LOG_MAX_BYTES,
+  OPT_OUT_FILENAME,
+  isOptedOut,
+  scanSessionLogs,
+  appendToUsageLog,
+  readUsageLog,
+} = await import(LEARNING_LIB);
+
+const { __test__: qmdTest } = await import(QMD_INDEX_LIB);
+
+describe('discoverqueries-learning', () => {
+  // ───────────────────────────────────────────────────────────────────────────
+  // BLUE-DQ-LEARN-A55-1: graceful empty when session-logs/ absent
+  // ───────────────────────────────────────────────────────────────────────────
+
+  test('BLUE-DQ-LEARN-A55-1: scanSessionLogs returns empty Map when session-logs/ absent', async () => {
+    const ws = await mkdtemp(join(tmpdir(), 'kioku-dq-learn-a55-1-'));
+    const vault = join(ws, 'vault');
+    try {
+      await mkdir(vault, { recursive: true });
+      // No session-logs/ subdir — graceful skip expected
+      const result = await scanSessionLogs(vault);
+      assert.ok(result instanceof Map, 'must return a Map');
+      assert.equal(result.size, 0, 'absent session-logs/ must yield empty Map');
+    } finally {
+      await rm(ws, { recursive: true, force: true });
+    }
+  });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // BLUE-DQ-LEARN-A55-2: extraction (#tag / [[wikilink]] / heading)
+  // ───────────────────────────────────────────────────────────────────────────
+
+  test('BLUE-DQ-LEARN-A55-2: scanSessionLogs extracts tags, wikilinks, headings', async () => {
+    const ws = await mkdtemp(join(tmpdir(), 'kioku-dq-learn-a55-2-'));
+    const vault = join(ws, 'vault');
+    try {
+      const sessionLogsDir = join(vault, 'session-logs');
+      await mkdir(sessionLogsDir, { recursive: true });
+      await writeFile(
+        join(sessionLogsDir, '20260515-100000-aaaa-test-prompt.md'),
+        [
+          '---',
+          'type: session-log',
+          'session_id: aaaa-1111',
+          '---',
+          '',
+          '## User',
+          '',
+          '#hot-cache の design について [[visualizer]] を見直したい',
+          '',
+          '## Assistant',
+          '',
+          '# Hot Cache Design Review',
+          '',
+          'Discussion of [[doctor]] and #wiki-rotting concerns.',
+          '',
+          '## Implementation Notes',
+          '',
+          'See related #wiki-rotting tag.',
+          '',
+        ].join('\n'),
+      );
+
+      const usage = await scanSessionLogs(vault);
+      assert.ok(usage instanceof Map);
+      assert.ok(usage.size > 0, 'must extract at least one query');
+
+      // Tags (lowercased)
+      assert.ok(usage.has('hot-cache'), `expected #hot-cache, got: ${Array.from(usage.keys()).join(', ')}`);
+      assert.equal(usage.get('wiki-rotting'), 2, '#wiki-rotting must appear twice');
+
+      // Wikilinks (lowercased)
+      assert.ok(usage.has('visualizer'), 'expected [[visualizer]]');
+      assert.ok(usage.has('doctor'), 'expected [[doctor]]');
+
+      // ATX headings (lowercased, length-filtered)
+      assert.ok(
+        usage.has('hot cache design review'),
+        `expected h1 heading, got keys: ${Array.from(usage.keys()).join(', ')}`,
+      );
+      assert.ok(usage.has('implementation notes'), 'expected h2 heading');
+    } finally {
+      await rm(ws, { recursive: true, force: true });
+    }
+  });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // BLUE-DQ-LEARN-A55-3: appendToUsageLog + 64KB FIFO rotation
+  // ───────────────────────────────────────────────────────────────────────────
+
+  test('BLUE-DQ-LEARN-A55-3: appendToUsageLog persists + FIFO rotates at 64KB', async () => {
+    const ws = await mkdtemp(join(tmpdir(), 'kioku-dq-learn-a55-3-'));
+    const vault = join(ws, 'vault');
+    try {
+      await mkdir(vault, { recursive: true });
+
+      // First append — small payload, fits well under 64KB. Schema is per-query:
+      // each map entry produces a `{query, count, firstSeen, lastSeen}` entry.
+      const small = new Map([['hot-cache', 3], ['doctor', 2]]);
+      await appendToUsageLog(vault, small);
+
+      const usageLogPath = join(vault, USAGE_LOG_FILENAME);
+      assert.ok(existsSync(usageLogPath), `usage log file must exist at ${usageLogPath}`);
+
+      const after1 = await readUsageLog(vault);
+      assert.ok(after1 && Array.isArray(after1.entries), 'usage log must parse');
+      assert.equal(after1.entries.length, 2, 'first append produces 2 per-query entries (hot-cache + doctor)');
+      assert.equal(after1.version, 1, 'schema version pinned');
+      // entry shape
+      const e0 = after1.entries.find((e) => e.query === 'hot-cache');
+      assert.ok(e0, 'hot-cache entry must exist');
+      assert.equal(e0.count, 3);
+      assert.match(e0.firstSeen, /^\d{4}-\d{2}-\d{2}T/);
+      assert.match(e0.lastSeen, /^\d{4}-\d{2}-\d{2}T/);
+
+      // Second append — adds visualizer, total 3 per-query entries
+      await new Promise((res) => setTimeout(res, 5));
+      const small2 = new Map([['visualizer', 1]]);
+      await appendToUsageLog(vault, small2);
+      const after2 = await readUsageLog(vault);
+      assert.equal(after2.entries.length, 3, 'second append → 3 unique queries (hot-cache + doctor + visualizer)');
+
+      // Now force FIFO rotation: append many fresh entries, each touch updates
+      // lastSeen so older "first batch" entries (hot-cache / doctor) become
+      // candidates for drop. Inject 200 unique keys ~10KB each * multiple rounds.
+      for (let round = 0; round < 10; round++) {
+        const bigQueries = new Map();
+        for (let i = 0; i < 200; i++) {
+          bigQueries.set(`round${round}-query-with-a-fairly-long-key-name-${i}`, i + 1);
+        }
+        await new Promise((res) => setTimeout(res, 5));
+        await appendToUsageLog(vault, bigQueries);
+      }
+
+      const afterRotate = await readUsageLog(vault);
+      assert.ok(afterRotate && Array.isArray(afterRotate.entries));
+
+      // Capacity invariant: serialized payload must be <= 64KB
+      const onDisk = await readFile(usageLogPath, 'utf8');
+      assert.ok(
+        Buffer.byteLength(onDisk, 'utf8') <= USAGE_LOG_MAX_BYTES,
+        `on-disk size ${Buffer.byteLength(onDisk, 'utf8')} must be <= 64KB (${USAGE_LOG_MAX_BYTES})`,
+      );
+
+      // FIFO evidence: oldest entries (the first `small` append: 'hot-cache'
+      // and 'doctor') should have been dropped because they have the oldest
+      // lastSeen timestamps. We verify by checking the per-query keys.
+      const queryNames = afterRotate.entries.map((e) => e.query);
+      assert.ok(
+        !queryNames.includes('hot-cache'),
+        `FIFO rotation must drop oldest entries; expected 'hot-cache' (oldest lastSeen) absent, got first 5: ${queryNames.slice(0, 5).join(', ')}`,
+      );
+      assert.ok(
+        !queryNames.includes('doctor'),
+        `FIFO rotation must drop oldest entries; expected 'doctor' (oldest lastSeen) absent`,
+      );
+
+      // At least one entry must remain (the "always keep latest" guarantee)
+      assert.ok(afterRotate.entries.length >= 1, 'at least 1 entry must remain after rotation');
+    } finally {
+      await rm(ws, { recursive: true, force: true });
+    }
+  });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // BLUE-DQ-LEARN-A55-4: 8th source integrates into discoverQueries TopN
+  // ───────────────────────────────────────────────────────────────────────────
+
+  test('BLUE-DQ-LEARN-A55-4: discoverQueries 8th source promotes session-log queries', async () => {
+    const ws = await mkdtemp(join(tmpdir(), 'kioku-dq-learn-a55-4-'));
+    const vault = join(ws, 'vault');
+    try {
+      // Static sources: minimal — only log.md with a low-count tag so that
+      // session-log query (weight 2.8 * 3 occurrences = 8.4) can clearly
+      // out-rank it.
+      await mkdir(join(vault, 'wiki'), { recursive: true });
+      await writeFile(
+        join(vault, 'wiki', 'log.md'),
+        '# Log\n\n- 2026-05-15 #static-tag mention\n',
+      );
+
+      // session-logs/: a single file mentioning a unique query 3 times.
+      // It will be tagged + heading'd to bias source 8 weight.
+      const sessionLogsDir = join(vault, 'session-logs');
+      await mkdir(sessionLogsDir, { recursive: true });
+      await writeFile(
+        join(sessionLogsDir, '20260515-110000-bbbb-test.md'),
+        [
+          '## User',
+          '',
+          '#session-only-query is mentioned',
+          '',
+          '## Assistant',
+          '',
+          '# session-only-query Heading',
+          '',
+          'Talking about #session-only-query repeatedly.',
+          '',
+        ].join('\n'),
+      );
+
+      const queries = await qmdTest.discoverQueries(vault, 10);
+      assert.ok(Array.isArray(queries));
+      assert.ok(queries.length > 0, 'must produce queries');
+
+      // 'session-only-query' should appear (proves 8th source integration).
+      // It does NOT have to be #1 in absolute terms, only that it's present
+      // and that 'static-tag' (weight 3 from log.md) is also there: we want
+      // additive integration, not replacement.
+      assert.ok(
+        queries.includes('session-only-query'),
+        `session-log derived query missing in TopN, got: ${queries.join(', ')}`,
+      );
+      assert.ok(
+        queries.includes('static-tag'),
+        `static log.md tag still must appear (additive contract), got: ${queries.join(', ')}`,
+      );
+    } finally {
+      await rm(ws, { recursive: true, force: true });
+    }
+  });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // BLUE-DQ-LEARN-A55-5: regression — static 7 source behavior unchanged
+  // ───────────────────────────────────────────────────────────────────────────
+
+  test('BLUE-DQ-LEARN-A55-5: discoverQueries unchanged for vaults with no session-logs/', async () => {
+    const ws = await mkdtemp(join(tmpdir(), 'kioku-dq-learn-a55-5-'));
+    const vault = join(ws, 'vault');
+    try {
+      // Minimal static-only vault — replicate the BLUE-QMD-INDEX-3 fixture
+      // shape (log.md with tag).
+      await mkdir(join(vault, 'wiki'), { recursive: true });
+      await writeFile(
+        join(vault, 'wiki', 'log.md'),
+        [
+          '# Log',
+          '',
+          '- 2026-05-14 #regression-marker noted',
+          '- 2026-05-13 #regression-marker again',
+          '- 2026-05-12 #other-tag',
+          '',
+        ].join('\n'),
+      );
+      // No session-logs/ at all
+
+      const queries = await qmdTest.discoverQueries(vault, 10);
+      // Static behavior preserved: 'regression-marker' (count 2, weight 3 * 2 = 6)
+      // outranks 'other-tag' (count 1, weight 3 * 1 = 3).
+      assert.ok(Array.isArray(queries));
+      assert.ok(queries.length >= 2, `expected >= 2 queries, got: ${queries.join(', ')}`);
+      const idxMarker = queries.indexOf('regression-marker');
+      const idxOther = queries.indexOf('other-tag');
+      assert.ok(idxMarker >= 0, `regression-marker missing in: ${queries.join(', ')}`);
+      assert.ok(idxOther >= 0, `other-tag missing in: ${queries.join(', ')}`);
+      assert.ok(
+        idxMarker < idxOther,
+        `regression-marker (count 2) must rank above other-tag (count 1), got order: ${queries.join(', ')}`,
+      );
+
+      // Additionally: usage log file must NOT have been created (no
+      // session-logs/ scanned → no persistence).
+      const usageLogPath = join(vault, USAGE_LOG_FILENAME);
+      assert.ok(
+        !existsSync(usageLogPath),
+        'usage log must not be created when session-logs/ absent',
+      );
+    } finally {
+      await rm(ws, { recursive: true, force: true });
+    }
+  });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // Auxiliary: isOptedOut + readUsageLog defensive paths
+  // ───────────────────────────────────────────────────────────────────────────
+
+  test('isOptedOut returns false for absent opt-out file', async () => {
+    const ws = await mkdtemp(join(tmpdir(), 'kioku-dq-learn-aux-1-'));
+    try {
+      const result = await isOptedOut(ws);
+      assert.equal(result, false);
+    } finally {
+      await rm(ws, { recursive: true, force: true });
+    }
+  });
+
+  test('isOptedOut returns true when opt-out file exists', async () => {
+    const ws = await mkdtemp(join(tmpdir(), 'kioku-dq-learn-aux-2-'));
+    try {
+      await writeFile(join(ws, OPT_OUT_FILENAME), '');
+      const result = await isOptedOut(ws);
+      assert.equal(result, true);
+    } finally {
+      await rm(ws, { recursive: true, force: true });
+    }
+  });
+
+  test('isOptedOut returns false for invalid vault argument', async () => {
+    assert.equal(await isOptedOut(''), false);
+    assert.equal(await isOptedOut(null), false);
+    assert.equal(await isOptedOut(undefined), false);
+  });
+
+  test('readUsageLog returns canonical empty shape for absent file', async () => {
+    const ws = await mkdtemp(join(tmpdir(), 'kioku-dq-learn-aux-3-'));
+    try {
+      const result = await readUsageLog(ws);
+      assert.ok(result && typeof result === 'object', 'must return object, not null');
+      assert.equal(result.version, 1);
+      assert.ok(Array.isArray(result.entries));
+      assert.equal(result.entries.length, 0);
+    } finally {
+      await rm(ws, { recursive: true, force: true });
+    }
+  });
+
+  test('readUsageLog returns canonical empty shape for malformed JSON', async () => {
+    const ws = await mkdtemp(join(tmpdir(), 'kioku-dq-learn-aux-4-'));
+    try {
+      await writeFile(join(ws, USAGE_LOG_FILENAME), 'not valid json {{{');
+      const result = await readUsageLog(ws);
+      assert.ok(result && typeof result === 'object', 'must return object, not null');
+      assert.equal(result.version, 1);
+      assert.ok(Array.isArray(result.entries));
+      assert.equal(result.entries.length, 0);
+    } finally {
+      await rm(ws, { recursive: true, force: true });
+    }
+  });
+
+  test('appendToUsageLog is no-op for empty Map', async () => {
+    const ws = await mkdtemp(join(tmpdir(), 'kioku-dq-learn-aux-5-'));
+    try {
+      await appendToUsageLog(ws, new Map());
+      assert.ok(!existsSync(join(ws, USAGE_LOG_FILENAME)));
+    } finally {
+      await rm(ws, { recursive: true, force: true });
+    }
+  });
+
+  test('scanSessionLogs returns Map only — caller is responsible for persistence', async () => {
+    // Library-clean contract: scanSessionLogs returns Map<query,count>; the
+    // caller (e.g., qmd-search-index.mjs Source 8) decides whether to call
+    // appendToUsageLog. This separation enables read-only scans (e.g., doctor
+    // diagnostics) without side effects on the usage log file.
+    const ws = await mkdtemp(join(tmpdir(), 'kioku-dq-learn-aux-6-'));
+    const vault = join(ws, 'vault');
+    try {
+      await mkdir(join(vault, 'session-logs'), { recursive: true });
+      await writeFile(
+        join(vault, 'session-logs', 'persist-test.md'),
+        '## User\n\n#persist-tag mention\n',
+      );
+      const usage = await scanSessionLogs(vault);
+      assert.ok(usage instanceof Map);
+      assert.ok(usage.has('persist-tag'), 'scan must extract the tag');
+      // scanSessionLogs alone does NOT auto-persist; appendToUsageLog is
+      // the dedicated persistence entry-point.
+      assert.ok(
+        !existsSync(join(vault, USAGE_LOG_FILENAME)),
+        'scanSessionLogs is read-only by contract; no persistence side-effect',
+      );
+
+      // Caller-driven persistence path: appendToUsageLog after scan
+      await appendToUsageLog(vault, usage);
+      assert.ok(existsSync(join(vault, USAGE_LOG_FILENAME)), 'appendToUsageLog persists');
+    } finally {
+      await rm(ws, { recursive: true, force: true });
+    }
+  });
+
+});
+
+// ─── Direct test of extractFromContent via learning module __test__ ───
+const { __test__ } = await import(LEARNING_LIB);
+
+describe('discoverqueries-learning internal helpers', () => {
+  test('pre-strip + extractQuerySignals strips frontmatter, fenced code, quote lines', () => {
+    const { extractQuerySignals, stripFrontmatter, stripCodeBlocks, stripCalloutBlocks } = __test__;
+    const content = [
+      '---',
+      'type: session-log',
+      'session_id: zzzz',
+      '---',
+      '',
+      '## Heading One',
+      '',
+      '#real-tag mentioned',
+      '',
+      '```bash',
+      '#fake-tag-in-code',
+      '[[fake-link-in-code]]',
+      '# Fake Heading In Code',
+      '```',
+      '',
+      '> #fake-tag-in-quote should be stripped',
+      '> [[fake-link-in-quote]]',
+      '',
+      '[[real-link]]',
+      '',
+    ].join('\n');
+
+    // mirror production pipeline: strip → extract
+    const stripped = stripCalloutBlocks(stripCodeBlocks(stripFrontmatter(content)));
+    const target = extractQuerySignals(stripped);
+
+    // Real content should be picked up
+    assert.ok(target.has('real-tag'), `expected real-tag, got: ${Array.from(target.keys()).join(', ')}`);
+    assert.ok(target.has('real-link'), 'expected real-link');
+    assert.ok(target.has('heading one'), 'expected heading-one');
+
+    // Content stripped by filters MUST NOT appear
+    assert.ok(!target.has('fake-tag-in-code'), 'fenced code block must be stripped');
+    assert.ok(!target.has('fake-link-in-code'), 'fenced code block wikilink must be stripped');
+    assert.ok(!target.has('fake heading in code'), 'fenced code block heading must be stripped');
+    assert.ok(!target.has('fake-tag-in-quote'), 'quote line must be stripped');
+    assert.ok(!target.has('fake-link-in-quote'), 'quote line wikilink must be stripped');
+  });
+
+  test('extractQuerySignals length-filters headings (2..80 chars)', () => {
+    const { extractQuerySignals } = __test__;
+    const content = [
+      '# A',                                                    // length 1 — should be skipped
+      `# ${'x'.repeat(81)}`,                                    // length 81 — should be skipped
+      '# Valid Heading',                                        // valid
+      '',
+    ].join('\n');
+    const target = extractQuerySignals(content);
+    assert.ok(target.has('valid heading'));
+    assert.ok(!target.has('a'));
+    assert.ok(!target.has('x'.repeat(81)));
+  });
+});

--- a/tests/discoverqueries-privacy.test.mjs
+++ b/tests/discoverqueries-privacy.test.mjs
@@ -1,0 +1,344 @@
+// discoverqueries-privacy.test.mjs — Sprint 5.5 PR A55 (axis B, N=32).
+//
+// Plan: tools/claude-brain/plan/claude/26051509_v0-10-sprint5-5-discoverqueries-learning-plan.md §「PR A55」 (BLUE-PRIVACY-1..3)
+//
+// F-number scope: per-file (NEW file = BLUE-PRIVACY-1..3).
+//
+// Test 観点 (privacy contract — the critical of this PR):
+//   - BLUE-PRIVACY-1: credential literal pinning. session-logs/ markdown
+//                     containing realistic-looking credential strings
+//                     (sk-ant-, ghp_, Bearer, github_pat_, etc.) MUST NOT
+//                     surface in the usage Map nor in the persisted usage
+//                     log JSON. masking SSOT replaces literals with `***`.
+//
+//   - BLUE-PRIVACY-2: helper-local PII layer. Verifies `sanitizePII`
+//                     (discoverqueries-learning.mjs), applied AFTER the
+//                     applyMasks SSOT pass, redacts email + Japanese-style
+//                     phone numbers to `<email>` / `<phone>` so they never
+//                     surface in the usage Map nor the persisted usage log
+//                     JSON. The PII layer is scope-local to this helper by
+//                     design — generalizing the masking.mjs SSOT MASK_RULES
+//                     beyond credentials (to email/phone) remains a separate
+//                     codify candidate and is intentionally NOT done here.
+//
+//   - BLUE-PRIVACY-3: opt-out complete skip. With `.kioku-discoverqueries-
+//                     opt-out` present, scanSessionLogs MUST return an empty
+//                     Map and MUST NOT create / touch / modify the usage
+//                     log file even when session-logs/ exists with content.
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync } from 'node:fs';
+import { mkdtemp, mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const LEARNING_LIB = join(__dirname, '..', 'mcp', 'lib', 'discoverqueries-learning.mjs');
+
+const {
+  USAGE_LOG_FILENAME,
+  OPT_OUT_FILENAME,
+  scanSessionLogs,
+  readUsageLog,
+  appendToUsageLog,
+} = await import(LEARNING_LIB);
+
+// -----------------------------------------------------------------------------
+// Credential literals used in fixtures (fake but pattern-matching real shapes)
+// -----------------------------------------------------------------------------
+
+const FAKE_CREDS = {
+  skAnt: 'sk-ant-api03-FAKEFAKEFAKEFAKEFAKE12345TESTONLY',
+  skProj: 'sk-proj-FAKEFAKEFAKEFAKEFAKE67890TESTONLY',
+  ghp: 'ghp_AAAABBBBCCCCDDDDEEEEFFFFGGGGHHHHIIII',
+  githubPat: 'github_pat_AAAABBBBCCCCDDDDEEEEFFFFGGGGHHHHIIII',
+  aiza: 'AIzaSyAAAABBBBCCCCDDDDEEEEFFFFGGGGHHHH',
+  akia: 'AKIAIOSFODNN7EXAMPLE',
+  xoxb: 'xoxb-FAKEFAKEFAKEFAKEFAKE',
+  npm: 'npm_AAAABBBBCCCCDDDDEEEEFFFFGGGGHHHHIIII',
+  vercel: 'vercel_AAAABBBBCCCCDDDDEEEEFFFFGGGGHHHHIIII',
+  bearer: 'Bearer eyJhbGciOiJIUzI1NiJ9.fake_jwt.body',
+  basicAuth: 'Basic ZmFrZS11c2VyOmZha2UtcGFzcw==',
+  urlEmbedded: 'https://fakeuser:fakepass@example.com/path',
+  privateKeyId: 'private_key_id: "fedcba9876543210fedcba9876543210fedcba98"',
+  passwordEq: 'password=hunter2-fake',
+  tokenEq: 'token="fake-token-value-here"',
+};
+
+// -----------------------------------------------------------------------------
+// BLUE-PRIVACY-1: credential literal pinning
+// -----------------------------------------------------------------------------
+
+describe('discoverqueries-privacy', () => {
+  test('BLUE-PRIVACY-1: credential literals do not surface in usage Map or usage log', async () => {
+    const ws = await mkdtemp(join(tmpdir(), 'kioku-dq-privacy-1-'));
+    const vault = join(ws, 'vault');
+    try {
+      const sessionLogsDir = join(vault, 'session-logs');
+      await mkdir(sessionLogsDir, { recursive: true });
+
+      // Build a fixture session-log that mixes real query candidates with
+      // credential literals scattered through different markdown contexts.
+      // The credentials must be filtered/masked, but the legitimate query
+      // candidates (#real-tag, [[real-link]], real heading) must survive.
+      const fixture = [
+        '---',
+        'type: session-log',
+        `session_id: ${FAKE_CREDS.skAnt}`,  // even frontmatter creds are not surfaced
+        '---',
+        '',
+        '## User',
+        '',
+        `Pasted token by accident: ${FAKE_CREDS.skAnt}`,
+        `And another: ${FAKE_CREDS.ghp}`,
+        '',
+        '#real-tag and discussion of [[real-link]]',
+        '',
+        '## Assistant',
+        '',
+        `Let me set: ${FAKE_CREDS.passwordEq}`,
+        `Authorization: ${FAKE_CREDS.bearer}`,
+        `URL: ${FAKE_CREDS.urlEmbedded}`,
+        '',
+        '# Real Heading In Session',
+        '',
+        `Maybe: ${FAKE_CREDS.tokenEq}`,
+        `Stripe-like: ${FAKE_CREDS.skProj}`,
+        `Google: ${FAKE_CREDS.aiza}`,
+        `AWS: ${FAKE_CREDS.akia}`,
+        `Slack: ${FAKE_CREDS.xoxb}`,
+        `NPM: ${FAKE_CREDS.npm}`,
+        `Vercel: ${FAKE_CREDS.vercel}`,
+        `GitHub PAT: ${FAKE_CREDS.githubPat}`,
+        `Basic auth: ${FAKE_CREDS.basicAuth}`,
+        `Private key id: ${FAKE_CREDS.privateKeyId}`,
+        '',
+      ].join('\n');
+      await writeFile(join(sessionLogsDir, 'fixture.md'), fixture);
+
+      const usageMap = await scanSessionLogs(vault);
+
+      // Map sanity: legitimate queries survive
+      assert.ok(usageMap.has('real-tag'), 'legitimate #real-tag must survive masking');
+      assert.ok(usageMap.has('real-link'), 'legitimate [[real-link]] must survive');
+      assert.ok(usageMap.has('real heading in session'), 'legitimate heading must survive');
+
+      // Map: NO credential literal is a key (negative assertion).
+      // Map keys are lowercased; check against lowercased credential prefixes.
+      const mapKeys = Array.from(usageMap.keys()).join('|');
+      assertNoCredentialLeak(mapKeys, 'usage Map keys');
+
+      // Caller-driven persistence: scanSessionLogs returns Map only;
+      // appendToUsageLog is the dedicated entry-point.
+      await appendToUsageLog(vault, usageMap);
+
+      // Persisted file: serialized JSON must not contain credential literals
+      const usageLogPath = join(vault, USAGE_LOG_FILENAME);
+      assert.ok(existsSync(usageLogPath), 'usage log must be created after appendToUsageLog');
+      const serialized = await readFile(usageLogPath, 'utf8');
+      assertNoCredentialLeak(serialized, 'usage log JSON');
+    } finally {
+      await rm(ws, { recursive: true, force: true });
+    }
+  });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // BLUE-PRIVACY-2: PII pattern sanitize (email + Japanese mobile phone)
+  // ───────────────────────────────────────────────────────────────────────────
+
+  test('BLUE-PRIVACY-2: email + Japanese phone PII is replaced with placeholders and never reaches usage log', async () => {
+    const ws = await mkdtemp(join(tmpdir(), 'kioku-dq-privacy-2-'));
+    const vault = join(ws, 'vault');
+    try {
+      const sessionLogsDir = join(vault, 'session-logs');
+      await mkdir(sessionLogsDir, { recursive: true });
+
+      // PII literals scattered through different markdown contexts.
+      // Email and Japanese mobile phone numbers must both be redacted to
+      // `<email>` / `<phone>` placeholders by sanitizePII (helper-local PII
+      // layer, applied after applyMasks SSOT).
+      const fakeEmail = 'user@example.com';
+      const fakeEmail2 = 'admin.test+tag@example.co.jp';
+      const fakePhone = '090-1234-5678';
+      const fakePhone2 = '08012345678';   // no hyphens — must still match
+      const fakePhone3 = '070-1111-2222';
+
+      const fixture = [
+        '---',
+        'type: session-log',
+        'session_id: privacy-pii-test',
+        '---',
+        '',
+        '## User',
+        '',
+        `Contact: ${fakeEmail}`,
+        `Mobile: ${fakePhone}`,
+        '',
+        '#real-pii-test-tag and [[real-pii-test-link]]',
+        '',
+        '## Assistant',
+        '',
+        `Another email: ${fakeEmail2}`,
+        `Another phone: ${fakePhone2}`,
+        `One more phone: ${fakePhone3}`,
+        '',
+        '# Real PII Test Heading',
+        '',
+      ].join('\n');
+      await writeFile(join(sessionLogsDir, 'pii-fixture.md'), fixture);
+
+      const usageMap = await scanSessionLogs(vault);
+      assert.ok(usageMap instanceof Map);
+
+      // Legitimate content survives PII sanitize
+      assert.ok(usageMap.has('real-pii-test-tag'), 'legitimate tag survives');
+      assert.ok(usageMap.has('real-pii-test-link'), 'legitimate wikilink survives');
+      assert.ok(
+        usageMap.has('real pii test heading'),
+        'legitimate heading survives',
+      );
+
+      // Map keys: no PII literal as a key
+      const mapKeysJoined = Array.from(usageMap.keys()).join('|');
+      for (const piiLiteral of [fakeEmail, fakeEmail2, fakePhone, fakePhone2, fakePhone3]) {
+        assert.ok(
+          !mapKeysJoined.includes(piiLiteral),
+          `PII literal "${piiLiteral}" leaked into Map keys: ${mapKeysJoined.slice(0, 200)}`,
+        );
+      }
+
+      // Persist + verify written usage log file is PII-clean
+      await appendToUsageLog(vault, usageMap);
+      const usageLogPath = join(vault, USAGE_LOG_FILENAME);
+      assert.ok(existsSync(usageLogPath), 'usage log file must be created');
+      const serialized = await readFile(usageLogPath, 'utf8');
+
+      for (const piiLiteral of [fakeEmail, fakeEmail2, fakePhone, fakePhone2, fakePhone3]) {
+        assert.ok(
+          !serialized.includes(piiLiteral),
+          `PII literal "${piiLiteral}" leaked into persisted usage log JSON`,
+        );
+      }
+    } finally {
+      await rm(ws, { recursive: true, force: true });
+    }
+  });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // BLUE-PRIVACY-3: opt-out file complete skip
+  // ───────────────────────────────────────────────────────────────────────────
+
+  test('BLUE-PRIVACY-3: opt-out file disables scan + persistence entirely', async () => {
+    const ws = await mkdtemp(join(tmpdir(), 'kioku-dq-privacy-3-'));
+    const vault = join(ws, 'vault');
+    try {
+      const sessionLogsDir = join(vault, 'session-logs');
+      await mkdir(sessionLogsDir, { recursive: true });
+      // session-logs/ is non-empty: would normally produce queries + persist
+      await writeFile(
+        join(sessionLogsDir, 'should-be-skipped.md'),
+        [
+          '## User',
+          '',
+          '#opt-out-test',
+          `Even credentials: ${FAKE_CREDS.skAnt}`,
+          '',
+          '# Heading That Should Not Be Picked Up',
+          '',
+        ].join('\n'),
+      );
+
+      // Plant opt-out file
+      await writeFile(join(vault, OPT_OUT_FILENAME), '');
+
+      const usage = await scanSessionLogs(vault);
+      assert.ok(usage instanceof Map);
+      assert.equal(usage.size, 0, 'opt-out must yield empty Map');
+
+      // Usage log file must NOT exist (no scan ⇒ no persistence)
+      const usageLogPath = join(vault, USAGE_LOG_FILENAME);
+      assert.ok(
+        !existsSync(usageLogPath),
+        'opt-out must not create the usage log file',
+      );
+
+      // Additional check: pre-existing usage log file is not touched when
+      // opt-out is enabled (mtime preserved). Build a usage log first via
+      // scan + appendToUsageLog (library-clean contract), enable opt-out,
+      // then verify both scan and appendToUsageLog become no-ops.
+      const ws2 = await mkdtemp(join(tmpdir(), 'kioku-dq-privacy-3b-'));
+      const vault2 = join(ws2, 'vault');
+      try {
+        const sl2 = join(vault2, 'session-logs');
+        await mkdir(sl2, { recursive: true });
+        await writeFile(
+          join(sl2, 'first-run.md'),
+          '## User\n\n#first-run-tag\n',
+        );
+        // First run without opt-out builds the file via caller-driven persist
+        const firstUsage = await scanSessionLogs(vault2);
+        assert.ok(firstUsage.has('first-run-tag'), 'first run must produce content');
+        await appendToUsageLog(vault2, firstUsage);
+        const usageLog2 = join(vault2, USAGE_LOG_FILENAME);
+        assert.ok(existsSync(usageLog2), 'first run must persist after appendToUsageLog');
+        const beforeStat = await stat(usageLog2);
+
+        // Now enable opt-out + run again — file must not be touched even if
+        // caller invokes appendToUsageLog (opt-out gate is enforced in both
+        // scanSessionLogs AND appendToUsageLog).
+        await writeFile(join(vault2, OPT_OUT_FILENAME), '');
+        await writeFile(
+          join(sl2, 'second-run.md'),
+          '## User\n\n#second-run-tag\n',
+        );
+        const optedOutUsage = await scanSessionLogs(vault2);
+        assert.equal(optedOutUsage.size, 0, 'scan opt-out yields empty Map');
+
+        // Even if caller bypasses scan and tries to manually append, opt-out
+        // must block (defense-in-depth axis 2 reinforcement)
+        await appendToUsageLog(vault2, new Map([['second-run-tag', 1]]));
+
+        const afterStat = await stat(usageLog2);
+        assert.equal(
+          beforeStat.mtimeMs,
+          afterStat.mtimeMs,
+          'opt-out must not modify pre-existing usage log file (mtime preserved)',
+        );
+
+        // Verify the second-run-tag never made it into the log
+        // (per-query entry schema: each entry has a `query` field)
+        const persisted = await readUsageLog(vault2);
+        assert.ok(persisted && Array.isArray(persisted.entries));
+        const queryNames = persisted.entries.map((e) => e.query);
+        assert.ok(
+          !queryNames.includes('second-run-tag'),
+          `opt-out must prevent second-run content from being appended, got: ${queryNames.join(', ')}`,
+        );
+      } finally {
+        await rm(ws2, { recursive: true, force: true });
+      }
+    } finally {
+      await rm(ws, { recursive: true, force: true });
+    }
+  });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // Negative assertion helper
+  // ───────────────────────────────────────────────────────────────────────────
+
+  function assertNoCredentialLeak(haystack, label) {
+    // Each credential literal MUST be absent from the haystack
+    for (const [name, literal] of Object.entries(FAKE_CREDS)) {
+      assert.ok(
+        !haystack.includes(literal),
+        `${label} leaked credential "${name}": found "${literal.slice(0, 30)}..."`,
+      );
+    }
+    // Plus: the high-entropy portions of password=*/token=* expressions
+    // must also be gone (mask replaces value with `***`).
+    assert.ok(!haystack.includes('hunter2-fake'), `${label} leaked password value`);
+    assert.ok(!haystack.includes('fake-token-value-here'), `${label} leaked token value`);
+  }
+});

--- a/tests/doctor.test.sh
+++ b/tests/doctor.test.sh
@@ -1012,6 +1012,124 @@ EOF
 }
 
 # -----------------------------------------------------------------------------
+# BLUE-DOCTOR-AI-INT-1: check_auto_ingest_state surfaces in default doctor output
+#
+# Sprint 5 PR B5 で追加した check_auto_ingest_state が main() に正しく登録されていて、
+# retry queue + manual review queue が text mode 出力にも JSON mode にも現れることを
+# pin する。auto-ingest-* の詳細 unit test は tests/auto-ingest-diagnostic.test.sh で
+# 持つが、本 assertion は「main() から関数 call が脱落しないこと」を保証する
+# regression guard (LEARN#5 cross-suite reference pinning、check_sync_state の AI-INT
+# 版)。
+# -----------------------------------------------------------------------------
+test_auto_ingest_state_integrated() {
+  echo "BLUE-DOCTOR-AI-INT-1: check_auto_ingest_state lines appear in default doctor output"
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "  skip  jq not available"
+    return 0
+  fi
+  local d
+  d="$(new_case "auto-ingest-integrated")"
+  stub_full_clis "${d}/bin"
+  stub_node_18 "${d}/bin"
+  stub_curl_ok "${d}/bin"
+  init_full_vault_with_commit "${d}/vault"
+
+  # Seed a summary so check_auto_ingest_state's "last marker" axis returns ok
+  # (rather than the "no activity yet" warn). init_full_vault_with_commit only
+  # creates empty wiki/ — we add wiki/summaries/seed.md to exercise the mtime
+  # fallback path of check_auto_ingest_state.
+  mkdir -p "${d}/vault/wiki/summaries"
+  cat >"${d}/vault/wiki/summaries/seed.md" <<'EOF'
+---
+type: summary
+---
+seed
+EOF
+
+  # Pre-populate a retry queue with the production schema (Sprint 5 PR A5
+  # writeAutoIngestRetryQueue output shape) so the integration assertion also
+  # pins schema parity with hooks/auto-ingest-retry.mjs.
+  cat >"${d}/vault/.kioku-auto-ingest-retry.json" <<'EOF'
+{
+  "version": 1,
+  "entries": [
+    {
+      "rawSource": "raw-sources/articles/integration-test.pdf",
+      "errorType": "extract_failed",
+      "message": "extract-pdf.sh: failed (rc=99) — integration test seed",
+      "firstAttempt": "2026-05-17T01:00:00.000Z",
+      "lastAttempt": "2026-05-17T02:00:00.000Z",
+      "retryCount": 0
+    }
+  ]
+}
+EOF
+
+  local out
+  set +e
+  out="$(run_doctor "${d}" OBSIDIAN_VAULT="${d}/vault" 2>&1)"
+  set -e
+
+  assert_contains "${out}" "Last auto-ingest activity:" \
+    "AI-INT-1: last auto-ingest line surfaces in integrated output"
+  assert_contains "${out}" "Pending auto-ingest retry queue" \
+    "AI-INT-1: pending retry line surfaces in integrated output"
+  assert_contains "${out}" "extract_failed" \
+    "AI-INT-1: errorType parsed from production-schema queue file"
+}
+
+# -----------------------------------------------------------------------------
+# BLUE-DOCTOR-DQ-INT-1: check_discoverqueries_state surfaces in default doctor output
+#
+# Sprint 5.5 PR B55 で追加した check_discoverqueries_state が main() に正しく
+# 登録されていて、usage log present 時に discoverqueries-usage ok line が
+# text mode 出力に現れることを pin する。discoverqueries-* の詳細 unit test は
+# tests/discoverqueries-diagnostic.test.sh で持つが、本 assertion は
+# 「main() から関数 call が脱落しないこと」を保証する regression guard
+# (LEARN#5 cross-suite reference pinning、check_auto_ingest_state の AI-INT 版)。
+# -----------------------------------------------------------------------------
+test_discoverqueries_state_integrated() {
+  echo "BLUE-DOCTOR-DQ-INT-1: check_discoverqueries_state lines appear in default doctor output"
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "  skip  jq not available"
+    return 0
+  fi
+  local d
+  d="$(new_case "discoverqueries-integrated")"
+  stub_full_clis "${d}/bin"
+  stub_node_18 "${d}/bin"
+  stub_curl_ok "${d}/bin"
+  init_full_vault_with_commit "${d}/vault"
+
+  # Pre-populate a usage log with the production schema (Sprint 5.5 PR A55
+  # appendToUsageLog output shape) so the integration assertion also pins
+  # schema parity with mcp/lib/discoverqueries-learning.mjs.
+  cat >"${d}/vault/.kioku-discoverqueries-usage.json" <<'EOF'
+{
+  "version": 1,
+  "entries": [
+    {
+      "query": "integration-test-query",
+      "count": 5,
+      "firstSeen": "2026-05-15T01:00:00.000Z",
+      "lastSeen": "2026-05-15T02:00:00.000Z"
+    }
+  ]
+}
+EOF
+
+  local out
+  set +e
+  out="$(run_doctor "${d}" OBSIDIAN_VAULT="${d}/vault" 2>&1)"
+  set -e
+
+  assert_contains "${out}" "DiscoverQueries dynamic learning: active" \
+    "DQ-INT-1: discoverqueries-usage active line surfaces in integrated output"
+  assert_contains "${out}" "queries learned" \
+    "DQ-INT-1: entries count parsed from production-schema usage log"
+}
+
+# -----------------------------------------------------------------------------
 # Run all
 # -----------------------------------------------------------------------------
 test_env_unset
@@ -1038,6 +1156,8 @@ test_install_mode_mcp_only
 test_install_mode_unknown
 test_install_mode_json
 test_sync_state_integrated
+test_auto_ingest_state_integrated
+test_discoverqueries_state_integrated
 
 echo ""
 echo "doctor.test.sh: ${PASS} passed, ${FAIL} failed"

--- a/tests/fixtures/test-helpers.mjs
+++ b/tests/fixtures/test-helpers.mjs
@@ -6,9 +6,25 @@
 // Sprint 4 Phase 4 PR B4 (LEARN#8b N=2 observation: mockGitPushFailure +
 //   readRetryQueue planned for sync-diagnostic.test.sh PATH-stub coverage +
 //   future hot-fix regression tests).
+// Sprint 5 PR B5 (LEARN#8b N=3 mandatory extract: classifyError + maskCredentials
+//   + retry queue I/O duplication 達 N=3 [hooks/sync-vault.mjs +
+//   hooks/auto-ingest-retry.mjs + planned 3rd retry-style helper] →
+//   mockAutoIngestFailure + readAutoIngestRetryQueue を本ファイルに集約。
+//   PATH-stub mechanism は mockGitPushFailure と同じ pattern を踏襲、retry queue
+//   read は readRetryQueue (sync 側) と pair で「retry queue 全種類を 1 file で
+//   inspect できる」test ergonomics を実現)。
+// Sprint 5.5 PR B55 (LEARN#8b N=4 reinforcement: queue/log read wrapper 系が
+//   readRetryQueue + readAutoIngestRetryQueue + readAutoIngestManualReviewQueue
+//   で既に N=3 集約済。本 PR は 4 つ目 caller (discoverQueries dynamic learning
+//   usage log) として mockSessionLogScan + readUsageLog を追加。readUsageLog は
+//   readAutoIngestRetryQueue と同 contract = missing は null (production
+//   discoverqueries-learning.mjs の readUsageLog は canonical empty shape を
+//   返す別 contract、test-helper 側は `=== null` 判定 ergonomics を優先)。
+//   mockSessionLogScan は scanSessionLogs が拾える minimal session-log fixture
+//   を programmatic 生成する。)
 
 import { existsSync } from 'node:fs';
-import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -158,6 +174,180 @@ export async function readRetryQueue(vaultPath) {
   if (!existsSync(queuePath)) return null;
   try {
     const raw = await readFile(queuePath, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object') return parsed;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * PATH-stub that makes one of the auto-ingest extract scripts fail with a
+ * canned stderr matching one of the `classifyAutoIngestError` buckets. Used by
+ * `tests/auto-ingest-diagnostic.test.sh` to exercise `doctor.sh
+ * check_auto_ingest_state` paths without relying on real PDF / EPUB / DOCX
+ * binaries or a live `claude` CLI.
+ *
+ * The stub script writes the canned stderr message to its stderr stream and
+ * exits with the supplied rc. By default rc=99 (matches auto-ingest.sh's
+ * `*` → enqueue branch). Caller passes the absolute path back into
+ * auto-ingest.sh via `KIOKU_EXTRACT_PDF_SCRIPT` (or the matching env var for
+ * EPUB / DOCX / URL) plus `KIOKU_ALLOW_EXTRACT_*_OVERRIDE=1` to bypass the
+ * VULN-004 env-injection guard.
+ *
+ * Returns an object with the stub script `path` (caller passes to the
+ * relevant `KIOKU_EXTRACT_*_SCRIPT`) and a `restore` function that removes
+ * the stub directory.
+ *
+ * Usage:
+ *   const { path, restore } = await mockAutoIngestFailure('llm_failed');
+ *   try { ... } finally { await restore(); }
+ *
+ * @param {'extract_failed' | 'llm_failed' | 'fs_error' | 'sha256_drift' | 'unknown'} errorType
+ * @param {{ rc?: number }} [opts]
+ * @returns {Promise<{ path: string, restore: () => Promise<void> }>}
+ */
+export async function mockAutoIngestFailure(errorType, opts = {}) {
+  const errorMessages = {
+    'extract_failed': 'extract-pdf.sh: failed (rc=1) — stub injected by mockAutoIngestFailure',
+    'llm_failed': 'claude -p timed out (test mock from mockAutoIngestFailure)',
+    'fs_error': 'ENOENT: no such file or directory, open ... (test mock)',
+    'sha256_drift': 'source_sha256 mismatch detected for chunk (test mock)',
+    'unknown': 'something unexpected happened (test mock)',
+  };
+  if (!Object.prototype.hasOwnProperty.call(errorMessages, errorType)) {
+    throw new Error(`mockAutoIngestFailure: unsupported errorType "${errorType}"`);
+  }
+  const rc = Number.isFinite(opts.rc) ? opts.rc : 99;
+
+  const stubDir = await mkdtemp(join(tmpdir(), 'kioku-auto-ingest-mock-'));
+  const stubPath = join(stubDir, 'extract-stub.sh');
+  const stubScript = [
+    '#!/usr/bin/env bash',
+    `echo ${shellQuote(errorMessages[errorType])} >&2`,
+    `exit ${rc}`,
+    '',
+  ].join('\n');
+  await writeFile(stubPath, stubScript, 'utf8');
+  await chmod(stubPath, 0o755);
+
+  let restored = false;
+  return {
+    path: stubPath,
+    async restore() {
+      if (restored) return;
+      restored = true;
+      await rm(stubDir, { recursive: true, force: true });
+    },
+  };
+}
+
+/**
+ * Read and parse `.kioku-auto-ingest-retry.json` from a Vault path. Returns
+ * `null` if the file is missing (unlike `readAutoIngestRetryQueue` in
+ * `hooks/auto-ingest-retry.mjs` which returns the canonical empty shape) — the
+ * test ergonomic here favors `=== null` checks for "queue absent" assertions.
+ * Returns `{ entries: [...] }` on success.
+ *
+ * Companion to `readRetryQueue` (sync side) and `readManualReviewQueue` so
+ * test code can inspect both kioku queue files via this single fixtures module.
+ *
+ * @param {string} vaultPath — absolute path to the Vault directory
+ * @returns {Promise<object | null>}
+ */
+export async function readAutoIngestRetryQueue(vaultPath) {
+  const queuePath = join(vaultPath, '.kioku-auto-ingest-retry.json');
+  if (!existsSync(queuePath)) return null;
+  try {
+    const raw = await readFile(queuePath, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object') return parsed;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read and parse `.kioku-auto-ingest-manual-review.json` from a Vault path.
+ * Same contract as `readAutoIngestRetryQueue` — returns `null` if file missing.
+ *
+ * @param {string} vaultPath — absolute path to the Vault directory
+ * @returns {Promise<object | null>}
+ */
+export async function readAutoIngestManualReviewQueue(vaultPath) {
+  const queuePath = join(vaultPath, '.kioku-auto-ingest-manual-review.json');
+  if (!existsSync(queuePath)) return null;
+  try {
+    const raw = await readFile(queuePath, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object') return parsed;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Generate a minimal session-log file under `${vaultPath}/session-logs/` that
+ * `scanSessionLogs` (mcp/lib/discoverqueries-learning.mjs) can pick up. The
+ * file body repeats `query` `count` times in a `## User (HH:MM:SS)` block so
+ * the query signal extraction (#tag / [[wikilink]] / ATX heading) registers
+ * `count` occurrences. `query` is emitted as a bare `#query` tag ref so it
+ * survives the pre-strip → mask → PII sanitize pipeline.
+ *
+ * Used by `tests/discoverqueries-diagnostic.test.sh` to seed a usage-log
+ * baseline (after the production `appendToUsageLog` consumes the scan result)
+ * without depending on real Claude sessions.
+ *
+ * @param {string} vaultPath — absolute path to the temp Vault directory
+ * @param {string} query — query token (tag-friendly: lowercase + hyphen)
+ * @param {number} [count=1] — occurrence count to write
+ * @returns {Promise<string>} absolute path to the generated session-log file
+ */
+export async function mockSessionLogScan(vaultPath, query, count = 1) {
+  if (typeof vaultPath !== 'string' || vaultPath.length === 0) {
+    throw new Error('mockSessionLogScan: vaultPath required');
+  }
+  if (typeof query !== 'string' || query.length === 0) {
+    throw new Error('mockSessionLogScan: query required');
+  }
+  const n = Number.isFinite(count) && count > 0 ? Math.floor(count) : 1;
+  const sessionLogsDir = join(vaultPath, 'session-logs');
+  await mkdir(sessionLogsDir, { recursive: true });
+  const lines = ['## User (12:00:00)', ''];
+  for (let i = 0; i < n; i += 1) {
+    lines.push(`#${query} mention ${i + 1}`);
+  }
+  lines.push('');
+  const stamp = `20260515-120000-mock-${query}`.replace(/[^a-zA-Z0-9-]/g, '-');
+  const filePath = join(sessionLogsDir, `${stamp}.md`);
+  await writeFile(filePath, lines.join('\n'), 'utf8');
+  return filePath;
+}
+
+/**
+ * Read and parse `.kioku-discoverqueries-usage.json` from a Vault path.
+ * Returns `null` if the file is missing (mirrors the test-friendly contract of
+ * `readAutoIngestRetryQueue` — note this differs from the production
+ * `readUsageLog` in `mcp/lib/discoverqueries-learning.mjs` which returns the
+ * canonical empty `{ version, entries: [] }` shape; here the `=== null` check
+ * is the ergonomic for "usage log absent" assertions). Returns the parsed
+ * object on success, `null` on malformed JSON.
+ *
+ * Companion to `readRetryQueue` / `readAutoIngestRetryQueue` /
+ * `readAutoIngestManualReviewQueue` so test code can inspect every kioku
+ * state file via this single fixtures module (LEARN#8b N=4 reinforcement).
+ *
+ * @param {string} vaultPath — absolute path to the Vault directory
+ * @returns {Promise<object | null>}
+ */
+export async function readUsageLog(vaultPath) {
+  const logPath = join(vaultPath, '.kioku-discoverqueries-usage.json');
+  if (!existsSync(logPath)) return null;
+  try {
+    const raw = await readFile(logPath, 'utf8');
     const parsed = JSON.parse(raw);
     if (parsed && typeof parsed === 'object') return parsed;
     return null;

--- a/tests/metadata-drift.test.mjs
+++ b/tests/metadata-drift.test.mjs
@@ -8,6 +8,9 @@
 //   - BLUE-DRIFT-TOOL-1     : MCP server.mjs registerTool ↔ manifest.json tools[].name 一致
 //   - BLUE-DRIFT-TOOL-2     : app/README.md (EN) tool 言及 ⊆ manifest set (no phantom)
 //   - BLUE-DRIFT-TOOL-3     : context/14-mcp-server.md tool 言及 ⊆ manifest set (no phantom)
+//   - BLUE-DRIFT-TOOL-4     : context/14-mcp-server.md "## 提供する N ツール" header N
+//                             === manifest tools[].length (2026-05-14 §47 incident codification、
+//                             LEARN#9 grep-based audit pattern の 機械検出版)
 //   - BLUE-DRIFT-VERSION-1  : 4 metadata file (mcp/package.json, mcp/manifest.json,
 //                             .claude-plugin/plugin.json, .claude-plugin/marketplace.json
 //                             metadata.version) all parity
@@ -173,6 +176,16 @@ function extractKiokuToolMentions(markdown) {
   return set;
 }
 
+// markdown header から「## 提供する N ツール」の N を抽出
+// 例: "## 提供する 11 ツール" → 11
+// 該当 header 不在なら null を返す (test 側で fail にする)
+function extractContextToolCountHeader(markdown) {
+  const re = /^##\s+提供する\s+(\d+)\s+ツール\s*$/m;
+  const match = markdown.match(re);
+  if (!match) return null;
+  return Number.parseInt(match[1], 10);
+}
+
 // markdown から fenced bash/sh/shell code block の本文のみを抽出
 function extractFencedBashBlocks(markdown) {
   const re = /```(?:bash|sh|shell)\s*\n([\s\S]*?)\n```/g;
@@ -243,6 +256,37 @@ describe('BLUE-DRIFT-TOOL: MCP tool registry drift', () => {
         `  expected: context/14 で言及される kioku_* tool は全て manifest.json tools[].name に存在\n` +
         `  found phantom: ${phantom.join(', ')}\n` +
         `  fix: context/14-mcp-server.md から該当 tool 言及を削除する、または manifest に追加する`,
+    );
+  });
+
+  test('BLUE-DRIFT-TOOL-4: context/14-mcp-server.md "## 提供する N ツール" header N === manifest tools[].length', async () => {
+    // 2026-05-14 §47 incident codification:
+    //   Sprint 2 v0.7.4 で kioku_health を MCP tool に追加した際、
+    //   context/14-mcp-server.md 本文は更新したが section header の "10" → "11" を更新し忘れ。
+    //   tests + manifest + server.mjs は全部 11 に整合、context doc header のみが古いまま残った。
+    //   本 test は header N と manifest tools[].length の drift を機械検出する 4th drift category。
+    //   LEARN#9 grep-based audit pattern の 機械検出版。
+    const manifest = await readJson(PATHS.manifest);
+    const manifestCount = manifest.tools.length;
+
+    const contextText = await readText(PATHS.contextMcp);
+    const headerCount = extractContextToolCountHeader(contextText);
+
+    assert.notEqual(
+      headerCount,
+      null,
+      `context/14-mcp-server.md に "## 提供する N ツール" header が見つかりません。\n` +
+        `  expected: "## 提供する <N> ツール" 形式の H2 header が 1 つ存在\n` +
+        `  fix: 該当 section を context/14-mcp-server.md に追加する、または regex を更新する`,
+    );
+
+    assert.equal(
+      headerCount,
+      manifestCount,
+      `context/14-mcp-server.md tool count header drift detected (§47 incident type)。\n` +
+        `  expected: header "## 提供する N ツール" の N が manifest.json tools[].length と一致\n` +
+        `  found: header N = ${headerCount}, manifest tools[].length = ${manifestCount}\n` +
+        `  fix: context/14-mcp-server.md L31 付近の header を "## 提供する ${manifestCount} ツール" に修正する`,
     );
   });
 });

--- a/tests/qmd-search-index.test.mjs
+++ b/tests/qmd-search-index.test.mjs
@@ -16,6 +16,7 @@
 //     - 7b: getFileHistory が `{ commits: [], error: 'not_a_git_repo' }` shape を返した second-layer guard (defense-in-depth)
 //   - F8 (BLUE-QMD-INDEX-8): wiki/hot.md content scan で ATX heading + 単独行 #tag 抽出 (weight 2.5)
 //   - F9 (BLUE-QMD-INDEX-9): empty PM-Vault-like fixture (no log tags, no index wikilinks, no concept files) でも raw-sources + git + hot.md から >= 3 query 産出 (regression guard)
+//   - F10 (BLUE-QMD-INDEX-10): Sprint 5.5 PR A55/B55 — discoverQueries が session-logs/ を Source 8 (weight 2.8) として additive 統合 + opt-out hard gate (両側 pin、LEARN#5 cross-suite reference)
 
 import { test, describe, before, after } from 'node:test';
 import assert from 'node:assert/strict';
@@ -459,6 +460,71 @@ describe('qmd-search-index', () => {
       // duplicate なし
       const uniq = new Set(queries);
       assert.equal(uniq.size, queries.length, 'discoverQueries must dedupe');
+    } finally {
+      await rm(ws, { recursive: true, force: true });
+    }
+  });
+
+  // Sprint 5.5 PR A55/B55: 8th source (session-logs/ scan) integration.
+  // A55 で discoverqueries-learning.test.mjs 側に統合 test (BLUE-DQ-LEARN-A55-4)
+  // はあるが、本 file 側からも「discoverQueries が session-logs/ 由来 query を
+  // Source 8 として weight 2.8 で additive 統合する」ことを pin して両側 guard
+  // にする (LEARN#5 cross-suite reference pinning: scanSessionLogs call が
+  // qmd-search-index.mjs discoverQueries から脱落しないこと)。
+  test('BLUE-QMD-INDEX-10 (F10): discoverQueries integrates session-logs/ as Source 8 (weight 2.8, additive)', async () => {
+    assert.ok(__test__);
+    const { discoverQueries } = __test__;
+    const ws = await mkdtemp(join(tmpdir(), 'kioku-qmd-f10-'));
+    const v = join(ws, 'vault');
+    try {
+      // Static source (Source 1): a low-count log.md tag.
+      await mkdir(join(v, 'wiki'), { recursive: true });
+      await writeFile(
+        join(v, 'wiki', 'log.md'),
+        '# Log\n\n- 2026-05-15 #f10-static-tag mention\n',
+      );
+
+      // Source 8: session-logs/ file mentioning a unique query repeatedly.
+      // weight 2.8 * occurrences should clearly surface it in TopN while the
+      // static tag still remains (additive, not replacement).
+      await mkdir(join(v, 'session-logs'), { recursive: true });
+      await writeFile(
+        join(v, 'session-logs', '20260515-120000-aaaa-f10.md'),
+        [
+          '## User (12:00:00)',
+          '',
+          '#f10-session-query asked repeatedly',
+          '',
+          '# f10-session-query Heading',
+          '',
+          'More about #f10-session-query here.',
+          '',
+        ].join('\n'),
+      );
+
+      const queries = await discoverQueries(v, 20);
+      assert.ok(Array.isArray(queries));
+      assert.ok(
+        queries.includes('f10-session-query'),
+        `Source 8 (session-logs/) query missing from TopN, got: ${queries.join(', ')}`,
+      );
+      assert.ok(
+        queries.includes('f10-static-tag'),
+        `static log.md tag must still appear (Source 8 is additive), got: ${queries.join(', ')}`,
+      );
+
+      // opt-out hard gate: with the marker present, Source 8 yields nothing
+      // (the static tag still appears — proves graceful additive skip).
+      await writeFile(join(v, '.kioku-discoverqueries-opt-out'), '', 'utf8');
+      const optedOut = await discoverQueries(v, 20);
+      assert.ok(
+        !optedOut.includes('f10-session-query'),
+        `opt-out must suppress Source 8, got: ${optedOut.join(', ')}`,
+      );
+      assert.ok(
+        optedOut.includes('f10-static-tag'),
+        `static sources unaffected by opt-out, got: ${optedOut.join(', ')}`,
+      );
     } finally {
       await rm(ws, { recursive: true, force: true });
     }


### PR DESCRIPTION
## KIOKU v0.10.0 — reliability + intelligence の 2 軸進化

Sprint 5 (axis A) + Sprint 5.5 (axis B) 全完走の bundle minor release。

### Sprint 5 axis A — auto-ingest pipeline reliability
- `hooks/auto-ingest-retry.mjs` — retry queue + classify + manual review queue + credential masking
- `scripts/doctor.sh` `check_auto_ingest_state` — auto-ingest 状態の read-only diagnostic
- LEARN#8b N=3 mandatory extract pattern

### Sprint 5.5 axis B — discoverQueries 自動学習
- `mcp/lib/discoverqueries-learning.mjs` — session-logs/ scan = 8th source (weight 2.8、最高) を additive 統合した dynamic learning
- privacy contract 3 axis — masking SSOT `applyMasks` / `.kioku-discoverqueries-opt-out` opt-out / `.kioku-discoverqueries-usage.json` 64KB FIFO rotate
- `scripts/doctor.sh` `check_discoverqueries_state` — 3 axis 診断 + LEARN#8b N=4 reinforcement

### scope
parent → kioku next sync (PR #176 = parent version bump の後段)。19 file / 4165 insertions。README は本 PR に含めない (LEARN#11、kioku 側別 PR で v0.10.0 Changelog land)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)