### PR TITLE
docs: v0.10.0 Changelog を 10 言語 README に展開 (LEARN#11 mandatory、post-release-sync 前 land)

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -263,6 +263,17 @@ Si encuentras un problema de seguridad, repórtalo a través de [SECURITY.md](SE
 
 ## Cambios
 
+### 2026-05-19 — v0.10.0: "Tu auto-ingest nunca falla en silencio, y la busqueda aprende de tus propias sesiones" — Sprint 5 + 5.5 completado (reliability + intelligence の 2 軸進化)
+
+v0.10.0 marca el **Sprint 5 (axis A) + Sprint 5.5 (axis B) 全完走**. reliability + intelligence の 2 軸進化, bundle minor release.
+
+- **Sprint 5 axis A (auto-ingest reliability)**: `hooks/auto-ingest-retry.mjs` retry queue (3x exponential backoff + persistent resume) + classify (network/transient/permanent) + manual review queue + credential masking (`applyMasks` SSOT), `scripts/doctor.sh` `check_auto_ingest_state` diagnostic, LEARN#8b N=3 extract
+- **Sprint 5.5 axis B (discoverQueries 自動学習)**: `mcp/lib/discoverqueries-learning.mjs` session-logs/ scan = 8th source (weight 2.8, 最高), privacy contract 3 axis (`applyMasks` SSOT / `.kioku-discoverqueries-opt-out` / `.kioku-discoverqueries-usage.json` 64KB FIFO), `scripts/doctor.sh` `check_discoverqueries_state`, LEARN#8b N=4 reinforcement
+- **Hardened design contract**: credential masking SSOT (`applyMasks`) reused across auto-ingest retry log + discoverQueries usage log
+- **Tests**: Sprint 5 + 5.5 全 BLUE-* green, Sprint 4 累計 regression なし
+- **subagent-driven N=29-34 cycle** — Sprint 5 (N=29-31) + Sprint 5.5 (N=32-34)
+- [Release v0.10.0](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.10.0) — `kioku-wiki-0.10.0.mcpb` attached
+
 ### 2026-05-15 — v0.9.0: "Abre tu wiki en el navegador, busca con Claude, incluso desde tu telefono" — Sprint 4 completado (4 pillar: Shell + Search + Mobile + Sync polish)
 
 v0.9.0 marca el **Sprint 4 全 phase 完走**. 4 pillar narrative: **Hardened LLM Wiki for Professionals + Claude-augmented Search + Mobile responsive + Sync polished**. Path C+β progress 70% → 100% completado, Sprint 4 全 cycle completion marker.

--- a/README.fr.md
+++ b/README.fr.md
@@ -326,6 +326,17 @@ Si vous trouvez un probleme de securite, veuillez le signaler via [SECURITY.md](
 
 ## Journal des modifications
 
+### 2026-05-19 — v0.10.0 : "Votre auto-ingest n'echoue jamais en silence, et la recherche apprend de vos propres sessions" — Sprint 5 + 5.5 termine (reliability + intelligence の 2 軸進化)
+
+v0.10.0 marque le **Sprint 5 (axis A) + Sprint 5.5 (axis B) 全完走**. reliability + intelligence の 2 軸進化, bundle minor release.
+
+- **Sprint 5 axis A (auto-ingest reliability)**: `hooks/auto-ingest-retry.mjs` retry queue (3x exponential backoff + persistent resume) + classify (network/transient/permanent) + manual review queue + credential masking (`applyMasks` SSOT), `scripts/doctor.sh` `check_auto_ingest_state` diagnostic, LEARN#8b N=3 extract
+- **Sprint 5.5 axis B (discoverQueries 自動学習)**: `mcp/lib/discoverqueries-learning.mjs` session-logs/ scan = 8th source (weight 2.8, 最高), privacy contract 3 axis (`applyMasks` SSOT / `.kioku-discoverqueries-opt-out` / `.kioku-discoverqueries-usage.json` 64KB FIFO), `scripts/doctor.sh` `check_discoverqueries_state`, LEARN#8b N=4 reinforcement
+- **Hardened design contract**: credential masking SSOT (`applyMasks`) reused across auto-ingest retry log + discoverQueries usage log
+- **Tests**: Sprint 5 + 5.5 全 BLUE-* green, Sprint 4 累計 regression なし
+- **subagent-driven N=29-34 cycle** — Sprint 5 (N=29-31) + Sprint 5.5 (N=32-34)
+- [Release v0.10.0](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.10.0) — `kioku-wiki-0.10.0.mcpb` attached
+
 ### 2026-05-15 — v0.9.0 : "Ouvrez votre wiki dans un navigateur, cherchez avec Claude, meme depuis votre telephone" — Sprint 4 termine (4 pillar : Shell + Search + Mobile + Sync polish)
 
 v0.9.0 marque le **Sprint 4 全 phase 完走**. 4 pillar narrative : **Hardened LLM Wiki for Professionals + Claude-augmented Search + Mobile responsive + Sync polished**. Path C+β progress 70% → 100% termine, Sprint 4 全 cycle completion marker.

--- a/README.hi.md
+++ b/README.hi.md
@@ -263,6 +263,17 @@ KIOKU एक Hook सिस्टम है जो **सभी Claude Code स�
 
 ## परिवर्तन इतिहास
 
+### 2026-05-19 — v0.10.0: "आपका auto-ingest कभी चुपचाप fail नहीं होता, और search आपके अपने sessions से सीखता है" — Sprint 5 + 5.5 पूर्ण (reliability + intelligence の 2 軸進化)
+
+v0.10.0 = **Sprint 5 (axis A) + Sprint 5.5 (axis B) 全完走**. reliability + intelligence の 2 軸進化, bundle minor release.
+
+- **Sprint 5 axis A (auto-ingest reliability)**: `hooks/auto-ingest-retry.mjs` retry queue (3x exponential backoff + persistent resume) + classify (network/transient/permanent) + manual review queue + credential masking (`applyMasks` SSOT), `scripts/doctor.sh` `check_auto_ingest_state` diagnostic, LEARN#8b N=3 extract
+- **Sprint 5.5 axis B (discoverQueries 自動学習)**: `mcp/lib/discoverqueries-learning.mjs` session-logs/ scan = 8th source (weight 2.8, 最高), privacy contract 3 axis (`applyMasks` SSOT / `.kioku-discoverqueries-opt-out` / `.kioku-discoverqueries-usage.json` 64KB FIFO), `scripts/doctor.sh` `check_discoverqueries_state`, LEARN#8b N=4 reinforcement
+- **Hardened design contract**: credential masking SSOT (`applyMasks`) reused across auto-ingest retry log + discoverQueries usage log
+- **Tests**: Sprint 5 + 5.5 全 BLUE-* green, Sprint 4 累計 regression なし
+- **subagent-driven N=29-34 cycle** — Sprint 5 (N=29-31) + Sprint 5.5 (N=32-34)
+- [Release v0.10.0](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.10.0) — `kioku-wiki-0.10.0.mcpb` attached
+
 ### 2026-05-15 — v0.9.0: "अपनी wiki को browser में खोलें, Claude के साथ search करें, phone से भी" — Sprint 4 पूर्ण (4 pillar: Shell + Search + Mobile + Sync polish)
 
 v0.9.0 **Sprint 4 全 phase 完走** marker है। 4 pillar narrative: **Hardened LLM Wiki for Professionals + Claude-augmented Search + Mobile responsive + Sync polished**। Path C+β progress 70% → 100% पूर्ण, Sprint 4 全 cycle completion।

--- a/README.ja.md
+++ b/README.ja.md
@@ -484,6 +484,29 @@ KIOKU は Claude Code の**全セッション入出力にアクセスする Hook
 
 ## 更新履歴
 
+### 2026-05-19 — v0.10.0: 「取り込みは静かに失敗しない、検索はあなたの会話から自動で賢くなる」— Sprint 5 + 5.5 完走 (reliability + intelligence の 2 軸進化)
+
+v0.10.0 は **Sprint 5 (axis A) + Sprint 5.5 (axis B) 全完走**。v0.9.0 (Sprint 4) で「使いたい時に使える体験」が 4 軸揃った上で、v0.10.0 は **基盤の信頼性と検索の知能を 2 軸** で底上げする。「自動取り込みが network 一時失敗で静かに止まらない」「検索 query が自分の過去 session から自動で学習して賢くなる」 — この 2 つを reliability + intelligence の bundle minor release として land。
+
+KIOKU positioning に **reliability (auto-ingest 自己回復) + intelligence (discoverQueries 自動学習)** の 2 軸が加わる。Sprint 4 (v0.9.0) の 4 pillar narrative の上に、基盤を強くする 2 軸進化。
+
+- **Sprint 5 axis A — auto-ingest pipeline reliability**（「取り込みが静かに失敗しない」）:
+  - `hooks/auto-ingest-retry.mjs` — auto-ingest 失敗を **retry queue** で 3 回 exponential backoff + persistent queue、次回起動時 resume
+  - **classify** — 失敗を category 分類 (network / transient / permanent) して recovery 戦略を分岐
+  - **manual review queue** — 自動回復不能な item を user が後から確認できる queue へ退避
+  - **credential masking** — retry log に token / password が残らないよう `applyMasks` SSOT で redact
+  - `scripts/doctor.sh` **`check_auto_ingest_state`** — queue 残件 / 最終成功時刻 / 失敗 category を read-only diagnostic
+  - LEARN#8b N=3 mandatory extract pattern 達成
+- **Sprint 5.5 axis B — discoverQueries 自動学習**（「検索が自分の会話から自動で賢くなる」）:
+  - `mcp/lib/discoverqueries-learning.mjs` — `discoverQueries` に **session-logs/ scan = 8th source** (weight 2.8、既存 7 source 中最高) を additive 統合、過去 session から query を dynamic 学習
+  - **privacy contract 3 axis** — (1) masking SSOT `applyMasks` で sensitive content を pin (2) `.kioku-discoverqueries-opt-out` で opt-out (3) `.kioku-discoverqueries-usage.json` 64KB FIFO rotate で usage log を bounded に
+  - `scripts/doctor.sh` **`check_discoverqueries_state`** — 3 axis (learning 有効性 / opt-out / usage log) を read-only diagnostic
+  - LEARN#8b N=4 reinforcement (mockSessionLogScan + readUsageLog)
+- **Hardened 設計契約 2 axis 通底** — credential masking SSOT (`applyMasks`) を auto-ingest retry log と discoverQueries usage log の両方で再利用、秘密を共有しても漏れない契約を 2 軸横断で維持
+- **Tests** — Sprint 5 (auto-ingest-retry .mjs/.sh + auto-ingest-diagnostic + doctor) + Sprint 5.5 (discoverqueries-learning + discoverqueries-privacy + discoverqueries-diagnostic) 全 BLUE-* green、Sprint 4 累計 regression なし
+- **subagent-driven N=29-34 cycle** — Sprint 5 (N=29-31) + Sprint 5.5 (N=32-34)、axis A+B 各 PR A/B/C の N=3 cycle 簡略形 × 2
+- [Release v0.10.0](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.10.0) — `kioku-wiki-0.10.0.mcpb` attached
+
 ### 2026-05-15 — v0.9.0: 「ブラウザで Wiki を一望、Claude で深掘り、スマホからも触れる」— Sprint 4 完走 (4 pillar: Shell + Search + Mobile + Sync polish)
 
 v0.9.0 は **Sprint 4 全 phase 完走**。Sprint 3 (v0.8.0 Visualizer β) で「過去が見える」が揃った上で、Sprint 4 は **「使いたい時に使える体験」を 4 軸** で揃える。「Obsidian を起動せずブラウザで Wiki を一望」「ブラウザで keyword 検索 → Claude で深掘り」「スマホで Wiki を読める」「Git push が静かに失敗しない」 — この 4 つの疑問に 3 日間 (5/13–5/15) で 4 phase land。

--- a/README.ko.md
+++ b/README.ko.md
@@ -326,6 +326,17 @@ KIOKU은 **모든 Claude Code 세션 입출력**에 접근하는 Hook 시스템�
 
 ## 변경 이력
 
+### 2026-05-19 — v0.10.0: "auto-ingest가 조용히 실패하지 않고, search가 내 session에서 스스로 학습" — Sprint 5 + 5.5 완주 (reliability + intelligence の 2 軸進化)
+
+v0.10.0은 **Sprint 5 (axis A) + Sprint 5.5 (axis B) 全完走**. reliability + intelligence の 2 軸進化, bundle minor release.
+
+- **Sprint 5 axis A (auto-ingest reliability)**: `hooks/auto-ingest-retry.mjs` retry queue (3x exponential backoff + persistent resume) + classify (network/transient/permanent) + manual review queue + credential masking (`applyMasks` SSOT), `scripts/doctor.sh` `check_auto_ingest_state` diagnostic, LEARN#8b N=3 extract
+- **Sprint 5.5 axis B (discoverQueries 自動学習)**: `mcp/lib/discoverqueries-learning.mjs` session-logs/ scan = 8th source (weight 2.8, 最高), privacy contract 3 axis (`applyMasks` SSOT / `.kioku-discoverqueries-opt-out` / `.kioku-discoverqueries-usage.json` 64KB FIFO), `scripts/doctor.sh` `check_discoverqueries_state`, LEARN#8b N=4 reinforcement
+- **Hardened design contract**: credential masking SSOT (`applyMasks`) reused across auto-ingest retry log + discoverQueries usage log
+- **Tests**: Sprint 5 + 5.5 全 BLUE-* green, Sprint 4 累計 regression なし
+- **subagent-driven N=29-34 cycle** — Sprint 5 (N=29-31) + Sprint 5.5 (N=32-34)
+- [Release v0.10.0](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.10.0) — `kioku-wiki-0.10.0.mcpb` attached
+
 ### 2026-05-15 — v0.9.0: "wiki를 browser에서 열고, Claude로 검색하고, 휴대폰으로도" — Sprint 4 완주 (4 pillar: Shell + Search + Mobile + Sync polish)
 
 v0.9.0은 **Sprint 4 全 phase 완주** marker. 4 pillar narrative: **Hardened LLM Wiki for Professionals + Claude-augmented Search + Mobile responsive + Sync polished**. Path C+β progress 70% → 100% 달성, Sprint 4 全 cycle completion marker.

--- a/README.md
+++ b/README.md
@@ -465,6 +465,29 @@ If you find a security issue, please report it via [SECURITY.md](SECURITY.md) �
 
 ## Changelog
 
+### 2026-05-19 — v0.10.0: "Your auto-ingest never fails silently, and search learns from your own sessions" — Sprint 5 + 5.5 完走 (reliability + intelligence の 2 軸進化)
+
+v0.10.0 ships **Sprint 5 (axis A) + Sprint 5.5 (axis B) 全完走** — v0.9.0 (Sprint 4) で「使いたい時に使える体験」が 4 軸揃った上で、v0.10.0 は **基盤の信頼性と検索の知能を 2 軸** で底上げする。「自動取り込みが network 一時失敗で静かに止まらない」「検索 query が自分の過去 session から自動で学習して賢くなる」 — この 2 つを reliability + intelligence の bundle minor release として land。
+
+KIOKU positioning に **reliability (auto-ingest 自己回復) + intelligence (discoverQueries 自動学習)** の 2 軸が加わる。Sprint 4 (v0.9.0) の 4 pillar narrative の上に、基盤を強くする 2 軸進化。
+
+- **Sprint 5 axis A — auto-ingest pipeline reliability** ("取り込みが静かに失敗しない"):
+  - `hooks/auto-ingest-retry.mjs` — auto-ingest 失敗を **retry queue** で 3 回 exponential backoff + persistent queue、次回起動時 resume
+  - **classify** — 失敗を category 分類 (network / transient / permanent) して recovery 戦略を分岐
+  - **manual review queue** — 自動回復不能な item を user が後から確認できる queue へ退避
+  - **credential masking** — retry log に token / password が残らないよう `applyMasks` SSOT で redact
+  - `scripts/doctor.sh` **`check_auto_ingest_state`** — queue 残件 / 最終成功時刻 / 失敗 category を read-only diagnostic
+  - LEARN#8b N=3 mandatory extract pattern 達成
+- **Sprint 5.5 axis B — discoverQueries 自動学習** ("検索が自分の会話から自動で賢くなる"):
+  - `mcp/lib/discoverqueries-learning.mjs` — `discoverQueries` に **session-logs/ scan = 8th source** (weight 2.8、既存 7 source 中最高) を additive 統合、過去 session から query を dynamic 学習
+  - **privacy contract 3 axis** — (1) masking SSOT `applyMasks` で sensitive content を pin (2) `.kioku-discoverqueries-opt-out` で opt-out (3) `.kioku-discoverqueries-usage.json` 64KB FIFO rotate で usage log を bounded に
+  - `scripts/doctor.sh` **`check_discoverqueries_state`** — 3 axis (learning 有効性 / opt-out / usage log) を read-only diagnostic
+  - LEARN#8b N=4 reinforcement (mockSessionLogScan + readUsageLog)
+- **Hardened 設計契約 2 axis 通底** — credential masking SSOT (`applyMasks`) を auto-ingest retry log と discoverQueries usage log の両方で再利用、秘密を共有しても漏れない契約を 2 軸横断で維持
+- **Tests** — Sprint 5 (auto-ingest-retry .mjs/.sh + auto-ingest-diagnostic + doctor) + Sprint 5.5 (discoverqueries-learning + discoverqueries-privacy + discoverqueries-diagnostic) 全 BLUE-* green、Sprint 4 累計 regression なし
+- **subagent-driven N=29-34 cycle** — Sprint 5 (N=29-31) + Sprint 5.5 (N=32-34)、axis A+B 各 PR A/B/C の N=3 cycle 簡略形 × 2
+- [Release v0.10.0](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.10.0) — `kioku-wiki-0.10.0.mcpb` attached
+
 ### 2026-05-15 — v0.9.0: "Open your wiki in a browser, search with Claude, even from your phone" — Sprint 4 完走 (4 pillar: Shell + Search + Mobile + Sync polish)
 
 v0.9.0 ships **Sprint 4 全 phase 完走** — Sprint 3 (v0.8.0 Visualizer β) で「過去が見える」が揃った上で、Sprint 4 は **「使いたい時に使える体験」を 4 軸** で揃える。「Obsidian を起動せずブラウザで Wiki を一望」「ブラウザで keyword 検索 → Claude で深掘り」「スマホで Wiki を読める」「Git push が静かに失敗しない」 — この 4 つの疑問に 3 日間 (5/13–5/15) で 4 phase land。

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -326,6 +326,17 @@ Se voce encontrar um problema de seguranca, por favor reporte via [SECURITY.md](
 
 ## Histórico de mudanças
 
+### 2026-05-19 — v0.10.0: "Seu auto-ingest nunca falha em silencio, e a busca aprende das suas proprias sessoes" — Sprint 5 + 5.5 concluido (reliability + intelligence の 2 軸進化)
+
+v0.10.0 marca o **Sprint 5 (axis A) + Sprint 5.5 (axis B) 全完走**. reliability + intelligence の 2 軸進化, bundle minor release.
+
+- **Sprint 5 axis A (auto-ingest reliability)**: `hooks/auto-ingest-retry.mjs` retry queue (3x exponential backoff + persistent resume) + classify (network/transient/permanent) + manual review queue + credential masking (`applyMasks` SSOT), `scripts/doctor.sh` `check_auto_ingest_state` diagnostic, LEARN#8b N=3 extract
+- **Sprint 5.5 axis B (discoverQueries 自動学習)**: `mcp/lib/discoverqueries-learning.mjs` session-logs/ scan = 8th source (weight 2.8, 最高), privacy contract 3 axis (`applyMasks` SSOT / `.kioku-discoverqueries-opt-out` / `.kioku-discoverqueries-usage.json` 64KB FIFO), `scripts/doctor.sh` `check_discoverqueries_state`, LEARN#8b N=4 reinforcement
+- **Hardened design contract**: credential masking SSOT (`applyMasks`) reused across auto-ingest retry log + discoverQueries usage log
+- **Tests**: Sprint 5 + 5.5 全 BLUE-* green, Sprint 4 累計 regression なし
+- **subagent-driven N=29-34 cycle** — Sprint 5 (N=29-31) + Sprint 5.5 (N=32-34)
+- [Release v0.10.0](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.10.0) — `kioku-wiki-0.10.0.mcpb` attached
+
 ### 2026-05-15 — v0.9.0: "Abra seu wiki no navegador, busque com Claude, ate do celular" — Sprint 4 concluido (4 pillar: Shell + Search + Mobile + Sync polish)
 
 v0.9.0 marca o **Sprint 4 全 phase 完走**. 4 pillar narrative: **Hardened LLM Wiki for Professionals + Claude-augmented Search + Mobile responsive + Sync polished**. Path C+β progress 70% → 100% concluido, Sprint 4 全 cycle completion marker.

--- a/README.ru.md
+++ b/README.ru.md
@@ -331,6 +331,17 @@ KIOKU спроектирован для **совместного использ�
 
 ## История изменений
 
+### 2026-05-19 — v0.10.0: "Ваш auto-ingest никогда не падает молча, а поиск учится на ваших сессиях" — Sprint 5 + 5.5 завершён (reliability + intelligence の 2 軸進化)
+
+v0.10.0 — **Sprint 5 (axis A) + Sprint 5.5 (axis B) 全完走**. reliability + intelligence の 2 軸進化, bundle minor release.
+
+- **Sprint 5 axis A (auto-ingest reliability)**: `hooks/auto-ingest-retry.mjs` retry queue (3x exponential backoff + persistent resume) + classify (network/transient/permanent) + manual review queue + credential masking (`applyMasks` SSOT), `scripts/doctor.sh` `check_auto_ingest_state` diagnostic, LEARN#8b N=3 extract
+- **Sprint 5.5 axis B (discoverQueries 自動学習)**: `mcp/lib/discoverqueries-learning.mjs` session-logs/ scan = 8th source (weight 2.8, 最高), privacy contract 3 axis (`applyMasks` SSOT / `.kioku-discoverqueries-opt-out` / `.kioku-discoverqueries-usage.json` 64KB FIFO), `scripts/doctor.sh` `check_discoverqueries_state`, LEARN#8b N=4 reinforcement
+- **Hardened design contract**: credential masking SSOT (`applyMasks`) reused across auto-ingest retry log + discoverQueries usage log
+- **Tests**: Sprint 5 + 5.5 全 BLUE-* green, Sprint 4 累計 regression なし
+- **subagent-driven N=29-34 cycle** — Sprint 5 (N=29-31) + Sprint 5.5 (N=32-34)
+- [Release v0.10.0](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.10.0) — `kioku-wiki-0.10.0.mcpb` attached
+
 ### 2026-05-15 — v0.9.0: "Откройте wiki в браузере, ищите с Claude, даже с телефона" — Sprint 4 завершен (4 pillar: Shell + Search + Mobile + Sync polish)
 
 v0.9.0 — marker **Sprint 4 全 phase 完走**. 4 pillar narrative: **Hardened LLM Wiki for Professionals + Claude-augmented Search + Mobile responsive + Sync polished**. Path C+β progress 70% → 100% завершено, Sprint 4 全 cycle completion marker.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -331,6 +331,17 @@ KIOKU 是一个可以访问**所有 Claude Code 会话输入输出**的 Hook 系
 
 ## 更新历史
 
+### 2026-05-19 — v0.10.0：「auto-ingest 不再静默失败，search 从你自己的 session 自动学习」— Sprint 5 + 5.5 完成 (reliability + intelligence の 2 軸進化)
+
+v0.10.0 是 **Sprint 5 (axis A) + Sprint 5.5 (axis B) 全完走** marker。reliability + intelligence の 2 軸進化，bundle minor release。
+
+- **Sprint 5 axis A (auto-ingest reliability)**：`hooks/auto-ingest-retry.mjs` retry queue (3x exponential backoff + persistent resume) + classify (network/transient/permanent) + manual review queue + credential masking (`applyMasks` SSOT)，`scripts/doctor.sh` `check_auto_ingest_state` diagnostic，LEARN#8b N=3 extract
+- **Sprint 5.5 axis B (discoverQueries 自動学習)**：`mcp/lib/discoverqueries-learning.mjs` session-logs/ scan = 8th source (weight 2.8, 最高)，privacy contract 3 axis (`applyMasks` SSOT / `.kioku-discoverqueries-opt-out` / `.kioku-discoverqueries-usage.json` 64KB FIFO)，`scripts/doctor.sh` `check_discoverqueries_state`，LEARN#8b N=4 reinforcement
+- **Hardened design contract**：credential masking SSOT (`applyMasks`) reused across auto-ingest retry log + discoverQueries usage log
+- **Tests**：Sprint 5 + 5.5 全 BLUE-* green，Sprint 4 累计 regression なし
+- **subagent-driven N=29-34 cycle** — Sprint 5 (N=29-31) + Sprint 5.5 (N=32-34)
+- [Release v0.10.0](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.10.0) — `kioku-wiki-0.10.0.mcpb` attached
+
 ### 2026-05-15 — v0.9.0：「在浏览器里打开 wiki，用 Claude 搜索，手机也能用」— Sprint 4 完成 (4 pillar: Shell + Search + Mobile + Sync polish)
 
 v0.9.0 是 **Sprint 4 全 phase 完走** marker。4 pillar narrative：**Hardened LLM Wiki for Professionals + Claude-augmented Search + Mobile responsive + Sync polished**。Path C+β progress 70% → 100% 达成，Sprint 4 全 cycle completion marker。

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -331,6 +331,17 @@ KIOKU 是一個存取**所有 Claude Code 工作階段 I/O** 的 Hook 系統。
 
 ## 更新歷史
 
+### 2026-05-19 — v0.10.0：「auto-ingest 不再靜默失敗，search 從你自己的 session 自動學習」— Sprint 5 + 5.5 完成 (reliability + intelligence の 2 軸進化)
+
+v0.10.0 是 **Sprint 5 (axis A) + Sprint 5.5 (axis B) 全完走** marker。reliability + intelligence の 2 軸進化，bundle minor release。
+
+- **Sprint 5 axis A (auto-ingest reliability)**：`hooks/auto-ingest-retry.mjs` retry queue (3x exponential backoff + persistent resume) + classify (network/transient/permanent) + manual review queue + credential masking (`applyMasks` SSOT)，`scripts/doctor.sh` `check_auto_ingest_state` diagnostic，LEARN#8b N=3 extract
+- **Sprint 5.5 axis B (discoverQueries 自動学習)**：`mcp/lib/discoverqueries-learning.mjs` session-logs/ scan = 8th source (weight 2.8, 最高)，privacy contract 3 axis (`applyMasks` SSOT / `.kioku-discoverqueries-opt-out` / `.kioku-discoverqueries-usage.json` 64KB FIFO)，`scripts/doctor.sh` `check_discoverqueries_state`，LEARN#8b N=4 reinforcement
+- **Hardened design contract**：credential masking SSOT (`applyMasks`) reused across auto-ingest retry log + discoverQueries usage log
+- **Tests**：Sprint 5 + 5.5 全 BLUE-* green，Sprint 4 累計 regression なし
+- **subagent-driven N=29-34 cycle** — Sprint 5 (N=29-31) + Sprint 5.5 (N=32-34)
+- [Release v0.10.0](https://github.com/megaphone-tokyo/kioku/releases/tag/v0.10.0) — `kioku-wiki-0.10.0.mcpb` attached
+
 ### 2026-05-15 — v0.9.0：「在瀏覽器裡打開 wiki，用 Claude 搜尋，手機也能用」— Sprint 4 完成 (4 pillar: Shell + Search + Mobile + Sync polish)
 
 v0.9.0 是 **Sprint 4 全 phase 完走** marker。4 pillar narrative：**Hardened LLM Wiki for Professionals + Claude-augmented Search + Mobile responsive + Sync polished**。Path C+β progress 70% → 100% 達成，Sprint 4 全 cycle completion marker。


### PR DESCRIPTION
## v0.10.0 Changelog — 10 言語 README 展開

axis A+B bundle minor release (reliability + intelligence の 2 軸進化) を 10 言語 README Changelog に記載。

- **README.md (English) + README.ja.md (日本語)**: full narrative (Sprint 5 axis A + Sprint 5.5 axis B 詳細 bullet)
- **他 8 言語 (es / fr / hi / ko / pt-BR / ru / zh-CN / zh-TW)**: compressed entry (v0.9.0 PR #48 同等 pattern、title + intro のみ localize)
- 10 / 10 v0.10.0 entry + Release link parity verify 済 (10 files / 134 insertions)

## LEARN#11 critical

本 PR は parent release PR #176 とは独立。**post-release-sync (parent Step 5) 前に land 必須** — merge 後 post-release-sync の rsync 全 overwrite で parent app/ に v0.10.0 README が正しく反映される。v0.6.0 で発火した sync boundary trap (PR #28 で事後 fix) を回避。

related: parent PR #176 (version bump、merge `fe73f48`) / kioku PR #49 (next→main sync、merge `9ae9f52`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)