### PR TITLE
Sync from parent — β path install URL 修正 (/install.sh → /scripts/install.sh)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,7 +7,7 @@
 #   Mode C: Codex / Gemini / 一般 user 向け manual install (本 script が clone + hooks 登録を実行)
 #
 # 使い方:
-#   bash <(curl -fsSL https://raw.githubusercontent.com/megaphone-tokyo/kioku/main/install.sh)
+#   bash <(curl -fsSL https://raw.githubusercontent.com/megaphone-tokyo/kioku/main/scripts/install.sh)
 #   bash install.sh                       # smart default 判定 + 確認 prompt
 #   bash install.sh --yes                 # 確認 prompt skip (smart default に従う)
 #   bash install.sh --mode=a              # Mode A を強制 (案内のみ、user が Claude Code で実行)


### PR DESCRIPTION
## Summary

Parent PR #189 (URL fix) を kioku 側にも反映。LP β publish 前に β path URL の embed mistake を修正。

## 変更内容 (1 file)

`scripts/install.sh` の help text 内 URL を root から `/scripts/` 配下に修正 (10 行内、+1 / -1)。LP β に組み込まれる artifact (marketing snippet) は kioku 側に sync 不要なので本 PR は 1 file のみ。

## β path URL (正)

`bash <(curl -fsSL https://raw.githubusercontent.com/megaphone-tokyo/kioku/main/scripts/install.sh)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)